### PR TITLE
feat: 채팅 도메인 Entity 및 Repository 구현

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -56,6 +57,9 @@ public class ChatMessage {
 
   @Builder.Default
   private int likeCount = 0;
+
+  @Version
+  private Long version;
 
   @Enumerated(EnumType.STRING)
   @Builder.Default

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
@@ -65,5 +65,6 @@ public class ChatMessage {
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  @Column
   private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,69 @@
+package com.example.WonkaoTalk.domain.chat.entity;
+
+import com.example.WonkaoTalk.domain.chat.enums.MessageStatus;
+import com.example.WonkaoTalk.domain.chat.enums.MessageType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "chat_message")
+public class ChatMessage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "message_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_room_id", nullable = false)
+  private ChatRoom chatRoom;
+
+  private Long senderId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "answer_message_id")
+  private ChatMessage answerMessage; // 답장 (Self-reference)
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private MessageType messageType;
+
+  @Column(columnDefinition = "TEXT")
+  private String content;
+
+  @Builder.Default
+  private int likeCount = 0;
+
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  private MessageStatus messageStatus = MessageStatus.NORMAL;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatParticipant.java
@@ -1,0 +1,56 @@
+package com.example.WonkaoTalk.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "chat_participant")
+public class ChatParticipant {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "participant_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_room_id", nullable = false)
+  private ChatRoom chatRoom;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  private String roomTitle;
+
+  @Column(columnDefinition = "TEXT")
+  private String roomImage;
+
+  private Long lastReadMessageId;
+
+  @Builder.Default
+  private boolean isAlarmOn = true;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,69 @@
+package com.example.WonkaoTalk.domain.chat.entity;
+
+import com.example.WonkaoTalk.domain.chat.enums.RoomStatus;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "chat_room")
+public class ChatRoom {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "chat_room_id")
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private RoomType roomType;
+
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String roomImage;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private int participantCount = 0;
+
+  @Column(columnDefinition = "TEXT")
+  private String lastMessageContent;
+
+  private LocalDateTime lastMessageAt;
+
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  @Column(nullable = false, length = 20)
+  private RoomStatus roomStatus = RoomStatus.ACTIVE;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
@@ -65,5 +65,7 @@ public class ChatRoom {
   @LastModifiedDate
   @Column(nullable = false)
   private LocalDateTime updatedAt;
+
+  @Column
   private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageHide.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageHide.java
@@ -1,0 +1,49 @@
+package com.example.WonkaoTalk.domain.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "message_hide", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"message_id", "user_id"})
+})
+public class MessageHide {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "hide_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "message_id", nullable = false)
+  private ChatMessage chatMessage;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageLike.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageLike.java
@@ -1,0 +1,64 @@
+package com.example.WonkaoTalk.domain.chat.entity;
+
+import com.example.WonkaoTalk.domain.chat.enums.LikeStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "message_like", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"message_id", "user_id"})
+})
+public class MessageLike {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "like_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "message_id", nullable = false)
+  private ChatMessage chatMessage;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  @Column(nullable = false, length = 20)
+  private LikeStatus likeStatus = LikeStatus.ACTIVE;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  private LocalDateTime canceledAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageLike.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageLike.java
@@ -60,5 +60,6 @@ public class MessageLike {
   @Column(nullable = false)
   private LocalDateTime updatedAt;
 
+  @Column
   private LocalDateTime canceledAt;
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/enums/LikeStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/enums/LikeStatus.java
@@ -1,0 +1,3 @@
+package com.example.WonkaoTalk.domain.chat.enums;
+
+public enum LikeStatus {ACTIVE, CANCELED}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/enums/MessageStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/enums/MessageStatus.java
@@ -1,0 +1,3 @@
+package com.example.WonkaoTalk.domain.chat.enums;
+
+public enum MessageStatus {NORMAL, DELETED}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/enums/MessageType.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/enums/MessageType.java
@@ -1,0 +1,3 @@
+package com.example.WonkaoTalk.domain.chat.enums;
+
+public enum MessageType {TEXT, IMAGE, GIFT, ALARM}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/enums/RoomStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/enums/RoomStatus.java
@@ -1,0 +1,3 @@
+package com.example.WonkaoTalk.domain.chat.enums;
+
+public enum RoomStatus {ACTIVE, DELETED}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/enums/RoomType.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/enums/RoomType.java
@@ -1,0 +1,3 @@
+package com.example.WonkaoTalk.domain.chat.enums;
+
+public enum RoomType {SINGLE, GROUP, ALARM}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.chat.repo;
+
+import com.example.WonkaoTalk.domain.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.chat.repo;
+
+import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.chat.repo;
+
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/MessageHideRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/MessageHideRepository.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.chat.repo;
+
+import com.example.WonkaoTalk.domain.chat.entity.MessageHide;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageHideRepository extends JpaRepository<MessageHide, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/MessageLikeRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/MessageLikeRepository.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.chat.repo;
+
+import com.example.WonkaoTalk.domain.chat.entity.MessageLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageLikeRepository extends JpaRepository<MessageLike, Long> {
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #3 

## 📝 작업 내용
- 도메인 기반 패키지 구조 설계 domain/chat/ entity, repository, enums
- 핵심 엔티티 구현 (ChatRoom, ChatParticipant, ChatMessage, MessageLike, MessageHide)
- enums 패키지를 통해 각 도메인의 상태값을 관리
- 각 엔티티에 대응하는 리포지토리 구축  

## ✅ 작업 결과 
<img width="510" height="424" alt="image" src="https://github.com/user-attachments/assets/dca8428d-5729-46de-af91-c766e3d35026" />

## 🎸 기타
- 채팅 도메인에선 enums 패키지를 분리하였습니다