### PR TITLE
feat: 유저 도메인 Entity 및 Repo 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application-local ###
+./src/main/resources/application-local.yml
+./src/main/resources/application-local.yaml

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
@@ -25,7 +25,7 @@ public class Seller {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int id;
+  private Long id;
 
   @Column(name = "buz_no", nullable = false, length = 10)
   private String buzNo;

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
@@ -20,7 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "users")
+@Table(name = "sellers")
 public class Seller {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
@@ -1,0 +1,46 @@
+package com.example.WonkaoTalk.domain.seller.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users")
+public class Seller {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+
+  @Column(name = "buz_no", nullable = false, length = 10)
+  private String buzNo;
+
+  @Column(nullable = false)
+  private String phone;
+
+  @Column(name = "auth_id", nullable = false)
+  private Long authId;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
@@ -1,0 +1,45 @@
+package com.example.WonkaoTalk.domain.seller.entity;
+
+import com.example.WonkaoTalk.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users")
+public class SellerConsent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "terms_version_id", nullable = false)
+  private Long termsVersionId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "seller_id")
+  private User sellerId;
+
+  @Column(name = "is_agreed", nullable = false)
+  private boolean isAgreed;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
@@ -1,6 +1,5 @@
 package com.example.WonkaoTalk.domain.seller.entity;
 
