### PR TITLE
feat: 채팅방 리스트 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
@@ -5,7 +5,9 @@ import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.service.ChatRoomService;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,13 +37,15 @@ public class ChatRoomController {
 
   @GetMapping
   public ResponseEntity<ApiResponse<ChatRoomListResponse>> getChatRoomList(
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime lastMessageAt,
       @RequestParam(required = false) Long cursorId,
       @RequestParam(defaultValue = "20") int size
   ) {
     // TODO 연동 전 임시로 ID 넣어둠
     Long myId = 1L;
 
-    ChatRoomListResponse data = chatRoomService.getChatRoomList(myId, cursorId, size);
+    ChatRoomListResponse data = chatRoomService.getChatRoomList(myId, lastMessageAt, cursorId,
+        size);
 
     return ResponseEntity.ok(ApiResponse.success("채팅방 목록을 불러왔습니다.", data));
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
@@ -2,13 +2,16 @@ package com.example.WonkaoTalk.domain.chat.controller;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,5 +31,18 @@ public class ChatRoomController {
     ChatRoomResponse data = chatRoomService.createChatRoom(myId, request);
 
     return ResponseEntity.ok(ApiResponse.success("채팅방이 생성되었습니다.", data));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<ChatRoomListResponse>> getChatRoomList(
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(defaultValue = "20") int size
+  ) {
+    // TODO 연동 전 임시로 ID 넣어둠
+    Long myId = 1L;
+
+    ChatRoomListResponse data = chatRoomService.getChatRoomList(myId, cursorId, size);
+
+    return ResponseEntity.ok(ApiResponse.success("채팅방 목록을 불러왔습니다.", data));
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomListResponse.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.chat.dto;
 
+import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
 import com.example.WonkaoTalk.domain.chat.enums.RoomType;
 import java.time.LocalDateTime;
@@ -26,12 +27,13 @@ public record ChatRoomListResponse(
       Integer participantCount
   ) {
 
-    public static ChatRoomInfo from(ChatRoom room, Integer unreadCount) {
+    public static ChatRoomInfo from(ChatParticipant participant, Integer unreadCount) {
+      ChatRoom room = participant.getChatRoom();
       return ChatRoomInfo.builder()
           .chatRoomId(room.getId())
           .roomType(room.getRoomType())
-          .roomTitle(room.getTitle())
-          .roomImage(room.getRoomImage())
+          .roomTitle(participant.getRoomTitle())
+          .roomImage(participant.getRoomImage())
           .lastMessageContent(room.getLastMessageContent())
           .lastMessageAt(room.getLastMessageAt())
           .unreadCount(unreadCount)

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomListResponse.java
@@ -1,0 +1,41 @@
+package com.example.WonkaoTalk.domain.chat.dto;
+
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ChatRoomListResponse(
+    List<ChatRoomInfo> rooms,
+    Boolean hasNext,
+    Long nextCursorId
+) {
+
+  @Builder
+  public record ChatRoomInfo(
+      Long chatRoomId,
+      RoomType roomType,
+      String roomTitle,
+      String roomImage,
+      String lastMessageContent,
+      LocalDateTime lastMessageAt,
+      Integer unreadCount,
+      Integer participantCount
+  ) {
+
+    public static ChatRoomInfo from(ChatRoom room, Integer unreadCount) {
+      return ChatRoomInfo.builder()
+          .chatRoomId(room.getId())
+          .roomType(room.getRoomType())
+          .roomTitle(room.getTitle())
+          .roomImage(room.getRoomImage())
+          .lastMessageContent(room.getLastMessageContent())
+          .lastMessageAt(room.getLastMessageAt())
+          .unreadCount(unreadCount)
+          .participantCount(room.getParticipantCount())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatRoomListResponse.java
@@ -10,7 +10,8 @@ import lombok.Builder;
 public record ChatRoomListResponse(
     List<ChatRoomInfo> rooms,
     Boolean hasNext,
-    Long nextCursorId
+    Long nextCursorId,
+    LocalDateTime nextLastMessageAt
 ) {
 
   @Builder

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepository.java
@@ -2,7 +2,10 @@ package com.example.WonkaoTalk.domain.chat.repo;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +20,23 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
       "AND p1.chatRoom.roomStatus = 'ACTIVE'")
   Optional<ChatRoom> findChatRoomByUsers(@Param("myId") Long myId,
       @Param("receiverId") Long receiverId);
+
+  // 2. 내가 참여 중인 채팅방 목록
+  @Query("""
+      SELECT p FROM ChatParticipant p
+      JOIN FETCH p.chatRoom r
+      WHERE p.userId = :myId
+      AND (
+          :lastMessageAt IS NULL
+          OR r.lastMessageAt < :lastMessageAt
+          OR (r.lastMessageAt = :lastMessageAt AND r.id < :cursorId)
+      )
+      ORDER BY r.lastMessageAt DESC, r.id DESC
+      """)
+  Slice<ChatParticipant> findMyChatRooms(
+      @Param("myId") Long myId,
+      @Param("lastMessageAt") LocalDateTime lastMessageAt,
+      @Param("cursorId") Long cursorId,
+      Pageable pageable
+  );
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
@@ -1,30 +1,8 @@
 package com.example.WonkaoTalk.domain.chat.repo;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
-import java.time.LocalDateTime;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-  @Query("""
-      SELECT p.chatRoom FROM ChatParticipant p
-      JOIN p.chatRoom r
-      WHERE p.userId = :myId
-      AND (
-          :lastMessageAt IS NULL
-          OR r.lastMessageAt < :lastMessageAt
-          OR (r.lastMessageAt = :lastMessageAt AND r.id < :cursorId)
-      )
-      ORDER BY r.lastMessageAt DESC, r.id DESC
-      """)
-  Slice<ChatRoom> findMyChatRooms(
-      @Param("myId") Long myId,
-      @Param("lastMessageAt") LocalDateTime lastMessageAt,
-      @Param("cursorId") Long cursorId,
-      Pageable pageable
-  );
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.chat.repo;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,10 +14,17 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       SELECT p.chatRoom FROM ChatParticipant p
       JOIN p.chatRoom r
       WHERE p.userId = :myId
-      AND (:cursorId IS NULL OR r.id < :cursorId)
+      AND (
+          :lastMessageAt IS NULL
+          OR r.lastMessageAt < :lastMessageAt
+          OR (r.lastMessageAt = :lastMessageAt AND r.id < :cursorId)
+      )
       ORDER BY r.lastMessageAt DESC, r.id DESC
       """)
-  Slice<ChatRoom> findMyChatRooms(@Param("myId") Long myId,
+  Slice<ChatRoom> findMyChatRooms(
+      @Param("myId") Long myId,
+      @Param("lastMessageAt") LocalDateTime lastMessageAt,
       @Param("cursorId") Long cursorId,
-      Pageable pageable);
+      Pageable pageable
+  );
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
@@ -10,10 +10,10 @@ import org.springframework.data.repository.query.Param;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   @Query("""
-      SELECT p.chatRoom FROM ChatParticipant p 
-      JOIN p.chatRoom r 
-      WHERE p.userId = :myId 
-      AND (:cursorId IS NULL OR r.id < :cursorId) 
+      SELECT p.chatRoom FROM ChatParticipant p
+      JOIN p.chatRoom r
+      WHERE p.userId = :myId
+      AND (:cursorId IS NULL OR r.id < :cursorId)
       ORDER BY r.lastMessageAt DESC, r.id DESC
       """)
   Slice<ChatRoom> findMyChatRooms(@Param("myId") Long myId,

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepository.java
@@ -1,8 +1,22 @@
 package com.example.WonkaoTalk.domain.chat.repo;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
+  @Query("""
+      SELECT p.chatRoom FROM ChatParticipant p 
+      JOIN p.chatRoom r 
+      WHERE p.userId = :myId 
+      AND (:cursorId IS NULL OR r.id < :cursorId) 
+      ORDER BY r.lastMessageAt DESC, r.id DESC
+      """)
+  Slice<ChatRoom> findMyChatRooms(@Param("myId") Long myId,
+      @Param("cursorId") Long cursorId,
+      Pageable pageable);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomService.java
@@ -1,9 +1,12 @@
 package com.example.WonkaoTalk.domain.chat.service;
 
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 
 public interface ChatRoomService {
 
   ChatRoomResponse createChatRoom(Long myId, ChatRoomCreateRequest request);
+
+  ChatRoomListResponse getChatRoomList(Long myId, Long cursorId, int size);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomService.java
@@ -3,10 +3,12 @@ package com.example.WonkaoTalk.domain.chat.service;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
+import java.time.LocalDateTime;
 
 public interface ChatRoomService {
 
   ChatRoomResponse createChatRoom(Long myId, ChatRoomCreateRequest request);
 
-  ChatRoomListResponse getChatRoomList(Long myId, Long cursorId, int size);
+  ChatRoomListResponse getChatRoomList(Long myId, LocalDateTime lastMessageAt, Long cursorId,
+      int size);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
@@ -73,14 +73,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
       int size) {
     PageRequest pageRequest = PageRequest.of(0, size);
 
-    Slice<ChatRoom> slice = chatRoomRepository.findMyChatRooms(myId,
-        lastMessageAt,
-        cursorId,
-        pageRequest);
+    Slice<ChatParticipant> slice = chatParticipantRepository.findMyChatRooms(myId, lastMessageAt,
+        cursorId, pageRequest);
 
     List<ChatRoomInfo> rooms = slice.getContent().stream()
         // TODO unreadCount 임시로 0 넣어 놓음
-        .map(room -> ChatRoomInfo.from(room, 0))
+        .map(participant -> ChatRoomInfo.from(participant, 0))
         .toList();
 
     Long nextCursorId = null;

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
@@ -4,12 +4,14 @@ import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse.ChatRoomInfo;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
 import com.example.WonkaoTalk.domain.chat.enums.RoomType;
 import com.example.WonkaoTalk.domain.chat.repo.ChatParticipantRepository;
 import com.example.WonkaoTalk.domain.chat.repo.ChatRoomRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ChatRoomServiceImpl implements ChatRoomService {
 
   private final ChatRoomRepository chatRoomRepository;
@@ -65,26 +68,35 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         });
   }
 
-  public ChatRoomListResponse getChatRoomList(Long myId, Long cursorId, int size) {
+  @Override
+  public ChatRoomListResponse getChatRoomList(Long myId, LocalDateTime lastMessageAt, Long cursorId,
+      int size) {
     PageRequest pageRequest = PageRequest.of(0, size);
 
-    Slice<ChatRoom> roomSlice = chatRoomRepository.findMyChatRooms(myId, cursorId, pageRequest);
+    Slice<ChatRoom> slice = chatRoomRepository.findMyChatRooms(myId,
+        lastMessageAt,
+        cursorId,
+        pageRequest);
 
-    List<ChatRoomListResponse.ChatRoomInfo> roomSummaries = roomSlice.getContent().stream()
-        .map(room -> {
-          // TODO: 추후 last_read_message_id 기준으로 count 쿼리 연동
-          Integer unreadCount = 0;
-          return ChatRoomListResponse.ChatRoomInfo.from(room, unreadCount);
-        })
+    List<ChatRoomInfo> rooms = slice.getContent().stream()
+        // TODO unreadCount 임시로 0 넣어 놓음
+        .map(room -> ChatRoomInfo.from(room, 0))
         .toList();
 
-    Long nextCursorId = roomSummaries.isEmpty() ? null :
-        roomSummaries.get(roomSummaries.size() - 1).chatRoomId();
+    Long nextCursorId = null;
+    LocalDateTime nextLastMessageAt = null;
+
+    if (slice.hasNext() && !rooms.isEmpty()) {
+      ChatRoomInfo lastRoom = rooms.getLast();
+      nextCursorId = lastRoom.chatRoomId();
+      nextLastMessageAt = lastRoom.lastMessageAt();
+    }
 
     return ChatRoomListResponse.builder()
-        .rooms(roomSummaries)
-        .hasNext(roomSlice.hasNext())
-        .nextCursorId(roomSlice.hasNext() ? nextCursorId : null)
+        .rooms(rooms)
+        .hasNext(slice.hasNext())
+        .nextCursorId(nextCursorId)
+        .nextLastMessageAt(nextLastMessageAt)
         .build();
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.chat.service;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
 import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
@@ -11,6 +12,8 @@ import com.example.WonkaoTalk.domain.chat.repo.ChatParticipantRepository;
 import com.example.WonkaoTalk.domain.chat.repo.ChatRoomRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +63,29 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
           return ChatRoomResponse.from(newRoom, createTempParticipants(myId, receiverId));
         });
+  }
+
+  public ChatRoomListResponse getChatRoomList(Long myId, Long cursorId, int size) {
+    PageRequest pageRequest = PageRequest.of(0, size);
+
+    Slice<ChatRoom> roomSlice = chatRoomRepository.findMyChatRooms(myId, cursorId, pageRequest);
+
+    List<ChatRoomListResponse.ChatRoomInfo> roomSummaries = roomSlice.getContent().stream()
+        .map(room -> {
+          // TODO: 추후 last_read_message_id 기준으로 count 쿼리 연동
+          Integer unreadCount = 0;
+          return ChatRoomListResponse.ChatRoomInfo.from(room, unreadCount);
+        })
+        .toList();
+
+    Long nextCursorId = roomSummaries.isEmpty() ? null :
+        roomSummaries.get(roomSummaries.size() - 1).chatRoomId();
+
+    return ChatRoomListResponse.builder()
+        .rooms(roomSummaries)
+        .hasNext(roomSlice.hasNext())
+        .nextCursorId(roomSlice.hasNext() ? nextCursorId : null)
+        .build();
   }
 
   // TODO: 유저 연동 전 임시 데이터임

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepositoryTest.java
@@ -49,7 +49,8 @@ class ChatRoomRepositoryTest {
     joinRoom(room1, receiverId);
 
     // when
-    Slice<ChatRoom> result = chatRoomRepository.findMyChatRooms(myId, null, PageRequest.of(0, 10));
+    Slice<ChatRoom> result = chatRoomRepository.findMyChatRooms(myId, null, null,
+        PageRequest.of(0, 10));
 
     // then
     List<ChatRoom> content = result.getContent();
@@ -78,12 +79,16 @@ class ChatRoomRepositoryTest {
     joinRoom(room3, myId);
 
     // when: room3을 보고 다음 페이지(cursorId = room3의 ID) 요청
-    Slice<ChatRoom> result = chatRoomRepository.findMyChatRooms(myId, room3.getId(),
-        PageRequest.of(0, 1));
+    Slice<ChatRoom> result = chatRoomRepository.findMyChatRooms(
+        myId,
+        room3.getLastMessageAt(),
+        room3.getId(),
+        PageRequest.of(0, 1)
+    );
 
     // then
     assertThat(result.getContent()).hasSize(1);
-    assertThat(result.getContent().get(0).getId()).isEqualTo(room2.getId());
+    assertThat(result.getContent().getFirst().getId()).isEqualTo(room2.getId());
     assertThat(result.hasNext()).isTrue();
   }
 

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatRoomRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.example.WonkaoTalk.domain.chat.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.WonkaoTalk.common.config.JpaConfig;
+import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class ChatRoomRepositoryTest {
+
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
+
+  @Autowired
+  private ChatParticipantRepository chatParticipantRepository;
+
+  @Test
+  @DisplayName("마지막 메시지 시간(lastMessageAt) 기준으로 내림차순 정렬되어야 한다")
+  void findMyChatRoomsSortingTest() {
+    // given
+    Long myId = 1L;
+    Long receiverId = 2L;
+
+    ChatRoom room1 = createRoom("방1", //작년에 만들었는데 톡 방금 옴
+        LocalDateTime.now().minusYears(1), LocalDateTime.now());
+
+    ChatRoom room2 = createRoom("방2", //한달 전 만들었는데 톡 1시간 전에 옴
+        LocalDateTime.now().minusMonths(1), LocalDateTime.now().minusHours(1));
+
+    ChatRoom room3 = createRoom("방3", // 어제 만들었는데 톡 2시간 전에 옴
+        LocalDateTime.now().minusDays(1), LocalDateTime.now().minusHours(2));
+
+    joinRoom(room1, myId);
+    joinRoom(room2, myId);
+    joinRoom(room3, myId);
+    joinRoom(room1, receiverId);
+
+    // when
+    Slice<ChatRoom> result = chatRoomRepository.findMyChatRooms(myId, null, PageRequest.of(0, 10));
+
+    // then
+    List<ChatRoom> content = result.getContent();
+    assertThat(content).hasSize(3);
+
+    assertThat(content.get(0).getId()).isEqualTo(room1.getId());
+    assertThat(content.get(1).getId()).isEqualTo(room2.getId());
+    assertThat(content.get(2).getId()).isEqualTo(room3.getId());
+  }
+
+  @Test
+  @DisplayName("커서 ID가 있으면 해당 ID보다 작은 방들만 조회되어야 한다")
+  void findMyChatRoomsPagingTest() {
+    // given
+    Long myId = 1L;
+
+    ChatRoom room1 = createRoom("방1", LocalDateTime.now().minusDays(3),
+        LocalDateTime.now().minusHours(3));
+    ChatRoom room2 = createRoom("방2", LocalDateTime.now().minusDays(2),
+        LocalDateTime.now().minusHours(2));
+    ChatRoom room3 = createRoom("방3", LocalDateTime.now().minusDays(1),
+        LocalDateTime.now().minusHours(1));
+
+    joinRoom(room1, myId);
+    joinRoom(room2, myId);
+    joinRoom(room3, myId);
+
+    // when: room3을 보고 다음 페이지(cursorId = room3의 ID) 요청
+    Slice<ChatRoom> result = chatRoomRepository.findMyChatRooms(myId, room3.getId(),
+        PageRequest.of(0, 1));
+
+    // then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getId()).isEqualTo(room2.getId());
+    assertThat(result.hasNext()).isTrue();
+  }
+
+  private ChatRoom createRoom(String title, LocalDateTime createdAt, LocalDateTime lastAt) {
+    ChatRoom room = chatRoomRepository.save(ChatRoom.builder()
+        .roomType(RoomType.SINGLE)
+        .participantCount(2)
+        .lastMessageAt(lastAt)
+        .build());
+
+    ReflectionTestUtils.setField(room, "createdAt", createdAt);
+    return chatRoomRepository.save(room);
+  }
+
+  private void joinRoom(ChatRoom room, Long userId) {
+    chatParticipantRepository.save(ChatParticipant.builder()
+        .chatRoom(room)
+        .userId(userId)
+        .roomTitle("임시방제목")
+        .build());
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #20 

## 📝 작업 내용
- 채팅방 목록 조 회 API 컨트롤러 및 로직 구현
- 응답 DTO 설계
- 참여 채팅방 가져오는 쿼리 작성
- 커서 기반 페이징 적용
- 방 생성 순서가 아닌 lastMessageAt 기준 내림차순 정렬 구현

## ✅ 작업 결과 
<img width="595" height="683" alt="image" src="https://github.com/user-attachments/assets/1635b7b7-a330-4126-8969-a66c744b78a7" />
만약 생성된 채팅방이 없어도 오류가뜨지않고 빈 데이터를 잘 담아내야 함!
<img width="704" height="329" alt="image" src="https://github.com/user-attachments/assets/20652041-d265-4079-8883-1090f8acda9c" />


## 🎸 기타
- 현재 unreadCount는 임시로 하드코딩돼있음 다음에 메시지쪽 개발 후 실제 카운트 반영할 예ㅂ정
