### PR TITLE
feat: 일반 회원가입 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 ### application-local ###
 ./src/main/resources/application-local.yml
 ./src/main/resources/application-local.yaml
+*/application-local.y*

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.example.WonkaoTalk.common.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        // REST API 서버이므로 CSRF 보호 비활성화 (토큰 기반 인증을 사용할 예정이므로 불필요)
+        .csrf(AbstractHttpConfigurer::disable)
+
+        // HTTP 요청에 대한 접근 권한 설정
+        .authorizeHttpRequests(auth -> auth
+            // 명시한 엔드포인트만 인증 없이 접근 허용
+            .requestMatchers(
+                "/api/v1/auth/check-email",
+                "/api/v1/auth/signup"
+            ).permitAll()
+
+            // 그 외의 다른 모든 요청은 인증을 거쳐야 함
+            .anyRequest().authenticated()
+        );
+
+    return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    // BCrypt의 경우 보안 성능이 강력하나 해시 연산 속도가 느림. 현재 서비스 로직 상 Transaction 내에서 암호화를 진행 해 병목 발생 가능성 높음.
+    // TODO: service 클래스 분리 작업 필수
+    return new BCryptPasswordEncoder();
+  }
+
+}

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -14,6 +14,12 @@ public enum ErrorCode {
   SERVER_ERROR(500, "SYS-INTERNAL-ERROR", "서버 내부 에러가 발생했습니다."),
   SERVICE_UNAVAILABLE(503, "SYS-SERVICE-UNAVAILABLE", "서버 점검 중입니다."),
 
+  // 인증 도메인
+  AUTH_INVALID_EMAIL(400, "AUTH-INVALID-EMAIL", "올바른 이메일 형식이 아닙니다."),
+  AUTH_INVALID_PASSWORD(400, "AUTH-INVALID-PASSWORD", "비밀번호는 영문 대/소문자와 숫자를 모두 포함하여 8자리 이상이어야 합니다."),
+  AUTH_DUPLICATE_EMAIL(409, "AUTH-DUPLICATE-EMAIL", "이미 사용 중인 이메일입니다."),
+  AUTH_MISMATCH_PASSWORD(400, "AUTH-MISMATCH-PASSWORD", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+
   // 유저 도메인
   USER_NOT_FOUND(404, "USER-NOTFOUND-ID", "해당 사용자 ID를 찾을 수 없습니다."),
 

--- a/src/main/java/com/example/WonkaoTalk/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/GlobalExceptionHandler.java
@@ -29,18 +29,9 @@ public class GlobalExceptionHandler {
     String errorMessage = fieldError != null ?
         fieldError.getDefaultMessage() : "입력값이 올바르지 않습니다";
 
-    ErrorCode errorCode = ErrorCode.BAD_REQUEST;
-
-    // 예외 필드가 "email" 인 경우 나중에 동일한 필드에서 발생하는 에러가 존재할 경우 에러 메세지 검토 필요.
-    if ("email".equals(field)) {
-      errorCode = ErrorCode.AUTH_INVALID_EMAIL;
-    } else if ("password".equals(field)) {
-      errorCode = ErrorCode.AUTH_INVALID_PASSWORD;
-    }
-
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
-        .body(ApiResponse.error(errorCode.getCode(), errorMessage));
+        .body(ApiResponse.error(ErrorCode.BAD_REQUEST.getCode(), errorMessage));
   }
 
   // 그 외 예상치 못한 에러가 발생했을 때 (500 에러 포장)

--- a/src/main/java/com/example/WonkaoTalk/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package com.example.WonkaoTalk.common.exception;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,6 +18,29 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(errorCode.getHttpStatus())
         .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
+  }
+
+  // @Valid 검증 실패 예외 처리
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ApiResponse<Void>> handleValidationException(
+      MethodArgumentNotValidException e) {
+    FieldError fieldError = e.getBindingResult().getFieldError();
+    String field = fieldError != null ? fieldError.getField() : "";
+    String errorMessage = fieldError != null ?
+        fieldError.getDefaultMessage() : "입력값이 올바르지 않습니다";
+
+    ErrorCode errorCode = ErrorCode.BAD_REQUEST;
+
+    // 예외 필드가 "email" 인 경우 나중에 동일한 필드에서 발생하는 에러가 존재할 경우 에러 메세지 검토 필요.
+    if ("email".equals(field)) {
+      errorCode = ErrorCode.AUTH_INVALID_EMAIL;
+    } else if ("password".equals(field)) {
+      errorCode = ErrorCode.AUTH_INVALID_PASSWORD;
+    }
+
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(ApiResponse.error(errorCode.getCode(), errorMessage));
   }
 
   // 그 외 예상치 못한 에러가 발생했을 때 (500 에러 포장)

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     EmailCheckResponse data = authService.validateEmail(request);
 
     String message =
-        data.isValid() ? "시용 기능한 이메일입니다." : "이미 사용 중인 이메일입니다.";
+        data.isValid() ? "사용 기능한 이메일입니다." : "이미 사용 중인 이메일입니다.";
 
     return ResponseEntity.ok(ApiResponse.success(message, data));
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -1,0 +1,46 @@
+package com.example.WonkaoTalk.domain.auth.controller;
+
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
+import com.example.WonkaoTalk.domain.auth.dto.SignUpRequest;
+import com.example.WonkaoTalk.domain.auth.dto.SignUpResponse;
+import com.example.WonkaoTalk.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/check-email")
+  public ResponseEntity<ApiResponse<EmailCheckResponse>> checkEmail(
+      @Valid @RequestBody EmailCheckRequest request
+  ) {
+    EmailCheckResponse data = authService.validateEmail(request);
+
+    String message =
+        data.isValid() ? "시용 기능한 이메일입니다." : "이미 사용 중인 이메일입니다.";
+
+    return ResponseEntity.ok(ApiResponse.success(message, data));
+  }
+
+  @PostMapping("/signup")
+  public ResponseEntity<ApiResponse<SignUpResponse>> signUp(
+      @Valid @RequestBody SignUpRequest request
+  ) {
+    SignUpResponse data = authService.signUp(request);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success("회원가입이 완료되었습니다.", data));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/EmailCheckRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/EmailCheckRequest.java
@@ -1,0 +1,16 @@
+package com.example.WonkaoTalk.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailCheckRequest(
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(
+        // OWASP 이메일 정규식
+        regexp = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$",
+        message = "올바른 이메일 형식이 아닙니다."
+    )
+    String email
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/EmailCheckResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/EmailCheckResponse.java
@@ -1,0 +1,15 @@
+package com.example.WonkaoTalk.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record EmailCheckResponse(
+    boolean isValid
+) {
+
+  public static EmailCheckResponse from(boolean isValid) {
+    return EmailCheckResponse.builder()
+        .isValid(isValid)
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/SignUpRequest.java
@@ -1,0 +1,46 @@
+package com.example.WonkaoTalk.domain.auth.dto;
+
+import com.example.WonkaoTalk.domain.user.enums.Gender;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+
+public record SignUpRequest(
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$",
+        message = "올바른 이메일 형식이 아닙니다."
+    )
+    String email,
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}$",
+        message = "비밀번호는 영문 대/소문자와 숫자를 포함하여 8자리 이상어야 합니다."
+    )
+    String password,
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+    String passwordCheck,
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    String name,
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    String nickname,
+
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    @Pattern(
+        regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$",
+        message = "올바른 전화번호 형식(000-0000-0000)이 아닙니다."
+    )
+    String phone,
+
+    LocalDate birthDate,
+
+    @NotNull(message = "성별을 선택해주세요.")
+    Gender gender
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/SignUpRequest.java
@@ -17,7 +17,7 @@ public record SignUpRequest(
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Pattern(
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,}$",
-        message = "비밀번호는 영문 대/소문자와 숫자를 포함하여 8자리 이상어야 합니다."
+        message = "비밀번호는 영문 대/소문자와 숫자를 포함하여 8자리 이상이어야 합니다."
     )
     String password,
 

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/SignUpResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/SignUpResponse.java
@@ -1,0 +1,13 @@
+package com.example.WonkaoTalk.domain.auth.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record SignUpResponse(
+    Long authId,
+    Long userId,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/entity/Auth.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/entity/Auth.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.auth.entity;
 
 
+import com.example.WonkaoTalk.domain.auth.enums.AccountStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/entity/Auth.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/entity/Auth.java
@@ -17,6 +17,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -25,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "auths")
@@ -34,6 +38,7 @@ public class Auth {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Builder.Default
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private AccountStatus status = AccountStatus.ACTIVE;
@@ -52,9 +57,11 @@ public class Auth {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  @Builder.Default
   @OneToMany(mappedBy = "auth", cascade = CascadeType.ALL)
   private List<AuthLocal> authLocals = new ArrayList<>();
 
+  @Builder.Default
   @OneToMany(mappedBy = "auth", cascade = CascadeType.ALL)
   private List<AuthSocial> authSocials = new ArrayList<>();
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthLocal.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthLocal.java
@@ -12,6 +12,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -19,6 +21,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "auth_locals")

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthSocial.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthSocial.java
@@ -15,6 +15,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -22,6 +24,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "auth_socials")

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthSocial.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthSocial.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.auth.entity;
 
+import com.example.WonkaoTalk.domain.auth.enums.AuthProvider;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/enums/AccountStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/enums/AccountStatus.java
@@ -1,4 +1,4 @@
-package com.example.WonkaoTalk.domain.auth.entity;
+package com.example.WonkaoTalk.domain.auth.enums;
 
 public enum AccountStatus {
   ACTIVE, // 활동

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/enums/AuthProvider.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/enums/AuthProvider.java
@@ -1,4 +1,4 @@
-package com.example.WonkaoTalk.domain.auth.entity;
+package com.example.WonkaoTalk.domain.auth.enums;
 
 public enum AuthProvider {
   NAVER,

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/repo/AuthLocalRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/repo/AuthLocalRepo.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthLocalRepo extends JpaRepository<AuthLocal, Long> {
 
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
@@ -1,0 +1,78 @@
+package com.example.WonkaoTalk.domain.auth.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
+import com.example.WonkaoTalk.domain.auth.dto.SignUpRequest;
+import com.example.WonkaoTalk.domain.auth.dto.SignUpResponse;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthSocialRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+  private final AuthRepo authRepo;
+  private final AuthLocalRepo authLocalRepo;
+  private final AuthSocialRepo authSocialRepo;
+  private final UserRepo userRepo;
+  private final PasswordEncoder passwordEncoder;
+
+  @Transactional(readOnly = true)
+  public EmailCheckResponse validateEmail(EmailCheckRequest request) {
+    boolean exists = authLocalRepo.existsByEmail(request.email());
+
+    return EmailCheckResponse.from(!exists);
+  }
+
+  @Transactional
+  public SignUpResponse signUp(SignUpRequest request) {
+    if (!request.password().equals(request.passwordCheck())) {
+      throw new BusinessException(ErrorCode.AUTH_MISMATCH_PASSWORD);
+    }
+
+    if (authLocalRepo.existsByEmail(request.email())) {
+      throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
+    }
+
+    Auth auth = Auth.builder().build();
+    Auth savedAuth = authRepo.save(auth);
+
+    String encodedPassword = passwordEncoder.encode(request.password());
+    AuthLocal authLocal = AuthLocal.builder()
+        .auth(savedAuth)
+        .email(request.email())
+        .passwordHash(encodedPassword)
+        .failedAttemptsCount(0)
+        .build();
+    authLocalRepo.save(authLocal);
+
+    User user = User.builder()
+        .authId(savedAuth)
+        .name(request.name())
+        .nickname(request.nickname())
+        .phone(request.phone())
+        .birthDate(request.birthDate())
+        .gender(request.gender())
+        .build();
+    User savedUser = userRepo.save(user);
+
+    return SignUpResponse.builder()
+        .authId(savedAuth.getId())
+        .userId(savedUser.getId())
+        .createdAt(savedAuth.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
@@ -10,7 +10,6 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
 import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
-import com.example.WonkaoTalk.domain.auth.repo.AuthSocialRepo;
 import com.example.WonkaoTalk.domain.user.entity.User;
 import com.example.WonkaoTalk.domain.user.repo.UserRepo;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,6 @@ public class AuthService {
 
   private final AuthRepo authRepo;
   private final AuthLocalRepo authLocalRepo;
-  private final AuthSocialRepo authSocialRepo;
   private final UserRepo userRepo;
   private final PasswordEncoder passwordEncoder;
 

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
@@ -1,12 +1,15 @@
 package com.example.WonkaoTalk.domain.seller.entity;
 
 
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -33,8 +36,9 @@ public class Seller {
   @Column(nullable = false)
   private String phone;
 
-  @Column(name = "auth_id", nullable = false)
-  private Long authId;
+  @OneToOne
+  @JoinColumn(name = "auth_id", nullable = false)
+  private Auth authId;
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/SellerConsent.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.seller.entity;
 
+import com.example.WonkaoTalk.domain.term.entity.TermVersion;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -30,7 +31,7 @@ public class SellerConsent {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "terms_version_id", nullable = false)
-  private Long termsVersionId;
+  private TermVersion termsVersionId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "seller_id")

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
@@ -1,18 +1,24 @@
 package com.example.WonkaoTalk.domain.user.entity;
 
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.user.enums.Gender;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -21,6 +27,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "users")
@@ -33,8 +41,9 @@ public class User {
   @Column(nullable = false, length = 20)
   private String nickname;
 
+  @Builder.Default
   @Column(nullable = false)
-  private String image;
+  private String image = "http://defaultImage.png"; // TODO: 기본 프로필 이미지 URL 작성 필요
 
   @Column(name = "birth_date")
   private LocalDate birthDate;
@@ -49,11 +58,13 @@ public class User {
   @Column(nullable = false)
   private Gender gender = Gender.NONE;
 
+  @Builder.Default
   @Column(name = "marketing_agree", nullable = false)
   private boolean marketingAgree = false;
 
-  @Column(name = "auth_id")
-  private Long authId;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "auth_id", nullable = false)
+  private Auth authId;
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/UserConsent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/UserConsent.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.user.entity;
 
+import com.example.WonkaoTalk.domain.term.entity.TermVersion;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -30,7 +31,7 @@ public class UserConsent {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "terms_version_id", nullable = false)
-  private Long termsVersionId;
+  private TermVersion termsVersionId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ server:
 
 logging:
   level:
-    root: DEBUG
+    root: INFO
 
 decorator:
   datasource:

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,48 @@
+package com.example.WonkaoTalk.domain.auth.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
+import com.example.WonkaoTalk.domain.auth.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = AuthController.class)
+// Spring Security 권한을 우회
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private AuthService authService;
+
+  @Test
+  @DisplayName("올바르지 않은 이메일 형식으로 중복 검사 실패")
+  public void CheckEmailFailedByInvalidEmail() throws Exception {
+    //given
+    EmailCheckRequest request = new EmailCheckRequest("test@test"); // 도메인 누락
+
+    //when & then
+    mockMvc.perform(post("/api/v1/auth/check-email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("AUTH-INVALID-EMAIL")); // ErrorCode 검증
+  }
+
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -62,7 +62,7 @@ class AuthServiceTest {
     //given
     SignUpRequest request = new SignUpRequest(
         "test@test.com", "Qwer1234", "Qwer1234",
-        "이병건", "침착맨", "010-1234-56678",
+        "이병건", "침착맨", "010-1234-5678",
         null, Gender.MALE
     );
 
@@ -94,7 +94,7 @@ class AuthServiceTest {
     //given
     SignUpRequest request = new SignUpRequest(
         "test@test.com", "Qwer1234", "Qwer12345",
-        "이병건", "침착맨", "010-1234-56678",
+        "이병건", "침착맨", "010-1234-5678",
         null, Gender.MALE
     );
 

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,110 @@
+package com.example.WonkaoTalk.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
+import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
+import com.example.WonkaoTalk.domain.auth.dto.SignUpRequest;
+import com.example.WonkaoTalk.domain.auth.dto.SignUpResponse;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.enums.Gender;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+  @InjectMocks
+  private AuthService authService;
+
+  @Mock
+  private AuthRepo authRepo;
+  @Mock
+  private AuthLocalRepo authLocalRepo;
+  @Mock
+  private UserRepo userRepo;
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Test
+  @DisplayName("사용 가능한 이메일 중복 검사")
+  public void checkEmailAvailable() {
+    //given
+    EmailCheckRequest request = new EmailCheckRequest("test@test.com");
+    given(authLocalRepo.existsByEmail(request.email())).willReturn(false);
+
+    //when
+    EmailCheckResponse response = authService.validateEmail(request);
+
+    //then
+    assertThat(response.isValid()).isTrue();
+  }
+
+  @Test
+  @DisplayName("정상적으로 회원가입에 성공")
+  public void signUpSuccess() {
+    //given
+    SignUpRequest request = new SignUpRequest(
+        "test@test.com", "Qwer1234", "Qwer1234",
+        "이병건", "침착맨", "010-1234-56678",
+        null, Gender.MALE
+    );
+
+    given(authLocalRepo.existsByEmail(request.email())).willReturn(false);
+    given(passwordEncoder.encode(request.password())).willReturn("EncodedPassword");
+
+    Auth auth = Auth.builder().build();
+    given(authRepo.save(any(Auth.class))).willReturn(auth);
+
+    AuthLocal authLocal = AuthLocal.builder().build();
+    given(authLocalRepo.save(any(AuthLocal.class))).willReturn(authLocal);
+
+    User user = User.builder().build();
+    given(userRepo.save(any(User.class))).willReturn(user);
+
+    //when
+    SignUpResponse response = authService.signUp(request);
+
+    //then
+    assertThat(response).isNotNull();
+    verify(authRepo).save(any(Auth.class));
+    verify(authLocalRepo).save(any(AuthLocal.class));
+    verify(userRepo).save(any(User.class));
+  }
+
+  @Test
+  @DisplayName("비밀번호 확인 불일치 회원가입 실패")
+  public void signUpFailedPasswordMismatch() {
+    //given
+    SignUpRequest request = new SignUpRequest(
+        "test@test.com", "Qwer1234", "Qwer12345",
+        "이병건", "침착맨", "010-1234-56678",
+        null, Gender.MALE
+    );
+
+    //when & then
+    BusinessException e = assertThrows(BusinessException.class, () -> {
+      authService.signUp(request);
+    });
+
+    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AUTH_MISMATCH_PASSWORD);
+
+  }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #24 

## 📝 작업 내용
- `AuthService.java` 일반 회원가입 및 이메일 중복 검사 기능 구현
- `AuthController.java`에 `/auth/check-email` , `/auth/signup` 엔드포인트 추가
- 엔드포인트에 대한 테스트 코드 작성

## ✅ 작업 결과 
<img width="450" height="202" alt="image" src="https://github.com/user-attachments/assets/743b8815-0cf5-494b-a8d7-6523e435fd41" />
<img width="459" height="171" alt="image" src="https://github.com/user-attachments/assets/7389ebb7-0bf3-496f-a200-c0c0a8ff7f1c" />


## 🎸 기타
TODO: 현재 비밀번호 암호화를 BCrypt를 사용하는데 암호화 속도가 느려서 Transaction 내부에서 작동하면 병목 발생 가능성이 높습니다.
추후 Service 클래스를 분리하여 트랜잭션 외부 작업과 내부 작업을 구분