-import com.example.WonkaoTalk.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -34,7 +33,7 @@ public class SellerConsent {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "seller_id")
-  private User sellerId;
+  private Seller sellerId;
 
   @Column(name = "is_agreed", nullable = false)
   private boolean isAgreed;

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
@@ -22,7 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "users")
+@Table(name = "seller_consents")
 public class SellerConsent {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
@@ -28,7 +28,8 @@ public class SellerConsent {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "terms_version_id", nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "terms_version_id", nullable = false)
   private Long termsVersionId;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/repo/SellerConsentRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/repo/SellerConsentRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.seller.repo;
+
+import com.example.WonkaoTalk.domain.seller.entity.SellerConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerConsentRepo extends JpaRepository<SellerConsent, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/repo/SellerRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/repo/SellerRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.seller.repo;
+
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerRepo extends JpaRepository<Seller, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/term/entity/Term.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/term/entity/Term.java
@@ -18,7 +18,7 @@ public class Term {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int id;
+  private Long id;
 
   @Column(nullable = false)
   private String code;

--- a/src/main/java/com/example/WonkaoTalk/domain/term/entity/Term.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/term/entity/Term.java
@@ -1,0 +1,31 @@
+package com.example.WonkaoTalk.domain.term.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "terms")
+public class Term {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+
+  @Column(nullable = false)
+  private String code;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(name = "is_required", nullable = false)
+  private boolean isRequired = true;
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/term/entity/TermVersion.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/term/entity/TermVersion.java
@@ -1,0 +1,48 @@
+package com.example.WonkaoTalk.domain.term.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "term_versions")
+public class TermVersion {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "term_id", nullable = false)
+  private Term termId;
+
+  @Column(nullable = false)
+  private String version;
+
+  @Lob
+  @Column(nullable = false)
+  private String content;
+
+  @Column(name = "is_Active", nullable = false)
+  private boolean isActive = true;
+
+  @Column(name = "effective_at", nullable = false)
+  private LocalDateTime effectiveAt;
+  
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/term/entity/TermVersion.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/term/entity/TermVersion.java
@@ -26,7 +26,7 @@ public class TermVersion {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int id;
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "term_id", nullable = false)
@@ -39,10 +39,10 @@ public class TermVersion {
   @Column(nullable = false)
   private String content;
 
-  @Column(name = "is_Active", nullable = false)
+  @Column(name = "is_active", nullable = false)
   private boolean isActive = true;
 
   @Column(name = "effective_at", nullable = false)
   private LocalDateTime effectiveAt;
-  
+
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/term/repo/TermRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/term/repo/TermRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.term.repo;
+
+import com.example.WonkaoTalk.domain.term.entity.Term;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermRepo extends JpaRepository<Term, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/term/repo/TermVersionRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/term/repo/TermVersionRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.term.repo;
+
+import com.example.WonkaoTalk.domain.term.entity.TermVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermVersionRepo extends JpaRepository<TermVersion, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/Friend.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/Friend.java
@@ -1,0 +1,63 @@
+package com.example.WonkaoTalk.domain.user.entity;
+
+import com.example.WonkaoTalk.domain.user.enums.FriendStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "friends")
+public class Friend {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User userId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "friend_id", nullable = false)
+  private User friendId;
+
+  @Column(length = 20)
+  private String alias;
+
+  private String memo;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private FriendStatus status = FriendStatus.ACTIVE;
+
+  @Column(name = "is_favorite", nullable = false)
+  private boolean isFavorite = false;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
@@ -28,7 +28,7 @@ public class User {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int id;
+  private Long id;
 
   @Column(nullable = false, length = 20)
   private String nickname;

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
@@ -1,0 +1,66 @@
+package com.example.WonkaoTalk.domain.user.entity;
+
+import com.example.WonkaoTalk.domain.user.enums.Gender;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+
+  @Column(nullable = false, length = 20)
+  private String nickname;
+
+  @Column(nullable = false)
+  private String image;
+
+  @Column(name = "birth_date")
+  private LocalDate birthDate;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false, length = 13)
+  private String phone;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Gender gender = Gender.NONE;
+
+  @Column(name = "marketing_agree", nullable = false)
+  private boolean marketingAgree = false;
+
+  @Column(name = "auth_id")
+  private Long authId;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/UserConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/UserConsent.java
@@ -28,7 +28,8 @@ public class UserConsent {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "terms_version_id", nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "terms_version_id", nullable = false)
   private Long termsVersionId;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/UserConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/UserConsent.java
@@ -1,0 +1,45 @@
+package com.example.WonkaoTalk.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "user_consents")
+public class UserConsent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "terms_version_id", nullable = false)
+  private Long termsVersionId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User userId;
+
+  @Column(name = "is_agreed", nullable = false)
+  private boolean isAgreed;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/enums/FriendStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/enums/FriendStatus.java
@@ -1,0 +1,7 @@
+package com.example.WonkaoTalk.domain.user.enums;
+
+public enum FriendStatus {
+  ACTIVE,
+  HIDDEN,
+  BLOCK
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/enums/Gender.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/enums/Gender.java
@@ -1,0 +1,7 @@
+package com.example.WonkaoTalk.domain.user.enums;
+
+public enum Gender {
+  MALE,
+  FEMALE,
+  NONE
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/repo/FriendRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/repo/FriendRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.user.repo;
+
+import com.example.WonkaoTalk.domain.user.entity.Friend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRepo extends JpaRepository<Friend, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserConsentRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserConsentRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.user.repo;
+
+import com.example.WonkaoTalk.domain.user.entity.UserConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserConsentRepo extends JpaRepository<UserConsent, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.user.repo;
+
+import com.example.WonkaoTalk.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepo extends JpaRepository<User, Long> {
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #21 

## 📝 작업 내용
- `user`, `seller`, `term` 도메인의 entity 구현
- 각 엔티티에 대응하는 Repository 구현

## ✅ 작업 결과 
<img width="1193" height="246" alt="image" src="https://github.com/user-attachments/assets/25baf6c8-1da7-4201-a9e5-58ab5931a5db" />
- 테이블이 정상적으로 생성 됨

## 🎸 기타
- Term 도메인은 현재로써는 기능적으로 분리할 이유는 없지만 SoC를 위해 분리했습니다.
- friend 도메인은 user id를 두번 참조하므로 별도 도메인으로 분리하지 않고 user 도메인에 유지시켰습니다.
- 도메인 분리 과정에서 약간의 ERD 수정이 있었습니다만 다른 도메인에 영향을 끼치진 않았으니 크게 신경쓰지 않으셔도 될듯합니다.
