### PR TITLE
feat: 전체 상품 및 특정 상품 조회 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-websocket-test'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:testcontainers-postgresql'
+	testImplementation 'org.testcontainers:testcontainers-kafka'
+	testImplementation 'com.redis:testcontainers-redis'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -18,14 +18,14 @@ public enum ErrorCode {
   USER_NOT_FOUND(404, "USER-NOTFOUND-ID", "해당 사용자 ID를 찾을 수 없습니다."),
 
   // 상품 도메인
-  PROD_INVALID_PRICE_RANGE(400, "PROD_INVALID_PRICE_RANGE", "최소 가격은 최대 가격보다 클 수 없습니다."),
-  PROD_INVALID_SORT(400, "PROD_INVALID_SORT", "허용되지 않는 정렬 기준입니다."),
-  PROD_INVALID_PAGE_SIZE(400, "PROD_INVALID_PAGE_SIZE", "조회 개수는 1 이상 100 이하여야 합니다."),
-  PROD_INVALID_PRODUCT_ID(400, "PROD_INVALID_PRODUCT_ID", "상품 ID는 숫자여야 합니다."),
-  PROD_CATEGORY_NOT_FOUND(404, "PROD_CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
-  PROD_STORE_NOT_FOUND(404, "PROD_STORE_NOT_FOUND", "존재하지 않는 스토어입니다."),
-  PROD_NOT_FOUND(404, "PROD_NOT_FOUND", "해당 상품을 찾을 수 없습니다."),
-  PROD_DELETED(410, "PROD_DELETED", "삭제된 상품입니다."),
+  PROD_INVALID_PRICE_RANGE(400, "PROD-INVALID-PRICE-RANGE", "최소 가격은 최대 가격보다 클 수 없습니다."),
+  PROD_INVALID_SORT(400, "PROD-INVALID-SORT", "허용되지 않는 정렬 기준입니다."),
+  PROD_INVALID_PAGE_SIZE(400, "PROD-INVALID-PAGE-SIZE", "조회 개수는 1 이상 100 이하여야 합니다."),
+  PROD_INVALID_PRODUCT_ID(400, "PROD-INVALID-PRODUCT-ID", "상품 ID는 숫자여야 합니다."),
+  PROD_CATEGORY_NOT_FOUND(404, "PROD-NOT-FOUND-CATEGORY", "존재하지 않는 카테고리입니다."),
+  PROD_STORE_NOT_FOUND(404, "PROD-NOT-FOUND-STORE", "존재하지 않는 스토어입니다."),
+  PROD_NOT_FOUND(404, "PROD-NOT-FOUND", "해당 상품을 찾을 수 없습니다."),
+  PROD_DELETED(410, "PROD-DELETED", "삭제된 상품입니다."),
 
   // 주문 도메인
 

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -18,6 +18,11 @@ public enum ErrorCode {
   USER_NOT_FOUND(404, "USER-NOTFOUND-ID", "해당 사용자 ID를 찾을 수 없습니다."),
 
   // 상품 도메인
+  PROD_INVALID_PRICE_RANGE(400, "PROD_INVALID_PRICE_RANGE", "최소 가격은 최대 가격보다 클 수 없습니다."),
+  PROD_INVALID_SORT(400, "PROD_INVALID_SORT", "허용되지 않는 정렬 기준입니다."),
+  PROD_INVALID_PAGE_SIZE(400, "PROD_INVALID_PAGE_SIZE", "조회 개수는 1 이상 100 이하여야 합니다."),
+  PROD_CATEGORY_NOT_FOUND(404, "PROD_CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
+  PROD_STORE_NOT_FOUND(404, "PROD_STORE_NOT_FOUND", "존재하지 않는 스토어입니다."),
 
   // 주문 도메인
 

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -21,8 +21,11 @@ public enum ErrorCode {
   PROD_INVALID_PRICE_RANGE(400, "PROD_INVALID_PRICE_RANGE", "최소 가격은 최대 가격보다 클 수 없습니다."),
   PROD_INVALID_SORT(400, "PROD_INVALID_SORT", "허용되지 않는 정렬 기준입니다."),
   PROD_INVALID_PAGE_SIZE(400, "PROD_INVALID_PAGE_SIZE", "조회 개수는 1 이상 100 이하여야 합니다."),
+  PROD_INVALID_PRODUCT_ID(400, "PROD_INVALID_PRODUCT_ID", "상품 ID는 숫자여야 합니다."),
   PROD_CATEGORY_NOT_FOUND(404, "PROD_CATEGORY_NOT_FOUND", "존재하지 않는 카테고리입니다."),
   PROD_STORE_NOT_FOUND(404, "PROD_STORE_NOT_FOUND", "존재하지 않는 스토어입니다."),
+  PROD_NOT_FOUND(404, "PROD_NOT_FOUND", "해당 상품을 찾을 수 없습니다."),
+  PROD_DELETED(410, "PROD_DELETED", "삭제된 상품입니다."),
 
   // 주문 도메인
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -1,0 +1,27 @@
+package com.example.WonkaoTalk.domain.product.controller;
+
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
+import com.example.WonkaoTalk.domain.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+  private final ProductService productService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<ProductListResponse>> getProducts(
+      @ModelAttribute ProductListRequest request) {
+    ProductListResponse response = productService.getProductList(request);
+    return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.product.controller;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +24,13 @@ public class ProductController {
   public ResponseEntity<ApiResponse<ProductListResponse>> getProducts(
       @ModelAttribute ProductListRequest request) {
     ProductListResponse response = productService.getProductList(request);
+    return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
+  }
+
+  @GetMapping("/{productId}")
+  public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
+      @PathVariable Long productId) {
+    ProductDetailResponse response = productService.getProductDetail(productId);
     return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductDetailResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductDetailResponse.java
@@ -1,0 +1,71 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductDetailResponse {
+
+  private Long productId;
+  private String productName;
+  private Integer price;
+  private Integer discountedPrice;
+  private Integer discountRate;
+  private String status;
+  private Integer likeCount;
+  @JsonProperty("isLiked")
+  private boolean isLiked;
+  private StoreInfo store;
+  private List<ImageInfo> images;
+  private DetailInfo detail;
+  private List<OptionGroupInfo> optionGroups;
+  private List<VariantInfo> variants;
+
+  @Getter
+  @Builder
+  public static class StoreInfo {
+    private Long storeId;
+    private String storeName;
+  }
+
+  @Getter
+  @Builder
+  public static class ImageInfo {
+    private String url;
+    private Integer sortOrder;
+  }
+
+  @Getter
+  @Builder
+  public static class DetailInfo {
+    private String content;
+  }
+
+  @Getter
+  @Builder
+  public static class OptionGroupInfo {
+    private Long productOptionGroupId;
+    private String name;
+    private List<OptionInfo> options;
+  }
+
+  @Getter
+  @Builder
+  public static class OptionInfo {
+    private Long productOptionId;
+    private String name;
+  }
+
+  @Getter
+  @Builder
+  public static class VariantInfo {
+    private Long variantId;
+    private String variantName;
+    private List<Long> combinationIds;
+    private Integer stock;
+    private String status;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListRequest.java
@@ -13,5 +13,6 @@ public class ProductListRequest {
   private Integer maxPrice;
   private String sort = "popular";
   private Long lastProductId;
+  private Long lastSortValue;
   private Integer size = 20;
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListRequest.java
@@ -1,0 +1,17 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProductListRequest {
+
+  private Long categoryId;
+  private Long storeId;
+  private Integer minPrice;
+  private Integer maxPrice;
+  private String sort = "popular";
+  private Long lastProductId;
+  private Integer size = 20;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListRequest.java
@@ -12,7 +12,7 @@ public class ProductListRequest {
   private Integer minPrice;
   private Integer maxPrice;
   private String sort = "popular";
-  private Long lastProductId;
+  private Long lastId;
   private Long lastSortValue;
   private Integer size = 20;
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListResponse.java
@@ -1,0 +1,34 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductListResponse {
+
+  private List<ProductSummary> products;
+  private boolean hasNext;
+
+  @Getter
+  @Builder
+  public static class ProductSummary {
+    private Long productId;
+    private String productName;
+    private String thumbnail;
+    private Integer price;
+    private Integer discountedPrice;
+    private Integer discountRate;
+    private Integer likeCount;
+    private String status;
+    private StoreInfo store;
+  }
+
+  @Getter
+  @Builder
+  public static class StoreInfo {
+    private Long storeId;
+    private String storeName;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListResponse.java
@@ -10,14 +10,14 @@ public class ProductListResponse {
 
   private List<ProductSummary> products;
   private boolean hasNext;
-  private Long nextCursorProductId;
+  private Long nextCursorId;
   private Long nextCursorSortValue;
 
   @Getter
   @Builder
   public static class ProductSummary {
-    private Long productId;
-    private String productName;
+    private Long id;
+    private String name;
     private String thumbnail;
     private Integer price;
     private Integer discountedPrice;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductListResponse.java
@@ -10,6 +10,8 @@ public class ProductListResponse {
 
   private List<ProductSummary> products;
   private boolean hasNext;
+  private Long nextCursorProductId;
+  private Long nextCursorSortValue;
 
   @Getter
   @Builder

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Cart.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Cart.java
@@ -9,13 +9,13 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "cart")
+@Table(name = "carts")
 public class Cart {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "cart_id")
-  private Long cartId;
+  @Column(name = "id")
+  private Long id;
 
   @Column(name = "user_id", nullable = false)
   // TODO: User Entity가 만들어 지면 타입 변경 필요

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/CartItem.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/CartItem.java
@@ -12,13 +12,13 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "cart_item")
+@Table(name = "cart_items")
 public class CartItem {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "cart_item_id")
-  private Long cartItemId;
+  @Column(name = "id")
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "cart_id", nullable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Category.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Category.java
@@ -9,9 +9,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "category")
+@Getter
+@NoArgsConstructor
 public class Category {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Category.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Category.java
@@ -13,18 +13,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "category")
+@Table(name = "categories")
 @Getter
 @NoArgsConstructor
 public class Category {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "category_id")
-  private Long categoryId;
+  @Column(name = "id")
+  private Long id;
 
-  @Column(name = "category_name", nullable = false)
-  private String categoryName;
+  @Column(name = "name", nullable = false)
+  private String name;
 
   @Column(name = "depth", nullable = false)
   private Integer depth;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -14,7 +14,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import org.hibernate.annotations.Formula;
 
 @Entity
 @Table(name = "products")
@@ -46,7 +45,7 @@ public class Product {
   @Column(name = "price", nullable = false)
   private Integer price;
 
-  @Formula("price * (100 - COALESCE(discount_rate, 0)) / 100") // price와 discount_rate에서 계산되는 파생값
+  @Column(name = "discounted_price", nullable = false)
   private Integer discountedPrice;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -17,21 +17,21 @@ import lombok.Getter;
 import org.hibernate.annotations.Formula;
 
 @Entity
-@Table(name = "product")
+@Table(name = "products")
 @Getter
 public class Product {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "product_id")
-  private Long productId;
+  @Column(name = "id")
+  private Long id;
 
   @Column(name = "store_id", nullable = false)
   // TODO: Store 엔티티 구현 시 @ManyToOne 관계로 변경 및 연관관계 매핑 필요
   private Long storeId;
 
-  @Column(name = "product_name", nullable = false)
-  private String productName;
+  @Column(name = "name", nullable = false)
+  private String name;
 
   @Column(name = "thumbnail")
   private String thumbnail;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.product.entity;
 
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,10 +13,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.hibernate.annotations.Formula;
 
 @Entity
 @Table(name = "product")
+@Getter
 public class Product {
 
   @Id
@@ -24,7 +27,7 @@ public class Product {
   private Long productId;
 
   @Column(name = "store_id", nullable = false)
-  // TODO: Store Entity가 만들어 지면 타입 변경 필요
+  // TODO: Store 엔티티 구현 시 @ManyToOne 관계로 변경 및 연관관계 매핑 필요
   private Long storeId;
 
   @Column(name = "product_name", nullable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
@@ -10,9 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
 @Table(name = "product_details")
+@Getter
 public class ProductDetail {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
@@ -12,20 +12,20 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "product_detail")
+@Table(name = "product_details")
 public class ProductDetail {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "product_detail_id")
-  private Long productDetailId;
+  @Column(name = "id")
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id", nullable = false)
   private Product product;
 
-  @Column(name = "detail_content", nullable = false, columnDefinition = "TEXT")
-  private String detailContent;
+  @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+  private String content;
 
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
@@ -12,23 +12,23 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "product_image")
+@Table(name = "product_images")
 public class ProductImage {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "product_image_id")
-  private Long productImageId;
+  @Column(name = "id")
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id", nullable = false)
   private Product product;
 
-  @Column(name = "image_url", nullable = false)
-  private String imageUrl;
+  @Column(name = "url", nullable = false)
+  private String url;
 
-  @Column(name = "image_order", nullable = false)
-  private Integer imageOrder;
+  @Column(name = "sort_order", nullable = false)
+  private Integer sortOrder;
 
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
@@ -10,9 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
 @Table(name = "product_images")
+@Getter
 public class ProductImage {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOption.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOption.java
@@ -11,16 +11,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 @Entity
-@Table(name = "product_option")
+@Table(name = "product_options")
 public class ProductOption {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "product_option_id")
-  private Long productOptionId;
+  @Column(name = "id")
+  private Long id;
 
-  @Column(name = "option_name", nullable = false)
-  private String optionName;
+  @Column(name = "name", nullable = false)
+  private String name;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_option_group_id", nullable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOption.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOption.java
@@ -10,8 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import lombok.Getter;
+
 @Entity
 @Table(name = "product_options")
+@Getter
 public class ProductOption {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOptionGroup.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOptionGroup.java
@@ -12,13 +12,13 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "product_option_group")
+@Table(name = "product_option_groups")
 public class ProductOptionGroup {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "product_option_group_id")
-  private Long productOptionGroupId;
+  @Column(name = "id")
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id", nullable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOptionGroup.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOptionGroup.java
@@ -10,9 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
 @Table(name = "product_option_groups")
+@Getter
 public class ProductOptionGroup {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -15,13 +15,13 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "product_variant")
+@Table(name = "product_variants")
 public class ProductVariant {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "variant_id")
-  private Long variantId;
+  @Column(name = "id")
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_id", nullable = false)
@@ -30,8 +30,8 @@ public class ProductVariant {
   @Column(name = "stock", nullable = false)
   private Integer stock;
 
-  @Column(name = "variant_name")
-  private String variantName;
+  @Column(name = "name")
+  private String name;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.product.entity;
 
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -13,9 +13,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
 @Table(name = "product_variants")
+@Getter
 public class ProductVariant {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/VariantOptionMap.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/VariantOptionMap.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.product.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import lombok.Getter;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -14,6 +15,7 @@ import jakarta.persistence.UniqueConstraint;
 @Entity
 @Table(name = "variant_option_maps",
     uniqueConstraints = @UniqueConstraint(columnNames = {"variant_id", "product_option_id"}))
+@Getter
 public class VariantOptionMap {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/VariantOptionMap.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/VariantOptionMap.java
@@ -12,14 +12,14 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 @Entity
-@Table(name = "variant_option_map",
+@Table(name = "variant_option_maps",
     uniqueConstraints = @UniqueConstraint(columnNames = {"variant_id", "product_option_id"}))
 public class VariantOptionMap {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "variant_option_map_id")
-  private Long variantOptionMapId;
+  @Column(name = "id")
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "variant_id", nullable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/enums/ProductSortType.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/enums/ProductSortType.java
@@ -1,0 +1,16 @@
+package com.example.WonkaoTalk.domain.product.enums;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+
+public enum ProductSortType {
+  POPULAR, LATEST, PRICE_ASC, PRICE_DESC;
+
+  public static ProductSortType from(String value) {
+    try {
+      return valueOf(value.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_SORT);
+    }
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/enums/SaleStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/enums/SaleStatus.java
@@ -1,4 +1,4 @@
-package com.example.WonkaoTalk.domain.product.entity;
+package com.example.WonkaoTalk.domain.product.enums;
 
 public enum SaleStatus {
   ON_SALE,      // 판매중

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/CategoryRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/CategoryRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.Category;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+  List<Category> findByParentCategory_CategoryId(Long parentId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/CategoryRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/CategoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-  List<Category> findByParentCategory_CategoryId(Long parentId);
+  List<Category> findByParentCategory_Id(Long parentId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductDetailRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductDetailRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductDetail;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductDetailRepository extends JpaRepository<ProductDetail, Long> {
 
+  Optional<ProductDetail> findFirstByProduct_Id(Long productId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductImageRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductImageRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
 
+  List<ProductImage> findByProduct_IdOrderBySortOrderAsc(Long productId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionGroupRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionGroupRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductOptionGroupRepository extends JpaRepository<ProductOptionGroup, Long> {
 
+  List<ProductOptionGroup> findByProduct_Id(Long productId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
 
   List<ProductOption> findByProductOptionGroup_Id(Long productOptionGroupId);
+
+  List<ProductOption> findByProductOptionGroup_IdIn(List<Long> groupIds);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductOption;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
 
+  List<ProductOption> findByProductOptionGroup_Id(Long productOptionGroupId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepository.java
@@ -3,6 +3,6 @@ package com.example.WonkaoTalk.domain.product.repo;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustom.java
@@ -13,6 +13,7 @@ public interface ProductRepositoryCustom {
       Integer maxPrice,
       ProductSortType sortType,
       Long lastProductId,
+      Long lastSortValue,
       int size
   );
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustom.java
@@ -12,7 +12,7 @@ public interface ProductRepositoryCustom {
       Integer minPrice,
       Integer maxPrice,
       ProductSortType sortType,
-      Long lastProductId,
+      Long lastId,
       Long lastSortValue,
       int size
   );

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustom.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustom.java
@@ -1,0 +1,18 @@
+package com.example.WonkaoTalk.domain.product.repo;
+
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import java.util.List;
+
+public interface ProductRepositoryCustom {
+
+  List<Product> findWithFilters(
+      List<Long> categoryIds,
+      Long storeId,
+      Integer minPrice,
+      Integer maxPrice,
+      ProductSortType sortType,
+      Long lastProductId,
+      int size
+  );
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
@@ -29,7 +29,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
       Integer minPrice,
       Integer maxPrice,
       ProductSortType sortType,
-      Long lastProductId,
+      Long lastId,
       Long lastSortValue,
       int size
   ) {
@@ -43,7 +43,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     // TODO: Store 엔티티 구현 시, N+1 문제 방지를 위해 fetch join(p.fetch("store")) 검토 필요
 
     if (categoryIds != null && !categoryIds.isEmpty()) {
-      predicates.add(p.get("category").get("categoryId").in(categoryIds));
+      predicates.add(p.get("category").get("id").in(categoryIds));
     }
     if (storeId != null) {
       predicates.add(cb.equal(p.get("storeId"), storeId));
@@ -54,8 +54,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     if (maxPrice != null) {
       predicates.add(cb.lessThanOrEqualTo(p.get("price"), maxPrice));
     }
-    if (lastProductId != null && lastSortValue != null) {
-      predicates.add(buildCursorPredicate(cb, p, sortType, lastProductId, lastSortValue));
+    if (lastId != null && lastSortValue != null) {
+      predicates.add(buildCursorPredicate(cb, p, sortType, lastId, lastSortValue));
     }
 
     cq.where(predicates.toArray(new Predicate[0]));
@@ -68,9 +68,9 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 
   private Predicate buildCursorPredicate(
       CriteriaBuilder cb, Root<Product> p,
-      ProductSortType sortType, Long lastProductId, Long lastSortValue
+      ProductSortType sortType, Long lastId, Long lastSortValue
   ) {
-    Predicate tieBreak = cb.lessThan(p.get("productId"), lastProductId);
+    Predicate tieBreak = cb.lessThan(p.get("id"), lastId);
 
     return switch (sortType) {
       case POPULAR -> {
@@ -106,12 +106,12 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
   }
 
   private List<Order> buildOrder(CriteriaBuilder cb, Root<Product> p, ProductSortType sortType) {
-    Order byProductId = cb.desc(p.get("productId"));
+    Order byId = cb.desc(p.get("id"));
     return switch (sortType) {
-      case POPULAR -> List.of(cb.desc(p.get("likeCount")), byProductId);
-      case LATEST -> List.of(cb.desc(p.get("createdAt")), byProductId);
-      case PRICE_ASC -> List.of(cb.asc(p.get("price")), byProductId);
-      case PRICE_DESC -> List.of(cb.desc(p.get("price")), byProductId);
+      case POPULAR -> List.of(cb.desc(p.get("likeCount")), byId);
+      case LATEST -> List.of(cb.desc(p.get("createdAt")), byId);
+      case PRICE_ASC -> List.of(cb.asc(p.get("price")), byId);
+      case PRICE_DESC -> List.of(cb.desc(p.get("price")), byId);
     };
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
@@ -9,6 +9,9 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Repository;
@@ -27,6 +30,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
       Integer maxPrice,
       ProductSortType sortType,
       Long lastProductId,
+      Long lastSortValue,
       int size
   ) {
     CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -50,8 +54,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     if (maxPrice != null) {
       predicates.add(cb.lessThanOrEqualTo(p.get("price"), maxPrice));
     }
-    if (lastProductId != null) {
-      predicates.add(cb.lessThan(p.get("productId"), lastProductId));
+    if (lastProductId != null && lastSortValue != null) {
+      predicates.add(buildCursorPredicate(cb, p, sortType, lastProductId, lastSortValue));
     }
 
     cq.where(predicates.toArray(new Predicate[0]));
@@ -62,12 +66,52 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
         .getResultList();
   }
 
-  private Order buildOrder(CriteriaBuilder cb, Root<Product> p, ProductSortType sortType) {
+  private Predicate buildCursorPredicate(
+      CriteriaBuilder cb, Root<Product> p,
+      ProductSortType sortType, Long lastProductId, Long lastSortValue
+  ) {
+    Predicate tieBreak = cb.lessThan(p.get("productId"), lastProductId);
+
     return switch (sortType) {
-      case LATEST -> cb.desc(p.get("createdAt"));
-      case PRICE_ASC -> cb.asc(p.get("price"));
-      case PRICE_DESC -> cb.desc(p.get("price"));
-      case POPULAR -> cb.desc(p.get("likeCount"));
+      case POPULAR -> {
+        int lastLikeCount = lastSortValue.intValue();
+        yield cb.or(
+            cb.lessThan(p.<Integer>get("likeCount"), lastLikeCount),
+            cb.and(cb.equal(p.get("likeCount"), lastLikeCount), tieBreak)
+        );
+      }
+      case PRICE_DESC -> {
+        int lastPrice = lastSortValue.intValue();
+        yield cb.or(
+            cb.lessThan(p.<Integer>get("price"), lastPrice),
+            cb.and(cb.equal(p.get("price"), lastPrice), tieBreak)
+        );
+      }
+      case PRICE_ASC -> {
+        int lastPrice = lastSortValue.intValue();
+        yield cb.or(
+            cb.greaterThan(p.<Integer>get("price"), lastPrice),
+            cb.and(cb.equal(p.get("price"), lastPrice), tieBreak)
+        );
+      }
+      case LATEST -> {
+        LocalDateTime lastCreatedAt = Instant.ofEpochMilli(lastSortValue)
+            .atOffset(ZoneOffset.UTC).toLocalDateTime();
+        yield cb.or(
+            cb.lessThan(p.<LocalDateTime>get("createdAt"), lastCreatedAt),
+            cb.and(cb.equal(p.get("createdAt"), lastCreatedAt), tieBreak)
+        );
+      }
+    };
+  }
+
+  private List<Order> buildOrder(CriteriaBuilder cb, Root<Product> p, ProductSortType sortType) {
+    Order byProductId = cb.desc(p.get("productId"));
+    return switch (sortType) {
+      case POPULAR -> List.of(cb.desc(p.get("likeCount")), byProductId);
+      case LATEST -> List.of(cb.desc(p.get("createdAt")), byProductId);
+      case PRICE_ASC -> List.of(cb.asc(p.get("price")), byProductId);
+      case PRICE_DESC -> List.of(cb.desc(p.get("price")), byProductId);
     };
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
@@ -1,0 +1,73 @@
+package com.example.WonkaoTalk.domain.product.repo;
+
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Override
+  public List<Product> findWithFilters(
+      List<Long> categoryIds,
+      Long storeId,
+      Integer minPrice,
+      Integer maxPrice,
+      ProductSortType sortType,
+      Long lastProductId,
+      int size
+  ) {
+    CriteriaBuilder cb = em.getCriteriaBuilder();
+    CriteriaQuery<Product> cq = cb.createQuery(Product.class);
+    Root<Product> p = cq.from(Product.class);
+
+    List<Predicate> predicates = new ArrayList<>();
+    predicates.add(cb.isNull(p.get("deletedAt")));
+
+    // TODO: Store 엔티티 구현 시, N+1 문제 방지를 위해 fetch join(p.fetch("store")) 검토 필요
+
+    if (categoryIds != null && !categoryIds.isEmpty()) {
+      predicates.add(p.get("category").get("categoryId").in(categoryIds));
+    }
+    if (storeId != null) {
+      predicates.add(cb.equal(p.get("storeId"), storeId));
+    }
+    if (minPrice != null) {
+      predicates.add(cb.greaterThanOrEqualTo(p.get("price"), minPrice));
+    }
+    if (maxPrice != null) {
+      predicates.add(cb.lessThanOrEqualTo(p.get("price"), maxPrice));
+    }
+    if (lastProductId != null) {
+      predicates.add(cb.lessThan(p.get("productId"), lastProductId));
+    }
+
+    cq.where(predicates.toArray(new Predicate[0]));
+    cq.orderBy(buildOrder(cb, p, sortType));
+
+    return em.createQuery(cq)
+        .setMaxResults(size + 1)
+        .getResultList();
+  }
+
+  private Order buildOrder(CriteriaBuilder cb, Root<Product> p, ProductSortType sortType) {
+    return switch (sortType) {
+      case LATEST -> cb.desc(p.get("createdAt"));
+      case PRICE_ASC -> cb.asc(p.get("price"));
+      case PRICE_DESC -> cb.desc(p.get("price"));
+      case POPULAR -> cb.desc(p.get("likeCount"));
+    };
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImpl.java
@@ -49,10 +49,10 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
       predicates.add(cb.equal(p.get("storeId"), storeId));
     }
     if (minPrice != null) {
-      predicates.add(cb.greaterThanOrEqualTo(p.get("price"), minPrice));
+      predicates.add(cb.greaterThanOrEqualTo(p.get("discountedPrice"), minPrice));
     }
     if (maxPrice != null) {
-      predicates.add(cb.lessThanOrEqualTo(p.get("price"), maxPrice));
+      predicates.add(cb.lessThanOrEqualTo(p.get("discountedPrice"), maxPrice));
     }
     if (lastId != null && lastSortValue != null) {
       predicates.add(buildCursorPredicate(cb, p, sortType, lastId, lastSortValue));
@@ -83,15 +83,15 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
       case PRICE_DESC -> {
         int lastPrice = lastSortValue.intValue();
         yield cb.or(
-            cb.lessThan(p.<Integer>get("price"), lastPrice),
-            cb.and(cb.equal(p.get("price"), lastPrice), tieBreak)
+            cb.lessThan(p.<Integer>get("discountedPrice"), lastPrice),
+            cb.and(cb.equal(p.get("discountedPrice"), lastPrice), tieBreak)
         );
       }
       case PRICE_ASC -> {
         int lastPrice = lastSortValue.intValue();
         yield cb.or(
-            cb.greaterThan(p.<Integer>get("price"), lastPrice),
-            cb.and(cb.equal(p.get("price"), lastPrice), tieBreak)
+            cb.greaterThan(p.<Integer>get("discountedPrice"), lastPrice),
+            cb.and(cb.equal(p.get("discountedPrice"), lastPrice), tieBreak)
         );
       }
       case LATEST -> {
@@ -110,8 +110,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
     return switch (sortType) {
       case POPULAR -> List.of(cb.desc(p.get("likeCount")), byId);
       case LATEST -> List.of(cb.desc(p.get("createdAt")), byId);
-      case PRICE_ASC -> List.of(cb.asc(p.get("price")), byId);
-      case PRICE_DESC -> List.of(cb.desc(p.get("price")), byId);
+      case PRICE_ASC -> List.of(cb.asc(p.get("discountedPrice")), byId);
+      case PRICE_DESC -> List.of(cb.desc(p.get("discountedPrice")), byId);
     };
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductVariantRepository extends JpaRepository<ProductVariant, Long> {
 
+  List<ProductVariant> findByProduct_Id(Long productId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/VariantOptionMapRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/VariantOptionMapRepository.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VariantOptionMapRepository extends JpaRepository<VariantOptionMap, Long> {
 
+  List<VariantOptionMap> findByProductVariant_Id(Long variantId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/VariantOptionMapRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/VariantOptionMapRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface VariantOptionMapRepository extends JpaRepository<VariantOptionMap, Long> {
 
   List<VariantOptionMap> findByProductVariant_Id(Long variantId);
+
+  List<VariantOptionMap> findByProductVariant_IdIn(List<Long> variantIds);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -86,7 +86,7 @@ public class ProductService {
     return switch (sortType) {
       case POPULAR -> (long) product.getLikeCount();
       case LATEST -> product.getCreatedAt().toInstant(ZoneOffset.UTC).toEpochMilli();
-      case PRICE_ASC, PRICE_DESC -> (long) product.getPrice();
+      case PRICE_ASC, PRICE_DESC -> (long) product.getDiscountedPrice();
     };
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -1,0 +1,102 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductListResponse.ProductSummary;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductService {
+
+  private final ProductRepository productRepository;
+  private final CategoryRepository categoryRepository;
+
+  public ProductListResponse getProductList(ProductListRequest request) {
+    int size = request.getSize() != null ? request.getSize() : 20;
+    if (size < 1 || size > 100) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_PAGE_SIZE);
+    }
+
+    String sortParam = request.getSort() != null ? request.getSort() : "popular";
+    ProductSortType sortType = ProductSortType.from(sortParam);
+
+    if (request.getMinPrice() != null && request.getMaxPrice() != null
+        && request.getMinPrice() > request.getMaxPrice()) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_PRICE_RANGE);
+    }
+
+    List<Long> categoryIds = null;
+    if (request.getCategoryId() != null) {
+      categoryRepository.findById(request.getCategoryId())
+          .orElseThrow(() -> new BusinessException(ErrorCode.PROD_CATEGORY_NOT_FOUND));
+      categoryIds = getAllCategoryIds(request.getCategoryId());
+    }
+
+    List<Product> products = productRepository.findWithFilters(
+        categoryIds,
+        request.getStoreId(),
+        request.getMinPrice(),
+        request.getMaxPrice(),
+        sortType,
+        request.getLastProductId(),
+        size
+    );
+
+    boolean hasNext = products.size() > size;
+    if (hasNext) {
+      products = products.subList(0, size);
+    }
+
+    List<ProductSummary> summaries = products.stream()
+        .map(this::toSummary)
+        .toList();
+
+    return ProductListResponse.builder()
+        .products(summaries)
+        .hasNext(hasNext)
+        .build();
+  }
+
+  private List<Long> getAllCategoryIds(Long categoryId) {
+    List<Long> result = new ArrayList<>();
+    result.add(categoryId);
+    collectChildIds(categoryId, result);
+    return result;
+  }
+
+  private void collectChildIds(Long parentId, List<Long> result) {
+    List<Category> children = categoryRepository.findByParentCategory_CategoryId(parentId);
+    for (Category child : children) {
+      result.add(child.getCategoryId());
+      collectChildIds(child.getCategoryId(), result);
+    }
+  }
+
+  private ProductSummary toSummary(Product product) {
+    return ProductSummary.builder()
+        .productId(product.getProductId())
+        .productName(product.getProductName())
+        .thumbnail(product.getThumbnail())
+        .price(product.getPrice())
+        .discountedPrice(product.getDiscountedPrice())
+        .discountRate(product.getDiscountRate())
+        .likeCount(product.getLikeCount())
+        .status(product.getStatus().name())
+        // TODO: Store 엔티티 구현 시 product.getStore()를 통해 StoreInfo 생성하도록 수정
+        .store(null)
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -10,6 +10,7 @@ import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepository;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepository;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -52,12 +53,21 @@ public class ProductService {
         request.getMaxPrice(),
         sortType,
         request.getLastProductId(),
+        request.getLastSortValue(),
         size
     );
 
     boolean hasNext = products.size() > size;
     if (hasNext) {
       products = products.subList(0, size);
+    }
+
+    Long nextCursorProductId = null;
+    Long nextCursorSortValue = null;
+    if (hasNext) {
+      Product lastItem = products.get(products.size() - 1);
+      nextCursorProductId = lastItem.getProductId();
+      nextCursorSortValue = toSortValue(lastItem, sortType);
     }
 
     List<ProductSummary> summaries = products.stream()
@@ -67,7 +77,17 @@ public class ProductService {
     return ProductListResponse.builder()
         .products(summaries)
         .hasNext(hasNext)
+        .nextCursorProductId(nextCursorProductId)
+        .nextCursorSortValue(nextCursorSortValue)
         .build();
+  }
+
+  private Long toSortValue(Product product, ProductSortType sortType) {
+    return switch (sortType) {
+      case POPULAR -> (long) product.getLikeCount();
+      case LATEST -> product.getCreatedAt().toInstant(ZoneOffset.UTC).toEpochMilli();
+      case PRICE_ASC, PRICE_DESC -> (long) product.getPrice();
+    };
   }
 
   private List<Long> getAllCategoryIds(Long categoryId) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -2,14 +2,28 @@ package com.example.WonkaoTalk.domain.product.service;
 
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse.DetailInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse.ImageInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse.OptionGroupInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse.OptionInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse.VariantInfo;
 import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse.ProductSummary;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductImageRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepository;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepository;
+import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepository;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +38,12 @@ public class ProductService {
 
   private final ProductRepository productRepository;
   private final CategoryRepository categoryRepository;
+  private final ProductImageRepository productImageRepository;
+  private final ProductDetailRepository productDetailRepository;
+  private final ProductOptionGroupRepository productOptionGroupRepository;
+  private final ProductOptionRepository productOptionRepository;
+  private final ProductVariantRepository productVariantRepository;
+  private final VariantOptionMapRepository variantOptionMapRepository;
 
   public ProductListResponse getProductList(ProductListRequest request) {
     int size = request.getSize() != null ? request.getSize() : 20;
@@ -79,6 +99,84 @@ public class ProductService {
         .hasNext(hasNext)
         .nextCursorId(nextCursorId)
         .nextCursorSortValue(nextCursorSortValue)
+        .build();
+  }
+
+  public ProductDetailResponse getProductDetail(Long productId) {
+    Product product = productRepository.findById(productId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_NOT_FOUND));
+
+    if (product.getDeletedAt() != null) {
+      throw new BusinessException(ErrorCode.PROD_DELETED);
+    }
+
+    List<ImageInfo> images = productImageRepository.findByProduct_IdOrderBySortOrderAsc(productId)
+        .stream()
+        .map(img -> ImageInfo.builder()
+            .url(img.getUrl())
+            .sortOrder(img.getSortOrder())
+            .build())
+        .toList();
+
+    DetailInfo detail = productDetailRepository.findFirstByProduct_Id(productId)
+        .map(d -> DetailInfo.builder().content(d.getContent()).build())
+        .orElse(null);
+
+    List<OptionGroupInfo> optionGroups = productOptionGroupRepository.findByProduct_Id(productId)
+        .stream()
+        .map(this::toOptionGroupInfo)
+        .toList();
+
+    List<VariantInfo> variants = productVariantRepository.findByProduct_Id(productId)
+        .stream()
+        .map(this::toVariantInfo)
+        .toList();
+
+    return ProductDetailResponse.builder()
+        .productId(product.getId())
+        .productName(product.getName())
+        .price(product.getPrice())
+        .discountedPrice(product.getDiscountedPrice())
+        .discountRate(product.getDiscountRate())
+        .status(product.getStatus().name())
+        .likeCount(product.getLikeCount())
+        .isLiked(false) // TODO: 로그인 사용자의 좋아요 여부 반영 필요 (PRODUCT_LIKE 테이블 조회)
+        .store(null) // TODO: Store 엔티티 구현 시 실제 스토어 정보 반환
+        .images(images)
+        .detail(detail)
+        .optionGroups(optionGroups)
+        .variants(variants)
+        .build();
+  }
+
+  private OptionGroupInfo toOptionGroupInfo(ProductOptionGroup group) {
+    List<OptionInfo> options = productOptionRepository.findByProductOptionGroup_Id(group.getId())
+        .stream()
+        .map(opt -> OptionInfo.builder()
+            .productOptionId(opt.getId())
+            .name(opt.getName())
+            .build())
+        .toList();
+
+    return OptionGroupInfo.builder()
+        .productOptionGroupId(group.getId())
+        .name(group.getName())
+        .options(options)
+        .build();
+  }
+
+  private VariantInfo toVariantInfo(ProductVariant variant) {
+    List<Long> combinationIds = variantOptionMapRepository.findByProductVariant_Id(variant.getId())
+        .stream()
+        .map(map -> map.getProductOption().getId())
+        .toList();
+
+    return VariantInfo.builder()
+        .variantId(variant.getId())
+        .variantName(variant.getName())
+        .combinationIds(combinationIds)
+        .stock(variant.getStock())
+        .status(variant.getStatus().name())
         .build();
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -52,7 +52,7 @@ public class ProductService {
         request.getMinPrice(),
         request.getMaxPrice(),
         sortType,
-        request.getLastProductId(),
+        request.getLastId(),
         request.getLastSortValue(),
         size
     );
@@ -62,11 +62,11 @@ public class ProductService {
       products = products.subList(0, size);
     }
 
-    Long nextCursorProductId = null;
+    Long nextCursorId = null;
     Long nextCursorSortValue = null;
     if (hasNext) {
       Product lastItem = products.get(products.size() - 1);
-      nextCursorProductId = lastItem.getProductId();
+      nextCursorId = lastItem.getId();
       nextCursorSortValue = toSortValue(lastItem, sortType);
     }
 
@@ -77,7 +77,7 @@ public class ProductService {
     return ProductListResponse.builder()
         .products(summaries)
         .hasNext(hasNext)
-        .nextCursorProductId(nextCursorProductId)
+        .nextCursorId(nextCursorId)
         .nextCursorSortValue(nextCursorSortValue)
         .build();
   }
@@ -98,17 +98,17 @@ public class ProductService {
   }
 
   private void collectChildIds(Long parentId, List<Long> result) {
-    List<Category> children = categoryRepository.findByParentCategory_CategoryId(parentId);
+    List<Category> children = categoryRepository.findByParentCategory_Id(parentId);
     for (Category child : children) {
-      result.add(child.getCategoryId());
-      collectChildIds(child.getCategoryId(), result);
+      result.add(child.getId());
+      collectChildIds(child.getId(), result);
     }
   }
 
   private ProductSummary toSummary(Product product) {
     return ProductSummary.builder()
-        .productId(product.getProductId())
-        .productName(product.getProductName())
+        .id(product.getId())
+        .name(product.getName())
         .thumbnail(product.getThumbnail())
         .price(product.getPrice())
         .discountedPrice(product.getDiscountedPrice())

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -13,8 +13,10 @@ import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse.ProductSummary;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductOption;
 import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
 import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepository;
 import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepository;
@@ -27,6 +29,8 @@ import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepository;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -122,14 +126,29 @@ public class ProductService {
         .map(d -> DetailInfo.builder().content(d.getContent()).build())
         .orElse(null);
 
-    List<OptionGroupInfo> optionGroups = productOptionGroupRepository.findByProduct_Id(productId)
+    List<ProductOptionGroup> groups = productOptionGroupRepository.findByProduct_Id(productId);
+    List<Long> groupIds = groups.stream().map(ProductOptionGroup::getId).toList();
+    Map<Long, List<ProductOption>> optionsByGroup = productOptionRepository
+        .findByProductOptionGroup_IdIn(groupIds)
         .stream()
-        .map(this::toOptionGroupInfo)
+        .collect(Collectors.groupingBy(opt -> opt.getProductOptionGroup().getId()));
+
+    List<OptionGroupInfo> optionGroups = groups.stream()
+        .map(group -> toOptionGroupInfo(group, optionsByGroup))
         .toList();
 
-    List<VariantInfo> variants = productVariantRepository.findByProduct_Id(productId)
+    List<ProductVariant> variantList = productVariantRepository.findByProduct_Id(productId);
+    List<Long> variantIds = variantList.stream().map(ProductVariant::getId).toList();
+    Map<Long, List<Long>> combinationIdsByVariant = variantOptionMapRepository
+        .findByProductVariant_IdIn(variantIds)
         .stream()
-        .map(this::toVariantInfo)
+        .collect(Collectors.groupingBy(
+            map -> map.getProductVariant().getId(),
+            Collectors.mapping(map -> map.getProductOption().getId(), Collectors.toList())
+        ));
+
+    List<VariantInfo> variants = variantList.stream()
+        .map(variant -> toVariantInfo(variant, combinationIdsByVariant))
         .toList();
 
     return ProductDetailResponse.builder()
@@ -149,8 +168,9 @@ public class ProductService {
         .build();
   }
 
-  private OptionGroupInfo toOptionGroupInfo(ProductOptionGroup group) {
-    List<OptionInfo> options = productOptionRepository.findByProductOptionGroup_Id(group.getId())
+  private OptionGroupInfo toOptionGroupInfo(ProductOptionGroup group,
+      Map<Long, List<ProductOption>> optionsByGroup) {
+    List<OptionInfo> options = optionsByGroup.getOrDefault(group.getId(), List.of())
         .stream()
         .map(opt -> OptionInfo.builder()
             .productOptionId(opt.getId())
@@ -165,11 +185,9 @@ public class ProductService {
         .build();
   }
 
-  private VariantInfo toVariantInfo(ProductVariant variant) {
-    List<Long> combinationIds = variantOptionMapRepository.findByProductVariant_Id(variant.getId())
-        .stream()
-        .map(map -> map.getProductOption().getId())
-        .toList();
+  private VariantInfo toVariantInfo(ProductVariant variant,
+      Map<Long, List<Long>> combinationIdsByVariant) {
+    List<Long> combinationIds = combinationIdsByVariant.getOrDefault(variant.getId(), List.of());
 
     return VariantInfo.builder()
         .variantId(variant.getId())

--- a/src/test/java/com/example/WonkaoTalk/WonkaoTalkApplicationTests.java
+++ b/src/test/java/com/example/WonkaoTalk/WonkaoTalkApplicationTests.java
@@ -1,9 +1,12 @@
 package com.example.WonkaoTalk;
 
+import com.example.WonkaoTalk.config.TestContainerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(TestContainerConfig.class)
 class WonkaoTalkApplicationTests {
 
 	@Test

--- a/src/test/java/com/example/WonkaoTalk/config/TestContainerConfig.java
+++ b/src/test/java/com/example/WonkaoTalk/config/TestContainerConfig.java
@@ -1,0 +1,30 @@
+package com.example.WonkaoTalk.config;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfig {
+
+  @Bean
+  @ServiceConnection
+  public PostgreSQLContainer postgreSQLContainer() {
+    return new PostgreSQLContainer("postgres:17");
+  }
+
+  @Bean
+  @ServiceConnection
+  public RedisContainer redisContainer() {
+    return new RedisContainer("redis:7.4");
+  }
+
+  @Bean
+  @ServiceConnection
+  public KafkaContainer kafkaContainer() {
+    return new KafkaContainer("apache/kafka:4.0.0");
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductDetailIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductDetailIntegrationTest.java
@@ -143,6 +143,7 @@ class ProductDetailIntegrationTest {
     ReflectionTestUtils.setField(p, "name", "테스트상품");
     ReflectionTestUtils.setField(p, "category", cat);
     ReflectionTestUtils.setField(p, "price", 10000);
+    ReflectionTestUtils.setField(p, "discountedPrice", 10000);
     ReflectionTestUtils.setField(p, "likeCount", 0);
     ReflectionTestUtils.setField(p, "status", SaleStatus.ON_SALE);
     ReflectionTestUtils.setField(p, "createdAt", LocalDateTime.now());

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductDetailIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductDetailIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.example.WonkaoTalk.domain.product.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductDetail;
+import com.example.WonkaoTalk.domain.product.entity.ProductImage;
+import com.example.WonkaoTalk.domain.product.entity.ProductOption;
+import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.service.ProductService;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Import(TestContainerConfig.class)
+@Transactional
+class ProductDetailIntegrationTest {
+
+  @Autowired
+  private EntityManager em;
+
+  @Autowired
+  private ProductService productService;
+
+  private Category category;
+  private Product product;
+
+  @BeforeEach
+  void setUp() {
+    category = saveCategory();
+    product = saveProduct(category);
+    em.flush();
+    em.clear();
+  }
+
+  @Test
+  @DisplayName("이미지가 sortOrder 오름차순으로 반환된다")
+  void images_returnedInSortOrderAscending() {
+    saveImage(product, "https://cdn.example.com/2.jpg", 2);
+    saveImage(product, "https://cdn.example.com/1.jpg", 1);
+    saveImage(product, "https://cdn.example.com/3.jpg", 3);
+    em.flush();
+    em.clear();
+
+    ProductDetailResponse response = productService.getProductDetail(product.getId());
+
+    assertThat(response.getImages()).hasSize(3);
+    assertThat(response.getImages().get(0).getSortOrder()).isEqualTo(1);
+    assertThat(response.getImages().get(1).getSortOrder()).isEqualTo(2);
+    assertThat(response.getImages().get(2).getSortOrder()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("옵션 그룹과 옵션이 계층 구조로 반환된다")
+  void optionGroups_containNestedOptions() {
+    ProductOptionGroup colorGroup = saveOptionGroup(product, "색상");
+    saveOption(colorGroup, "화이트");
+    saveOption(colorGroup, "네이비");
+
+    ProductOptionGroup sizeGroup = saveOptionGroup(product, "사이즈");
+    saveOption(sizeGroup, "M");
+    em.flush();
+    em.clear();
+
+    ProductDetailResponse response = productService.getProductDetail(product.getId());
+
+    assertThat(response.getOptionGroups()).hasSize(2);
+    ProductDetailResponse.OptionGroupInfo color = response.getOptionGroups().stream()
+        .filter(g -> g.getName().equals("색상")).findFirst().orElseThrow();
+    assertThat(color.getOptions()).hasSize(2);
+    assertThat(color.getOptions().stream().map(ProductDetailResponse.OptionInfo::getName))
+        .containsExactlyInAnyOrder("화이트", "네이비");
+  }
+
+  @Test
+  @DisplayName("variant의 combinationIds에 연결된 optionId 목록이 포함된다")
+  void variants_containCombinationIds() {
+    ProductOptionGroup group = saveOptionGroup(product, "색상");
+    ProductOption white = saveOption(group, "화이트");
+    ProductOption navy = saveOption(group, "네이비");
+
+    ProductVariant variant = saveVariant(product, "화이트 / M", 50);
+    saveVariantOptionMap(variant, white);
+    saveVariantOptionMap(variant, navy);
+    em.flush();
+    em.clear();
+
+    ProductDetailResponse response = productService.getProductDetail(product.getId());
+
+    assertThat(response.getVariants()).hasSize(1);
+    assertThat(response.getVariants().get(0).getCombinationIds())
+        .containsExactlyInAnyOrder(white.getId(), navy.getId());
+  }
+
+  @Test
+  @DisplayName("상세 내용이 없으면 detail이 null이다")
+  void detail_isNullWhenNotExists() {
+    ProductDetailResponse response = productService.getProductDetail(product.getId());
+
+    assertThat(response.getDetail()).isNull();
+  }
+
+  @Test
+  @DisplayName("상세 내용이 있으면 content가 반환된다")
+  void detail_returnsContent_whenExists() {
+    saveDetail(product, "<p>상품 상세 내용</p>");
+    em.flush();
+    em.clear();
+
+    ProductDetailResponse response = productService.getProductDetail(product.getId());
+
+    assertThat(response.getDetail()).isNotNull();
+    assertThat(response.getDetail().getContent()).isEqualTo("<p>상품 상세 내용</p>");
+  }
+
+  // ── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+  private Category saveCategory() {
+    Category cat = new Category();
+    ReflectionTestUtils.setField(cat, "name", "테스트카테고리");
+    ReflectionTestUtils.setField(cat, "depth", 1);
+    em.persist(cat);
+    return cat;
+  }
+
+  private Product saveProduct(Category cat) {
+    Product p = new Product();
+    ReflectionTestUtils.setField(p, "storeId", 1L);
+    ReflectionTestUtils.setField(p, "name", "테스트상품");
+    ReflectionTestUtils.setField(p, "category", cat);
+    ReflectionTestUtils.setField(p, "price", 10000);
+    ReflectionTestUtils.setField(p, "likeCount", 0);
+    ReflectionTestUtils.setField(p, "status", SaleStatus.ON_SALE);
+    ReflectionTestUtils.setField(p, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(p, "updatedAt", LocalDateTime.now());
+    em.persist(p);
+    return p;
+  }
+
+  private ProductImage saveImage(Product p, String url, int sortOrder) {
+    ProductImage img = new ProductImage();
+    ReflectionTestUtils.setField(img, "product", p);
+    ReflectionTestUtils.setField(img, "url", url);
+    ReflectionTestUtils.setField(img, "sortOrder", sortOrder);
+    ReflectionTestUtils.setField(img, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(img, "updatedAt", LocalDateTime.now());
+    em.persist(img);
+    return img;
+  }
+
+  private ProductDetail saveDetail(Product p, String content) {
+    ProductDetail detail = new ProductDetail();
+    ReflectionTestUtils.setField(detail, "product", p);
+    ReflectionTestUtils.setField(detail, "content", content);
+    ReflectionTestUtils.setField(detail, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(detail, "updatedAt", LocalDateTime.now());
+    em.persist(detail);
+    return detail;
+  }
+
+  private ProductOptionGroup saveOptionGroup(Product p, String name) {
+    ProductOptionGroup group = new ProductOptionGroup();
+    ReflectionTestUtils.setField(group, "product", p);
+    ReflectionTestUtils.setField(group, "name", name);
+    ReflectionTestUtils.setField(group, "sortOrder", 1);
+    ReflectionTestUtils.setField(group, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(group, "updatedAt", LocalDateTime.now());
+    em.persist(group);
+    return group;
+  }
+
+  private ProductOption saveOption(ProductOptionGroup group, String name) {
+    ProductOption option = new ProductOption();
+    ReflectionTestUtils.setField(option, "productOptionGroup", group);
+    ReflectionTestUtils.setField(option, "name", name);
+    em.persist(option);
+    return option;
+  }
+
+  private ProductVariant saveVariant(Product p, String name, int stock) {
+    ProductVariant variant = new ProductVariant();
+    ReflectionTestUtils.setField(variant, "product", p);
+    ReflectionTestUtils.setField(variant, "name", name);
+    ReflectionTestUtils.setField(variant, "stock", stock);
+    ReflectionTestUtils.setField(variant, "status", SaleStatus.ON_SALE);
+    ReflectionTestUtils.setField(variant, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(variant, "updatedAt", LocalDateTime.now());
+    em.persist(variant);
+    return variant;
+  }
+
+  private void saveVariantOptionMap(ProductVariant variant, ProductOption option) {
+    VariantOptionMap map = new VariantOptionMap();
+    ReflectionTestUtils.setField(map, "productVariant", variant);
+    ReflectionTestUtils.setField(map, "productOption", option);
+    em.persist(map);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductRepositoryCustomImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductRepositoryCustomImplTest.java
@@ -190,12 +190,14 @@ class ProductRepositoryCustomImplTest {
 
   private Product saveProduct(Long storeId, Category cat, int price, Integer discountRate,
       int likeCount, LocalDateTime deletedAt) {
+    int discountedPrice = discountRate != null ? price * (100 - discountRate) / 100 : price;
     Product product = new Product();
     ReflectionTestUtils.setField(product, "storeId", storeId);
     ReflectionTestUtils.setField(product, "name", "상품-" + price);
     ReflectionTestUtils.setField(product, "category", cat);
     ReflectionTestUtils.setField(product, "price", price);
     ReflectionTestUtils.setField(product, "discountRate", discountRate);
+    ReflectionTestUtils.setField(product, "discountedPrice", discountedPrice);
     ReflectionTestUtils.setField(product, "likeCount", likeCount);
     ReflectionTestUtils.setField(product, "status", SaleStatus.ON_SALE);
     ReflectionTestUtils.setField(product, "createdAt", LocalDateTime.now());

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductRepositoryCustomImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductRepositoryCustomImplTest.java
@@ -1,15 +1,16 @@
-package com.example.WonkaoTalk.domain.product.repo;
+package com.example.WonkaoTalk.domain.product.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.example.WonkaoTalk.config.TestContainerConfig;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepository;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
-import com.example.WonkaoTalk.config.TestContainerConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -205,7 +206,7 @@ class ProductRepositoryCustomImplTest {
   }
 
   private void flushAndClear() {
-    em.flush();  // SQL을 DB에 전송
-    em.clear();  // 1차 캐시 제거 → 이후 조회 시 @Formula 포함해 DB에서 새로 로드
+    em.flush();
+    em.clear();
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/repo/ProductRepositoryCustomImplTest.java
@@ -1,0 +1,211 @@
+package com.example.WonkaoTalk.domain.product.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import com.example.WonkaoTalk.config.TestContainerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Import(TestContainerConfig.class)
+@Transactional
+class ProductRepositoryCustomImplTest {
+
+  @Autowired
+  private EntityManager em;
+
+  @Autowired
+  private ProductRepository productRepository;
+
+  private Category category;
+
+  @BeforeEach
+  void setUp() {
+    category = saveCategory("테스트카테고리");
+  }
+
+  // ── 기본 필터 ────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("deletedAt이 있는 상품은 조회되지 않는다")
+  void excludesDeletedProducts() {
+    saveProduct(1L, category, 10000, null, 0, null);
+    saveProduct(1L, category, 8000, null, 0, LocalDateTime.now()); // 삭제됨
+    flushAndClear();
+
+    List<Product> result = productRepository.findWithFilters(
+        null, null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getPrice()).isEqualTo(10000);
+  }
+
+  @Test
+  @DisplayName("storeId로 필터링된다")
+  void filtersProductsByStoreId() {
+    saveProduct(1L, category, 10000, null, 0, null);
+    saveProduct(2L, category, 8000, null, 0, null);
+    flushAndClear();
+
+    List<Product> result = productRepository.findWithFilters(
+        null, 1L, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getStoreId()).isEqualTo(1L);
+  }
+
+  // ── 가격 필터 (할인가 기준) ──────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("minPrice 필터는 discountedPrice 기준으로 동작한다")
+  void filtersProductsByMinDiscountedPrice() {
+    // discountedPrice = 10000 * (100 - 20) / 100 = 8000
+    saveProduct(1L, category, 10000, 20, 0, null);
+    // discountedPrice = 10000 * (100 - 0) / 100 = 10000
+    saveProduct(1L, category, 10000, null, 0, null);
+    flushAndClear();
+
+    // minPrice=9000 → discountedPrice 10000짜리만 해당
+    List<Product> result = productRepository.findWithFilters(
+        null, null, 9000, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getDiscountedPrice()).isEqualTo(10000);
+  }
+
+  @Test
+  @DisplayName("maxPrice 필터는 discountedPrice 기준으로 동작한다")
+  void filtersProductsByMaxDiscountedPrice() {
+    // discountedPrice = 10000 * (100 - 20) / 100 = 8000
+    saveProduct(1L, category, 10000, 20, 0, null);
+    // discountedPrice = 10000 * (100 - 0) / 100 = 10000
+    saveProduct(1L, category, 10000, null, 0, null);
+    flushAndClear();
+
+    // maxPrice=9000 → discountedPrice 8000짜리만 해당
+    List<Product> result = productRepository.findWithFilters(
+        null, null, null, 9000, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getDiscountedPrice()).isEqualTo(8000);
+  }
+
+  // ── 정렬 (할인가 기준) ───────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("PRICE_ASC 정렬은 discountedPrice 오름차순이다")
+  void sortsByDiscountedPriceAscending() {
+    // discountedPrice: 7000, 5000, 7200
+    saveProduct(1L, category, 10000, 30, 0, null); // 10000 * 70 / 100 = 7000
+    saveProduct(1L, category, 5000, null, 0, null); // 5000
+    saveProduct(1L, category, 8000, 10, 0, null);  // 8000 * 90 / 100 = 7200
+    flushAndClear();
+
+    List<Product> result = productRepository.findWithFilters(
+        null, null, null, null, ProductSortType.PRICE_ASC, null, null, 10);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).getDiscountedPrice()).isEqualTo(5000);
+    assertThat(result.get(1).getDiscountedPrice()).isEqualTo(7000);
+    assertThat(result.get(2).getDiscountedPrice()).isEqualTo(7200);
+  }
+
+  @Test
+  @DisplayName("PRICE_DESC 정렬은 discountedPrice 내림차순이다")
+  void sortsByDiscountedPriceDescending() {
+    // discountedPrice: 7000, 5000, 7200
+    saveProduct(1L, category, 10000, 30, 0, null); // 7000
+    saveProduct(1L, category, 5000, null, 0, null); // 5000
+    saveProduct(1L, category, 8000, 10, 0, null);  // 7200
+    flushAndClear();
+
+    List<Product> result = productRepository.findWithFilters(
+        null, null, null, null, ProductSortType.PRICE_DESC, null, null, 10);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).getDiscountedPrice()).isEqualTo(7200);
+    assertThat(result.get(1).getDiscountedPrice()).isEqualTo(7000);
+    assertThat(result.get(2).getDiscountedPrice()).isEqualTo(5000);
+  }
+
+  // ── 커서 페이지네이션 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("PRICE_ASC 커서 이후의 항목만 조회된다")
+  void returnsOnlyItemsAfterCursor_whenSortByPriceAsc() {
+    saveProduct(1L, category, 5000, null, 0, null);  // discountedPrice=5000
+    Product mid = saveProduct(1L, category, 8000, null, 0, null);  // discountedPrice=8000
+    saveProduct(1L, category, 12000, null, 0, null); // discountedPrice=12000
+    Long midId = mid.getId();
+    flushAndClear();
+
+    // mid(8000)를 커서로 설정 → 8000 초과 항목만 조회
+    List<Product> result = productRepository.findWithFilters(
+        null, null, null, null, ProductSortType.PRICE_ASC, midId, 8000L, 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getDiscountedPrice()).isEqualTo(12000);
+  }
+
+  @Test
+  @DisplayName("동일한 discountedPrice 내에서 id 내림차순으로 tiebreak된다")
+  void tiebreaksById_whenDiscountedPriceIsEqual() {
+    Product p1 = saveProduct(1L, category, 5000, null, 0, null);
+    Product p2 = saveProduct(1L, category, 5000, null, 0, null);
+    saveProduct(1L, category, 5000, null, 0, null);
+    Long p2Id = p2.getId();
+    flushAndClear();
+
+    // p2를 커서로 설정 → p2보다 id가 작은 항목(p1)만 조회
+    List<Product> result = productRepository.findWithFilters(
+        null, null, null, null, ProductSortType.PRICE_ASC, p2Id, 5000L, 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getId()).isLessThan(p2Id);
+  }
+
+  // ── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+  private Category saveCategory(String name) {
+    Category cat = new Category();
+    ReflectionTestUtils.setField(cat, "name", name);
+    ReflectionTestUtils.setField(cat, "depth", 1);
+    em.persist(cat);
+    return cat;
+  }
+
+  private Product saveProduct(Long storeId, Category cat, int price, Integer discountRate,
+      int likeCount, LocalDateTime deletedAt) {
+    Product product = new Product();
+    ReflectionTestUtils.setField(product, "storeId", storeId);
+    ReflectionTestUtils.setField(product, "name", "상품-" + price);
+    ReflectionTestUtils.setField(product, "category", cat);
+    ReflectionTestUtils.setField(product, "price", price);
+    ReflectionTestUtils.setField(product, "discountRate", discountRate);
+    ReflectionTestUtils.setField(product, "likeCount", likeCount);
+    ReflectionTestUtils.setField(product, "status", SaleStatus.ON_SALE);
+    ReflectionTestUtils.setField(product, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(product, "updatedAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(product, "deletedAt", deletedAt);
+    em.persist(product);
+    return product;
+  }
+
+  private void flushAndClear() {
+    em.flush();  // SQL을 DB에 전송
+    em.clear();  // 1차 캐시 제거 → 이후 조회 시 @Formula 포함해 DB에서 새로 로드
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
@@ -1,0 +1,233 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductServiceTest {
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private CategoryRepository categoryRepository;
+
+  @InjectMocks
+  private ProductService productService;
+
+  // ── 입력 검증 ──────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("페이지 사이즈가 0이면 예외를 던진다")
+  void throwsException_whenPageSizeIsZero() {
+    ProductListRequest request = defaultRequest();
+    request.setSize(0);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductList(request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_PAGE_SIZE);
+  }
+
+  @Test
+  @DisplayName("페이지 사이즈가 101이면 예외를 던진다")
+  void throwsException_whenPageSizeExceeds100() {
+    ProductListRequest request = defaultRequest();
+    request.setSize(101);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductList(request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_PAGE_SIZE);
+  }
+
+  @Test
+  @DisplayName("최소 가격이 최대 가격보다 크면 예외를 던진다")
+  void throwsException_whenMinPriceExceedsMaxPrice() {
+    ProductListRequest request = defaultRequest();
+    request.setMinPrice(10000);
+    request.setMaxPrice(5000);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductList(request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_PRICE_RANGE);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 카테고리 ID면 예외를 던진다")
+  void throwsException_whenCategoryNotFound() {
+    ProductListRequest request = defaultRequest();
+    request.setCategoryId(999L);
+    when(categoryRepository.findById(999L)).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductList(request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_CATEGORY_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 정렬값이면 예외를 던진다")
+  void throwsException_whenSortTypeIsInvalid() {
+    ProductListRequest request = defaultRequest();
+    request.setSort("invalid_sort");
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductList(request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_SORT);
+  }
+
+  // ── 페이지네이션 ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("결과가 size보다 많으면 hasNext가 true이고 마지막 항목이 제거된다")
+  void hasNext_trueAndLastItemRemoved_whenResultsExceedSize() {
+    ProductListRequest request = defaultRequest();
+    request.setSize(2);
+
+    List<Product> products = mockProducts(3);
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(products);
+
+    ProductListResponse response = productService.getProductList(request);
+
+    assertThat(response.isHasNext()).isTrue();
+    assertThat(response.getProducts()).hasSize(2);
+    assertThat(response.getNextCursorId()).isNotNull();
+    assertThat(response.getNextCursorSortValue()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("결과가 size 이하면 hasNext가 false이고 커서가 null이다")
+  void hasNext_falseAndCursorNull_whenResultsWithinSize() {
+    ProductListRequest request = defaultRequest();
+    request.setSize(5);
+
+    List<Product> products = mockProducts(3);
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(products);
+
+    ProductListResponse response = productService.getProductList(request);
+
+    assertThat(response.isHasNext()).isFalse();
+    assertThat(response.getNextCursorId()).isNull();
+    assertThat(response.getNextCursorSortValue()).isNull();
+  }
+
+  // ── 커서 값 계산 ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("POPULAR 정렬의 커서값은 likeCount이다")
+  void cursorValue_isLikeCount_whenSortByPopular() {
+    ProductListRequest request = defaultRequest();
+    request.setSize(1);
+    request.setSort("popular");
+
+    Product first = mockProduct(1L, 10000, 20, 8000, 42, LocalDateTime.now());
+    Product second = mockProduct(2L, 5000, 0, 5000, 10, LocalDateTime.now());
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(List.of(first, second));
+
+    ProductListResponse response = productService.getProductList(request);
+
+    assertThat(response.getNextCursorSortValue()).isEqualTo(42L);
+  }
+
+  @Test
+  @DisplayName("LATEST 정렬의 커서값은 createdAt의 epoch milliseconds이다")
+  void cursorValue_isCreatedAtEpochMillis_whenSortByLatest() {
+    LocalDateTime createdAt = LocalDateTime.of(2024, 6, 1, 12, 0, 0);
+    long expectedMillis = createdAt.toInstant(ZoneOffset.UTC).toEpochMilli();
+
+    ProductListRequest request = defaultRequest();
+    request.setSize(1);
+    request.setSort("latest");
+
+    Product first = mockProduct(1L, 10000, 20, 8000, 5, createdAt);
+    Product second = mockProduct(2L, 5000, 0, 5000, 3, LocalDateTime.now());
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(List.of(first, second));
+
+    ProductListResponse response = productService.getProductList(request);
+
+    assertThat(response.getNextCursorSortValue()).isEqualTo(expectedMillis);
+  }
+
+  @Test
+  @DisplayName("PRICE 정렬의 커서값은 discountedPrice이다")
+  void cursorValue_isDiscountedPrice_whenSortByPrice() {
+    ProductListRequest request = defaultRequest();
+    request.setSize(1);
+    request.setSort("price_asc");
+
+    // price=10000, discountRate=20 → discountedPrice=8000
+    Product first = mockProduct(1L, 10000, 20, 8000, 5, LocalDateTime.now());
+    Product second = mockProduct(2L, 15000, 0, 15000, 3, LocalDateTime.now());
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(List.of(first, second));
+
+    ProductListResponse response = productService.getProductList(request);
+
+    assertThat(response.getNextCursorSortValue()).isEqualTo(8000L);
+  }
+
+  // ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+  private ProductListRequest defaultRequest() {
+    ProductListRequest request = new ProductListRequest();
+    request.setSort("popular");
+    request.setSize(20);
+    return request;
+  }
+
+  private Product mockProduct(Long id, int price, int discountRate, int discountedPrice,
+      int likeCount, LocalDateTime createdAt) {
+    Product product = mock(Product.class);
+    when(product.getId()).thenReturn(id);
+    when(product.getName()).thenReturn("상품" + id);
+    when(product.getPrice()).thenReturn(price);
+    when(product.getDiscountRate()).thenReturn(discountRate);
+    when(product.getDiscountedPrice()).thenReturn(discountedPrice);
+    when(product.getLikeCount()).thenReturn(likeCount);
+    when(product.getCreatedAt()).thenReturn(createdAt);
+    when(product.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    return product;
+  }
+
+  private List<Product> mockProducts(int count) {
+    List<Product> products = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      products.add(mockProduct((long) (i + 1), 10000, 0, 10000, i, LocalDateTime.now()));
+    }
+    return products;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
@@ -9,12 +9,22 @@ import static org.mockito.Mockito.when;
 
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductOption;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductImageRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepository;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepository;
+import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -38,6 +48,24 @@ class ProductServiceTest {
 
   @Mock
   private CategoryRepository categoryRepository;
+
+  @Mock
+  private ProductImageRepository productImageRepository;
+
+  @Mock
+  private ProductDetailRepository productDetailRepository;
+
+  @Mock
+  private ProductOptionGroupRepository productOptionGroupRepository;
+
+  @Mock
+  private ProductOptionRepository productOptionRepository;
+
+  @Mock
+  private ProductVariantRepository productVariantRepository;
+
+  @Mock
+  private VariantOptionMapRepository variantOptionMapRepository;
 
   @InjectMocks
   private ProductService productService;
@@ -198,6 +226,84 @@ class ProductServiceTest {
     ProductListResponse response = productService.getProductList(request);
 
     assertThat(response.getNextCursorSortValue()).isEqualTo(8000L);
+  }
+
+  // ── getProductDetail ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("존재하지 않는 상품 ID면 PROD_NOT_FOUND 예외를 던진다")
+  void throwsException_whenProductIdNotFound() {
+    when(productRepository.findById(999L)).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductDetail(999L));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 상품이면 PROD_DELETED 예외를 던진다")
+  void throwsException_whenProductIsDeleted() {
+    Product product = mockProduct(1L, 10000, 0, 10000, 0, LocalDateTime.now());
+    when(product.getDeletedAt()).thenReturn(LocalDateTime.now());
+    when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productService.getProductDetail(1L));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DELETED);
+  }
+
+  @Test
+  @DisplayName("isLiked는 항상 false를 반환한다")
+  void isLiked_isAlwaysFalse() {
+    Product product = mockProduct(1L, 10000, 0, 10000, 0, LocalDateTime.now());
+    when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+    ProductDetailResponse response = productService.getProductDetail(1L);
+
+    assertThat(response.isLiked()).isFalse();
+  }
+
+  @Test
+  @DisplayName("store는 항상 null을 반환한다")
+  void store_isAlwaysNull() {
+    Product product = mockProduct(1L, 10000, 0, 10000, 0, LocalDateTime.now());
+    when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+    ProductDetailResponse response = productService.getProductDetail(1L);
+
+    assertThat(response.getStore()).isNull();
+  }
+
+  @Test
+  @DisplayName("variant의 combinationIds는 VariantOptionMap에 연결된 productOptionId 목록이다")
+  void variantCombinationIds_mappedFromVariantOptionMap() {
+    Product product = mockProduct(1L, 10000, 0, 10000, 0, LocalDateTime.now());
+    when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+
+    ProductVariant variant = mock(ProductVariant.class);
+    when(variant.getId()).thenReturn(10L);
+    when(variant.getName()).thenReturn("화이트 / M");
+    when(variant.getStock()).thenReturn(50);
+    when(variant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    when(productVariantRepository.findByProduct_Id(1L)).thenReturn(List.of(variant));
+
+    ProductOption option1 = mock(ProductOption.class);
+    when(option1.getId()).thenReturn(201L);
+    ProductOption option2 = mock(ProductOption.class);
+    when(option2.getId()).thenReturn(301L);
+
+    VariantOptionMap map1 = mock(VariantOptionMap.class);
+    when(map1.getProductOption()).thenReturn(option1);
+    VariantOptionMap map2 = mock(VariantOptionMap.class);
+    when(map2.getProductOption()).thenReturn(option2);
+    when(variantOptionMapRepository.findByProductVariant_Id(10L)).thenReturn(List.of(map1, map2));
+
+    ProductDetailResponse response = productService.getProductDetail(1L);
+
+    assertThat(response.getVariants()).hasSize(1);
+    assertThat(response.getVariants().get(0).getCombinationIds()).containsExactly(201L, 301L);
   }
 
   // ── 헬퍼 ────────────────────────────────────────────────────────────────────

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
@@ -295,15 +295,17 @@ class ProductServiceTest {
     when(option2.getId()).thenReturn(301L);
 
     VariantOptionMap map1 = mock(VariantOptionMap.class);
+    when(map1.getProductVariant()).thenReturn(variant);
     when(map1.getProductOption()).thenReturn(option1);
     VariantOptionMap map2 = mock(VariantOptionMap.class);
+    when(map2.getProductVariant()).thenReturn(variant);
     when(map2.getProductOption()).thenReturn(option2);
-    when(variantOptionMapRepository.findByProductVariant_Id(10L)).thenReturn(List.of(map1, map2));
+    when(variantOptionMapRepository.findByProductVariant_IdIn(List.of(10L))).thenReturn(List.of(map1, map2));
 
     ProductDetailResponse response = productService.getProductDetail(1L);
 
     assertThat(response.getVariants()).hasSize(1);
-    assertThat(response.getVariants().get(0).getCombinationIds()).containsExactly(201L, 301L);
+    assertThat(response.getVariants().get(0).getCombinationIds()).containsExactlyInAnyOrder(201L, 301L);
   }
 
   // ── 헬퍼 ────────────────────────────────────────────────────────────────────

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,4 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 📌 관련 이슈
- #10 

## 📝 작업 내용
- 전체 상품 목록 조회 API를 제작했습니다.
- 특정 상품 목록 조회 API를 제작했습니다.
- 테스트 코드를 작성했습니다.

## ✅ 작업 결과 
- 상품 목록 조회 API
https://github.com/user-attachments/assets/4042c74c-761d-4967-9af5-d5c19dbcb476

- 특정 상품 정보 조회 API
https://github.com/user-attachments/assets/97789886-6365-43e8-9a4d-994cee84c30d


## 🎸 기타
- TestContainer를 띄우기 위한 설정을 추가했습니다. TestContainerConfig파일에 정의해 놓았고, 이미지 버전의 경우 docker-compose.yml파일에 정의된 버전을 사용했습니다.
- domain.product폴더 안에 테스트 코드를 작성했습니다. 내부 폴더 구조에 대한 컨벤션이 존재하지 않아 통합 테스트는 integration폴더에, 그 외 단위 테스트는 각 계층 폴더에 작성했습니다.
- Test폴더 안에 application.yaml파일을 추가했습니다. 원활한 테스트를 위한 설정으로, 현재로서는 ddl-auto 설정만 존재합니다.
- store정보의 경우, 현재 엔티티가 만들어져 있지 않아 null을 반환하도록 했습니다. 추가 이후 수정하겠습니다.
- 로그인 상태에 따라 값이 변화되는 경우도 존재하나, 현재 해당 기능이 구현되어 있지 않아 이 역시 추후 수정하겠습니다.
- 개발 및 테스트시에는 spring security라이브러리를 비활성화한 후 수정을 진행했습니다.