### PR TITLE
feat: 1:1 채팅방 생성 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,47 +1,48 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '4.0.6'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '4.0.6'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(25)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-kafka'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-websocket-test'
-	testCompileOnly 'org.projectlombok:lombok'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testAnnotationProcessor 'org.projectlombok:lombok'
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-websocket-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 test {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/WonkaoTalk/common/config/JpaConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.example.WonkaoTalk.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
   // 주문 도메인
 
   // 채팅 도메인
-  ROOM_NOT_FOUND(404, "CHAT-NOTFOUND-ROOM", "존재하지 않는 채팅방입니다.");
+  ROOM_NOT_FOUND(404, "CHAT-NOTFOUND-ROOM", "존재하지 않는 채팅방입니다."),
+  CANNOT_CHAT_SELF(400, "CHAT-INVALID-SELF", "자기 자신과는 채팅방을 생성할 수 없습니다.");
 
   private final int httpStatus;
   private final String code;

--- a/src/main/java/com/example/WonkaoTalk/common/response/ApiResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/common/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.common.response;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -8,7 +9,9 @@ import lombok.Getter;
 
 @Getter
 @Builder
+@JsonPropertyOrder({"status", "message", "data", "error", "timestamp"})
 public class ApiResponse<T> {
+
   private final String status;
   private final String message;
   private final T data;

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
@@ -20,7 +20,7 @@ public class ChatRoomController {
 
   @PostMapping
   public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(
-      @RequestBody ChatRoomCreateRequest request
+      @jakarta.validation.Valid @RequestBody ChatRoomCreateRequest request
       // @AuthenticationPrincipal CustomUserDetails userDetails
   ) { // TODO 연동 전 임시로 ID넣어둠
     Long myId = 1L;

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,32 @@
+package com.example.WonkaoTalk.domain.chat.controller;
+
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
+import com.example.WonkaoTalk.domain.chat.service.ChatRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chats")
+public class ChatRoomController {
+
+  private final ChatRoomService chatRoomService;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(
+      @RequestBody ChatRoomCreateRequest request
+      // @AuthenticationPrincipal CustomUserDetails userDetails
+  ) { // TODO 연동 전 임시로 ID넣어둠
+    Long myId = 1L;
+
+    ChatRoomResponse data = chatRoomService.createChatRoom(myId, request);
+
+    return ResponseEntity.ok(ApiResponse.success("채팅방이 생성되었습니다.", data));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomCreateRequest.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ChatRoomCreateRequest(
+    @jakarta.validation.constraints.NotNull(message = "상대방 ID는 필수입니다.")
     Long receiverId
 ) {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,10 @@
+package com.example.WonkaoTalk.domain.chat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChatRoomCreateRequest(
+    Long receiverId
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomResponse.java
@@ -2,6 +2,7 @@ package com.example.WonkaoTalk.domain.chat.dto;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
 import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -10,7 +11,7 @@ public record ChatRoomResponse(
     Long chatRoomId,
     RoomType roomType,
     List<ParticipantDto> participants,
-    String createdAt
+    LocalDateTime createdAt
 ) {
 
   public static ChatRoomResponse from(ChatRoom room, List<ParticipantDto> participants) {
@@ -18,7 +19,7 @@ public record ChatRoomResponse(
         .chatRoomId(room.getId())
         .roomType(room.getRoomType())
         .participants(participants)
-        .createdAt(room.getCreatedAt().toString())
+        .createdAt(room.getCreatedAt())
         .build();
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,29 @@
+package com.example.WonkaoTalk.domain.chat.dto;
+
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ChatRoomResponse(
+    Long chatRoomId,
+    RoomType roomType,
+    List<ParticipantDto> participants,
+    String createdAt
+) {
+
+  public static ChatRoomResponse from(ChatRoom room, List<ParticipantDto> participants) {
+    return ChatRoomResponse.builder()
+        .chatRoomId(room.getId())
+        .roomType(room.getRoomType())
+        .participants(participants)
+        .createdAt(room.getCreatedAt().toString())
+        .build();
+  }
+
+  @Builder
+  public record ParticipantDto(Long userId, String nickname, String profileImage) {
+
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatMessage.java
@@ -30,12 +30,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "chat_message")
+@Table(name = "chat_messages")
 public class ChatMessage {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "message_id")
+  @Column(name = "id")
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -46,7 +46,7 @@ public class ChatMessage {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "answer_message_id")
-  private ChatMessage answerMessage; // 답장 (Self-reference)
+  private ChatMessage answerMessage;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 20)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatParticipant.java
@@ -25,12 +25,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "chat_participant")
+@Table(name = "chat_participants")
 public class ChatParticipant {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "participant_id")
+  @Column(name = "id")
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatParticipant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatParticipant.java
@@ -45,7 +45,9 @@ public class ChatParticipant {
   @Column(columnDefinition = "TEXT")
   private String roomImage;
 
-  private Long lastReadMessageId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "last_read_message_id")
+  private ChatMessage lastReadMessage;
 
   @Builder.Default
   private boolean isAlarmOn = true;

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
@@ -27,12 +27,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "chat_room")
+@Table(name = "chat_rooms")
 public class ChatRoom {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "chat_room_id")
+  @Column(name = "id")
   private Long id;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/ChatRoom.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -57,6 +58,9 @@ public class ChatRoom {
   @Builder.Default
   @Column(nullable = false, length = 20)
   private RoomStatus roomStatus = RoomStatus.ACTIVE;
+
+  @Version
+  private Long version;
 
   @CreatedDate
   @Column(nullable = false, updatable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageHide.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageHide.java
@@ -26,14 +26,14 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "message_hide", uniqueConstraints = {
+@Table(name = "message_hides", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"message_id", "user_id"})
 })
 public class MessageHide {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "hide_id")
+  @Column(name = "id")
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageLike.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/entity/MessageLike.java
@@ -30,14 +30,14 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "message_like", uniqueConstraints = {
+@Table(name = "message_likes", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"message_id", "user_id"})
 })
 public class MessageLike {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "like_id")
+  @Column(name = "id")
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepository.java
@@ -1,8 +1,20 @@
 package com.example.WonkaoTalk.domain.chat.repo;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
 
+  //이미 참여 중인 방이 있는지?
+  @Query("SELECT p1.chatRoom FROM ChatParticipant p1 " +
+      "JOIN ChatParticipant p2 ON p1.chatRoom.id = p2.chatRoom.id " +
+      "WHERE p1.userId = :myId AND p2.userId = :receiverId " +
+      "AND p1.chatRoom.roomType = 'SINGLE' " +
+      "AND p1.chatRoom.roomStatus = 'ACTIVE'")
+  Optional<ChatRoom> findChatRoomByUsers(@Param("myId") Long myId,
+      @Param("receiverId") Long receiverId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,9 @@
+package com.example.WonkaoTalk.domain.chat.service;
+
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
+
+public interface ChatRoomService {
+
+  ChatRoomResponse createChatRoom(Long myId, ChatRoomCreateRequest request);
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
@@ -1,0 +1,66 @@
+package com.example.WonkaoTalk.domain.chat.service;
+
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
+import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import com.example.WonkaoTalk.domain.chat.repo.ChatParticipantRepository;
+import com.example.WonkaoTalk.domain.chat.repo.ChatRoomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatParticipantRepository chatParticipantRepository;
+
+  @Override
+  @Transactional
+  public ChatRoomResponse createChatRoom(Long myId, ChatRoomCreateRequest request) {
+    Long receiverId = request.receiverId();
+
+    return chatParticipantRepository.findChatRoomByUsers(myId, receiverId)
+        .map(room -> ChatRoomResponse.from(room, createTempParticipants(myId, receiverId)))
+        .orElseGet(() -> {
+          ChatRoom newRoom = chatRoomRepository.saveAndFlush(
+              ChatRoom.builder()
+                  .roomType(RoomType.SINGLE)
+                  .participantCount(2)
+                  .build()
+          );
+
+          // 내 참여 정보
+          chatParticipantRepository.save(
+              ChatParticipant.builder()
+                  .chatRoom(newRoom)
+                  .userId(myId)
+                  .roomTitle("상대방 닉네임") // TODO: UserService 연동 시 receiver nickname/profile 주입
+                  .roomImage("상대방 이미지URL")
+                  .build());
+
+          // 상대방 참여 정보
+          chatParticipantRepository.save(
+              ChatParticipant.builder()
+                  .chatRoom(newRoom)
+                  .userId(receiverId)
+                  .roomTitle("나의 닉네임") // TODO: UserService 연동 시 my nickname/profile 주입
+                  .roomImage("나의 이미지URL")
+                  .build());
+
+          return ChatRoomResponse.from(newRoom, createTempParticipants(myId, receiverId));
+        });
+  }
+
+  // TODO: 유저 연동 전 임시 데이터임
+  private List<ChatRoomResponse.ParticipantDto> createTempParticipants(Long myId, Long receiverId) {
+    return List.of(
+        ChatRoomResponse.ParticipantDto.builder().userId(myId).nickname("나").build(),
+        ChatRoomResponse.ParticipantDto.builder().userId(receiverId).nickname("상대방").build()
+    );
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.WonkaoTalk.domain.chat.service;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
@@ -24,10 +26,14 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   public ChatRoomResponse createChatRoom(Long myId, ChatRoomCreateRequest request) {
     Long receiverId = request.receiverId();
 
+    if (myId.equals(receiverId)) {
+      throw new BusinessException(ErrorCode.CANNOT_CHAT_SELF);
+    }
+
     return chatParticipantRepository.findChatRoomByUsers(myId, receiverId)
         .map(room -> ChatRoomResponse.from(room, createTempParticipants(myId, receiverId)))
         .orElseGet(() -> {
-          ChatRoom newRoom = chatRoomRepository.saveAndFlush(
+          ChatRoom newRoom = chatRoomRepository.save(
               ChatRoom.builder()
                   .roomType(RoomType.SINGLE)
                   .participantCount(2)


### PR DESCRIPTION
## 📌 관련 이슈
- #11 

## 📝 작업 내용
- JPA Auditing 공통 설정 추가
- 컨벤션 변경을오 인한 도메인 엔티티 리팩토링
- 공통 응답 포맷 수정
- 1:1 채팅방 api 구현
  - 채팅방 생성 엔드포인트 구현
  - 기존 1:1방 조회 및 새 채팅방/참여자 생성 로직 구현
  - api 입출력 위한 dto 정의

## ✅ 작업 결과 
<img width="692" height="505" alt="image" src="https://github.com/user-attachments/assets/b55d4c54-b474-484a-b3da-bda2364c72a4" />
<img width="1142" height="189" alt="image" src="https://github.com/user-attachments/assets/e15cb456-62d6-43df-bb88-5eed0191ab5f" />
<img width="1157" height="159" alt="image" src="https://github.com/user-attachments/assets/b1f9dd4a-8505-427e-870f-c05a6c0eb1cb" />

## 🎸 기타
- 현재 유저 도메인 연동 전이라 참여자 닉네임/프로필 등은 임시 데이터로 처리되어 있습니다
- security오류도 SecurityConfig 파일 만들어서 임시로 무시 후 테스트했습니다 (임시용 파일이라 커밋하진 않음)
