### PR TITLE
feat: 상품 등록 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ application-local.yml
 application-local.yaml
 application-secret.yml
 */application-local.y*
+
+### Docker volume data ###
+postgres/
+kafka/
+minio/
+
+### macOS ###
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // --- AWS SDK v2 (S3 / MinIO)
+    implementation platform('software.amazon.awssdk:bom:2.31.9')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-transfer-manager'
+
     // --- Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-transfer-manager'
 
+    // --- XSS Sanitizer
+    implementation 'org.jsoup:jsoup:1.18.3'
+
     // --- Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,19 +63,6 @@ services:
     volumes:
       - ./minio/data:/data
 
-  minio-init:
-    image: minio/mc:latest
-    container_name: wonkao-talk-minio-init
-    depends_on:
-      - minio
-    entrypoint: >
-      /bin/sh -c "
-      sleep 3;
-      mc alias set local http://minio:9000 minioadmin minioadmin;
-      mc mb --ignore-existing local/wonkaotalk;
-      exit 0;
-      "
-
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
     container_name: wonkao-talk-es

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,32 @@ services:
     volumes:
       - ./kafka/data:/var/lib/kafka/data
 
+  minio:
+    image: minio/minio:latest
+    container_name: wonkao-talk-minio
+    ports:
+      - "9000:9000"  # API
+      - "9001:9001"  # 콘솔 (브라우저)
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - ./minio/data:/data
+
+  minio-init:
+    image: minio/mc:latest
+    container_name: wonkao-talk-minio-init
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      sleep 3;
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb --ignore-existing local/wonkaotalk;
+      exit 0;
+      "
+
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
     container_name: wonkao-talk-es

--- a/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -47,6 +48,9 @@ public class S3Config {
         .credentialsProvider(StaticCredentialsProvider.create(
             AwsBasicCredentials.create(accessKey, secretKey)))
         .region(Region.AP_NORTHEAST_2)
+        .serviceConfiguration(S3Configuration.builder()
+            .pathStyleAccessEnabled(true)
+            .build())
         .build();
   }
 

--- a/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
@@ -30,14 +30,17 @@ public class S3Config {
   @Value("${storage.bucket}")
   private String bucket;
 
+  @Value("${storage.region}")
+  private String region;
+
   @Bean
   public S3Client s3Client() {
     return S3Client.builder()
         .endpointOverride(URI.create(endpoint))
         .credentialsProvider(StaticCredentialsProvider.create(
             AwsBasicCredentials.create(accessKey, secretKey)))
-        .region(Region.AP_NORTHEAST_2)
-        .forcePathStyle(true) // MinIO는 path-style 필수
+        .region(Region.of(region))
+        .forcePathStyle(true)
         .build();
   }
 
@@ -47,7 +50,7 @@ public class S3Config {
         .endpointOverride(URI.create(endpoint))
         .credentialsProvider(StaticCredentialsProvider.create(
             AwsBasicCredentials.create(accessKey, secretKey)))
-        .region(Region.AP_NORTHEAST_2)
+        .region(Region.of(region))
         .serviceConfiguration(S3Configuration.builder()
             .pathStyleAccessEnabled(true)
             .build())

--- a/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
@@ -2,12 +2,16 @@ package com.example.WonkaoTalk.common.config;
 
 import java.net.URI;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -21,6 +25,9 @@ public class S3Config {
 
   @Value("${storage.secret-key}")
   private String secretKey;
+
+  @Value("${storage.bucket}")
+  private String bucket;
 
   @Bean
   public S3Client s3Client() {
@@ -41,5 +48,18 @@ public class S3Config {
             AwsBasicCredentials.create(accessKey, secretKey)))
         .region(Region.AP_NORTHEAST_2)
         .build();
+  }
+
+  @Bean
+  public CommandLineRunner bucketInitializer(S3Client s3Client) {
+    return args -> {
+      try {
+        s3Client.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+      } catch (S3Exception e) {
+        if (e.statusCode() == 404) {
+          s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        }
+      }
+    };
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/S3Config.java
@@ -1,0 +1,45 @@
+package com.example.WonkaoTalk.common.config;
+
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+  @Value("${storage.endpoint}")
+  private String endpoint;
+
+  @Value("${storage.access-key}")
+  private String accessKey;
+
+  @Value("${storage.secret-key}")
+  private String secretKey;
+
+  @Bean
+  public S3Client s3Client() {
+    return S3Client.builder()
+        .endpointOverride(URI.create(endpoint))
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKey, secretKey)))
+        .region(Region.AP_NORTHEAST_2)
+        .forcePathStyle(true) // MinIO는 path-style 필수
+        .build();
+  }
+
+  @Bean
+  public S3Presigner s3Presigner() {
+    return S3Presigner.builder()
+        .endpointOverride(URI.create(endpoint))
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKey, secretKey)))
+        .region(Region.AP_NORTHEAST_2)
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig {
                 "/api/v1/sellers/register"
             ).authenticated()
             .requestMatchers(
-                "/api/v1/sellers/**"
+                "/api/v1/sellers/**",
+                "/api/v1/images/**"
             ).hasRole("SELLER")
 
             // SecurityTest용 엔드포인트

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.example.WonkaoTalk.common.config.security.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,15 +31,18 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         // HTTP 요청에 대한 접근 권한 설정
         .authorizeHttpRequests(auth -> auth
+            .requestMatchers(HttpMethod.GET,
+                "/api/v1/products",
+                "/api/v1/products/*",
+                "/api/v1/products/categories"
+            ).permitAll()
+            .requestMatchers(HttpMethod.POST, "/api/v1/products").hasRole("SELLER")
             .requestMatchers(
                 "/api/v1/auth/check-email",
                 "/api/v1/users/signup",
                 "/api/v1/sellers/signup",
-                "/api/v1/products",
-                "/api/v1/products/*",
                 "/api/v1/search",
                 "/api/v1/auth/login",
-                "/api/v1/sellers/signup",
                 "/api/v1/chats/**"
             ).permitAll() // 인증 없이 접근 허용
             .requestMatchers(

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -45,6 +45,11 @@ public enum ErrorCode {
   PROD_VARIANT_UNAVAILABLE(400, "PROD-UNAVAILABLE-VARIANT", "구매 불가능한 상품 옵션입니다."),
   PROD_INVALID_QUANTITY(400, "PROD-INVALID-QUANTITY", "수량은 최소 1개 이상이어야 합니다."),
 
+  // 이미지 도메인
+  IMAGE_INVALID_TYPE(400, "IMAGE-INVALID-TYPE", "허용되지 않는 파일 형식입니다. (jpg, jpeg, png, webp)"),
+  IMAGE_INVALID_KEY(400, "IMAGE-INVALID-KEY", "유효하지 않은 이미지 키 형식입니다."),
+  IMAGE_NOT_FOUND_KEY(400, "IMAGE-NOT-FOUND-KEY", "업로드되지 않았거나 만료된 이미지 키입니다."),
+
   // 주문 도메인
 
   // 채팅 도메인

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -44,6 +44,11 @@ public enum ErrorCode {
   PROD_STOCK_INSUFFICIENT(400, "PROD-INSUFFICIENT-STOCK", "재고가 부족합니다."),
   PROD_VARIANT_UNAVAILABLE(400, "PROD-UNAVAILABLE-VARIANT", "구매 불가능한 상품 옵션입니다."),
   PROD_INVALID_QUANTITY(400, "PROD-INVALID-QUANTITY", "수량은 최소 1개 이상이어야 합니다."),
+  PROD_INVALID_PRICE(400, "PROD-INVALID-PRICE", "가격은 0 이상이어야 합니다."),
+  PROD_INVALID_DISCOUNT_RATE(400, "PROD-INVALID-DISCOUNT-RATE", "할인율은 0에서 100 사이여야 합니다."),
+  PROD_MISMATCH_VARIANT_OPTION(400, "PROD-MISMATCH-VARIANT-OPTION", "variant의 옵션 이름이 등록된 옵션 목록과 일치하지 않습니다."),
+  PROD_INVALID_STOCK_OPTION(400, "PROD-INVALID-STOCK-OPTION", "옵션이 있는 상품은 stock을 직접 입력할 수 없습니다."),
+  PROD_DUPLICATE_SORT_ORDER(400, "PROD-DUPLICATE-SORT-ORDER", "sortOrder 값이 중복되었습니다."),
 
   // 이미지 도메인
   IMAGE_INVALID_TYPE(400, "IMAGE-INVALID-TYPE", "허용되지 않는 파일 형식입니다. (jpg, jpeg, png, webp)"),

--- a/src/main/java/com/example/WonkaoTalk/domain/image/controller/ImageController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/controller/ImageController.java
@@ -1,0 +1,29 @@
+package com.example.WonkaoTalk.domain.image.controller;
+
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.image.dto.PresignedUrlRequest;
+import com.example.WonkaoTalk.domain.image.dto.PresignedUrlResponse;
+import com.example.WonkaoTalk.domain.image.service.ImageService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+  private final ImageService imageService;
+
+  @PostMapping("/presigned-url")
+  public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
+      @Valid @RequestBody PresignedUrlRequest request
+  ) {
+    PresignedUrlResponse data = imageService.issuePresignedUrl(request);
+    return ResponseEntity.ok(ApiResponse.success("Presigned URL이 발급되었습니다.", data));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/image/dto/PresignedUrlRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/dto/PresignedUrlRequest.java
@@ -1,0 +1,7 @@
+package com.example.WonkaoTalk.domain.image.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUrlRequest(
+    @NotBlank String filename
+) {}

--- a/src/main/java/com/example/WonkaoTalk/domain/image/dto/PresignedUrlResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/dto/PresignedUrlResponse.java
@@ -1,0 +1,7 @@
+package com.example.WonkaoTalk.domain.image.dto;
+
+public record PresignedUrlResponse(
+    String uploadUrl,
+    String objectKey,
+    String contentType
+) {}

--- a/src/main/java/com/example/WonkaoTalk/domain/image/service/ImageService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/service/ImageService.java
@@ -1,0 +1,76 @@
+package com.example.WonkaoTalk.domain.image.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.image.dto.PresignedUrlRequest;
+import com.example.WonkaoTalk.domain.image.dto.PresignedUrlResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+  private static final Map<String, String> ALLOWED_EXTENSIONS = Map.of(
+      "jpg", "image/jpeg",
+      "jpeg", "image/jpeg",
+      "png", "image/png",
+      "webp", "image/webp"
+  );
+
+  private final S3Presigner s3Presigner;
+
+  @Value("${storage.bucket}")
+  private String bucket;
+
+  @Value("${storage.temp-prefix}")
+  private String tempPrefix;
+
+  @Value("${storage.presigned-expiry-minutes}")
+  private long expiryMinutes;
+
+  public PresignedUrlResponse issuePresignedUrl(PresignedUrlRequest request) {
+    String extension = extractExtension(request.filename());
+    String contentType = ALLOWED_EXTENSIONS.get(extension);
+    if (contentType == null) {
+      throw new BusinessException(ErrorCode.IMAGE_INVALID_TYPE);
+    }
+
+    String objectKey = tempPrefix + UUID.randomUUID() + "." + extension;
+
+    PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+        .bucket(bucket)
+        .key(objectKey)
+        .contentType(contentType)
+        .build();
+
+    PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+        .signatureDuration(Duration.ofMinutes(expiryMinutes))
+        .putObjectRequest(putObjectRequest)
+        .build();
+
+    PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
+
+    return new PresignedUrlResponse(
+        presigned.url().toString(),
+        objectKey,
+        contentType
+    );
+  }
+
+  private String extractExtension(String filename) {
+    int dotIndex = filename.lastIndexOf('.');
+    if (dotIndex < 0 || dotIndex == filename.length() - 1) {
+      throw new BusinessException(ErrorCode.IMAGE_INVALID_TYPE);
+    }
+    return filename.substring(dotIndex + 1).toLowerCase();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/image/service/ImageService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/service/ImageService.java
@@ -4,17 +4,28 @@ import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.image.dto.PresignedUrlRequest;
 import com.example.WonkaoTalk.domain.image.dto.PresignedUrlResponse;
+import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ImageService {
@@ -26,7 +37,15 @@ public class ImageService {
       "webp", "image/webp"
   );
 
+  private static final Pattern TEMP_KEY_PATTERN = Pattern.compile(
+      "^temp/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.(jpg|jpeg|png|webp)$"
+  );
+
+  private final S3Client s3Client;
   private final S3Presigner s3Presigner;
+
+  @Value("${storage.endpoint}")
+  private String endpoint;
 
   @Value("${storage.bucket}")
   private String bucket;
@@ -64,6 +83,50 @@ public class ImageService {
         objectKey,
         contentType
     );
+  }
+
+  public String validateAndGetProductUrl(String objectKey) {
+    if (objectKey == null) {
+      return null;
+    }
+    if (!TEMP_KEY_PATTERN.matcher(objectKey).matches()) {
+      throw new BusinessException(ErrorCode.IMAGE_INVALID_KEY);
+    }
+    try {
+      s3Client.headObject(HeadObjectRequest.builder()
+          .bucket(bucket)
+          .key(objectKey)
+          .build());
+    } catch (NoSuchKeyException e) {
+      throw new BusinessException(ErrorCode.IMAGE_NOT_FOUND_KEY);
+    }
+    String productKey = "products/" + objectKey.substring(tempPrefix.length());
+    return endpoint + "/" + bucket + "/" + productKey;
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handleProductCreated(ProductCreatedEvent event) {
+    event.objectKeys().forEach(objectKey -> {
+      try {
+        moveToProducts(objectKey);
+      } catch (Exception e) {
+        log.error("S3 파일 이동 실패 (재시도 필요): {}", objectKey, e);
+      }
+    });
+  }
+
+  private void moveToProducts(String objectKey) {
+    String productKey = "products/" + objectKey.substring(tempPrefix.length());
+    s3Client.copyObject(CopyObjectRequest.builder()
+        .sourceBucket(bucket)
+        .sourceKey(objectKey)
+        .destinationBucket(bucket)
+        .destinationKey(productKey)
+        .build());
+    s3Client.deleteObject(DeleteObjectRequest.builder()
+        .bucket(bucket)
+        .key(objectKey)
+        .build());
   }
 
   private String extractExtension(String filename) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -1,18 +1,27 @@
 package com.example.WonkaoTalk.domain.product.controller;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.product.dto.CategoryResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.service.CategoryService;
+import com.example.WonkaoTalk.domain.product.service.ProductCreateService;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,7 +31,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
   private final ProductService productService;
+  private final ProductCreateService productCreateService;
   private final CategoryService categoryService;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody ProductCreateRequest request) {
+    ProductCreateResponse response = productCreateService.create(userDetails.getAuthId(), request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success("상품이 등록되었습니다", response));
+  }
 
   @GetMapping
   public ResponseEntity<ApiResponse<ProductListResponse>> getProducts(

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -1,10 +1,13 @@
 package com.example.WonkaoTalk.domain.product.controller;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.product.dto.CategoryResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
+import com.example.WonkaoTalk.domain.product.service.CategoryService;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProductController {
 
   private final ProductService productService;
+  private final CategoryService categoryService;
 
   @GetMapping
   public ResponseEntity<ApiResponse<ProductListResponse>> getProducts(
@@ -31,6 +35,12 @@ public class ProductController {
   public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
       @PathVariable Long productId) {
     ProductDetailResponse response = productService.getProductDetail(productId);
+    return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
+  }
+
+  @GetMapping("/categories")
+  public ResponseEntity<ApiResponse<List<CategoryResponse>>> getCategories() {
+    List<CategoryResponse> response = categoryService.getCategoryTree();
     return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/CategoryResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/CategoryResponse.java
@@ -1,0 +1,12 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import java.util.List;
+
+public record CategoryResponse(
+    Long id,
+    String name,
+    Integer depth,
+    List<CategoryResponse> children
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductCreateRequest.java
@@ -1,0 +1,44 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ProductCreateRequest(
+    @NotBlank @Size(max = 255) String name,
+    @NotNull Long categoryId,
+    String thumbnailKey,
+    @NotNull @Min(0) Integer price,
+    @Min(0) @Max(100) Integer discountRate,
+    String detail,
+    Integer stock,
+    @Valid List<ImageRequest> images,
+    @Valid List<OptionGroupRequest> optionGroups,
+    @Valid List<VariantRequest> variants
+) {
+
+  public record ImageRequest(
+      @NotBlank String objectKey,
+      @NotNull Integer sortOrder
+  ) {}
+
+  public record OptionGroupRequest(
+      @NotBlank String name,
+      @NotNull Integer sortOrder,
+      @NotEmpty @Valid List<OptionRequest> options
+  ) {}
+
+  public record OptionRequest(
+      @NotBlank String name
+  ) {}
+
+  public record VariantRequest(
+      @NotNull @NotEmpty List<String> optionNames,
+      @NotNull @Min(1) Integer stock
+  ) {}
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductCreateResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductCreateResponse.java
@@ -1,0 +1,18 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import java.time.LocalDateTime;
+
+public record ProductCreateResponse(
+    Long productId,
+    Long storeId,
+    String name,
+    Long categoryId,
+    String thumbnail,
+    Integer price,
+    Integer discountRate,
+    Integer discountedPrice,
+    String status,
+    LocalDateTime createdAt
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -15,7 +15,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -23,6 +27,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "products")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Product {
 
@@ -58,6 +65,7 @@ public class Product {
   @Column(name = "status", nullable = false)
   private SaleStatus status;
 
+  @Builder.Default
   @Column(name = "like_count", nullable = false)
   private Integer likeCount = 0;
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.product.entity;
 
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -30,9 +31,9 @@ public class Product {
   @Column(name = "id")
   private Long id;
 
-  @Column(name = "store_id", nullable = false)
-  // TODO: Store 엔티티 구현 시 @ManyToOne 관계로 변경 및 연관관계 매핑 필요
-  private Long storeId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "store_id", nullable = false)
+  private Store store;
 
   @Column(name = "name", nullable = false)
   private String name;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
@@ -11,7 +11,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +23,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "product_details")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ProductDetail {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
@@ -11,7 +11,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +23,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "product_images")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ProductImage {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOption.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOption.java
@@ -9,12 +9,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "product_options")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class ProductOption {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOptionGroup.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductOptionGroup.java
@@ -11,7 +11,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,6 +23,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "product_option_groups")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ProductOptionGroup {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -14,7 +14,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -22,6 +26,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(name = "product_variants")
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ProductVariant {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/VariantOptionMap.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/VariantOptionMap.java
@@ -3,7 +3,6 @@ package com.example.WonkaoTalk.domain.product.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import lombok.Getter;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -11,11 +10,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "variant_option_maps",
     uniqueConstraints = @UniqueConstraint(columnNames = {"variant_id", "product_option_id"}))
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
 public class VariantOptionMap {
 
   @Id

--- a/src/main/java/com/example/WonkaoTalk/domain/product/event/ProductCreatedEvent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/event/ProductCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.example.WonkaoTalk.domain.product.event;
+
+import java.util.List;
+
+public record ProductCreatedEvent(List<String> objectKeys) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/CategoryRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/CategoryRepo.java
@@ -3,8 +3,12 @@ package com.example.WonkaoTalk.domain.product.repo;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CategoryRepo extends JpaRepository<Category, Long> {
 
   List<Category> findByParentCategoryId(Long parentId);
+
+  @Query("SELECT c FROM Category c LEFT JOIN FETCH c.parentCategory")
+  List<Category> findAllWithParent();
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
@@ -8,6 +8,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
@@ -42,13 +43,13 @@ public class ProductRepoCustomImpl implements ProductRepoCustom {
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.isNull(p.get("deletedAt")));
 
-    // TODO: Store 엔티티 구현 시, N+1 문제 방지를 위해 fetch join(p.fetch("store")) 검토 필요
+    p.fetch("store", JoinType.LEFT);
 
     if (categoryIds != null && !categoryIds.isEmpty()) {
       predicates.add(p.get("category").get("id").in(categoryIds));
     }
     if (storeId != null) {
-      predicates.add(cb.equal(p.get("storeId"), storeId));
+      predicates.add(cb.equal(p.get("store").get("id"), storeId));
     }
     if (minPrice != null) {
       predicates.add(cb.greaterThanOrEqualTo(p.get("discountedPrice"), minPrice));
@@ -87,7 +88,7 @@ public class ProductRepoCustomImpl implements ProductRepoCustom {
     predicates.add(cb.isNull(p.get("deletedAt")));
     predicates.add(cb.notEqual(p.get("status"), SaleStatus.STOP_SALE));
 
-    // TODO: Store 엔티티 구현 시, N+1 문제 방지를 위해 fetch join(p.fetch("store")) 검토 필요
+    p.fetch("store", JoinType.LEFT);
     // TODO: ElasticSearch 등 검색 엔진 도입 시 동의어(예: 레드-빨강) 처리 및 스코어 기반 정렬로 교체 필요
 
     predicates.add(cb.like(p.get("name"), "%" + keyword + "%"));

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/CategoryService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/CategoryService.java
@@ -1,0 +1,42 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import com.example.WonkaoTalk.domain.product.dto.CategoryResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+  private final CategoryRepo categoryRepository;
+
+  public List<CategoryResponse> getCategoryTree() {
+    List<Category> all = categoryRepository.findAllWithParent();
+
+    Map<Long, List<Category>> childrenByParentId = all.stream()
+        .filter(c -> c.getParentCategory() != null)
+        .collect(Collectors.groupingBy(c -> c.getParentCategory().getId()));
+
+    return all.stream()
+        .filter(c -> c.getParentCategory() == null)
+        .map(root -> toResponse(root, childrenByParentId))
+        .toList();
+  }
+
+  private CategoryResponse toResponse(Category category, Map<Long, List<Category>> childrenByParentId) {
+    List<CategoryResponse> children = childrenByParentId
+        .getOrDefault(category.getId(), List.of())
+        .stream()
+        .map(child -> new CategoryResponse(child.getId(), child.getName(), child.getDepth(), List.of()))
+        .toList();
+
+    return new CategoryResponse(category.getId(), category.getName(), category.getDepth(), children);
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
@@ -1,0 +1,302 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.image.service.ImageService;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.ImageRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.OptionGroupRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.VariantRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductDetail;
+import com.example.WonkaoTalk.domain.product.entity.ProductImage;
+import com.example.WonkaoTalk.domain.product.entity.ProductOption;
+import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductImageRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductCreateService {
+
+  private final SellerRepo sellerRepo;
+  private final StoreRepo storeRepo;
+  private final CategoryRepo categoryRepo;
+  private final ProductRepo productRepo;
+  private final ProductDetailRepo productDetailRepo;
+  private final ProductImageRepo productImageRepo;
+  private final ProductOptionGroupRepo productOptionGroupRepo;
+  private final ProductOptionRepo productOptionRepo;
+  private final ProductVariantRepo productVariantRepo;
+  private final VariantOptionMapRepo variantOptionMapRepo;
+  private final ImageService imageService;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional
+  public ProductCreateResponse create(Long authId, ProductCreateRequest request) {
+    Seller seller = sellerRepo.findByAuthId(authId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+    Store store = storeRepo.findBySeller(seller)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_STORE_NOT_FOUND));
+    Category category = categoryRepo.findById(request.categoryId())
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_CATEGORY_NOT_FOUND));
+
+    validatePrice(request);
+    validateOptionVariantConsistency(request);
+    validateSortOrders(request);
+    validateOptionNames(request);
+
+    boolean hasOptions = hasOptions(request);
+    int discountRate = request.discountRate() != null ? request.discountRate() : 0;
+    int discountedPrice = (int) Math.round(request.price() * (1 - discountRate / 100.0));
+
+    List<String> objectKeysToMove = new ArrayList<>();
+
+    String thumbnailUrl = null;
+    if (request.thumbnailKey() != null) {
+      thumbnailUrl = imageService.validateAndGetProductUrl(request.thumbnailKey());
+      objectKeysToMove.add(request.thumbnailKey());
+    }
+
+    List<String> imageUrls = new ArrayList<>();
+    if (request.images() != null) {
+      for (ImageRequest img : request.images()) {
+        imageUrls.add(imageService.validateAndGetProductUrl(img.objectKey()));
+        objectKeysToMove.add(img.objectKey());
+      }
+    }
+
+    Product product = Product.builder()
+        .store(store)
+        .name(request.name())
+        .thumbnail(thumbnailUrl)
+        .category(category)
+        .discountRate(discountRate)
+        .price(request.price())
+        .discountedPrice(discountedPrice)
+        .status(SaleStatus.ON_SALE)
+        .build();
+    productRepo.save(product);
+
+    if (request.detail() != null) {
+      String sanitized = Jsoup.clean(request.detail(), Safelist.relaxed());
+      productDetailRepo.save(ProductDetail.builder()
+          .product(product)
+          .content(sanitized)
+          .build());
+    }
+
+    if (request.images() != null) {
+      for (int i = 0; i < request.images().size(); i++) {
+        ImageRequest imgReq = request.images().get(i);
+        productImageRepo.save(ProductImage.builder()
+            .product(product)
+            .url(imageUrls.get(i))
+            .sortOrder(imgReq.sortOrder())
+            .build());
+      }
+    }
+
+    if (!hasOptions) {
+      if (request.stock() < 1) {
+        throw new BusinessException(ErrorCode.PROD_INVALID_QUANTITY);
+      }
+      productVariantRepo.save(ProductVariant.builder()
+          .product(product)
+          .name("기본")
+          .stock(request.stock())
+          .status(SaleStatus.ON_SALE)
+          .build());
+    } else {
+      saveOptionsAndVariants(product, request);
+    }
+
+    if (!objectKeysToMove.isEmpty()) {
+      eventPublisher.publishEvent(new ProductCreatedEvent(objectKeysToMove));
+    }
+
+    return new ProductCreateResponse(
+        product.getId(),
+        store.getId(),
+        product.getName(),
+        category.getId(),
+        product.getThumbnail(),
+        product.getPrice(),
+        product.getDiscountRate(),
+        product.getDiscountedPrice(),
+        product.getStatus().name(),
+        product.getCreatedAt()
+    );
+  }
+
+  private void saveOptionsAndVariants(Product product, ProductCreateRequest request) {
+    List<OptionGroupRequest> sortedGroups = request.optionGroups().stream()
+        .sorted((a, b) -> a.sortOrder().compareTo(b.sortOrder()))
+        .toList();
+
+    // groupIndex → Map<optionName, ProductOption>
+    List<Map<String, ProductOption>> groupOptionMaps = new ArrayList<>();
+
+    for (OptionGroupRequest groupReq : sortedGroups) {
+      ProductOptionGroup group = productOptionGroupRepo.save(ProductOptionGroup.builder()
+          .product(product)
+          .name(groupReq.name())
+          .sortOrder(groupReq.sortOrder())
+          .build());
+
+      Map<String, ProductOption> optionMap = new LinkedHashMap<>();
+      for (var optReq : groupReq.options()) {
+        ProductOption option = productOptionRepo.save(ProductOption.builder()
+            .productOptionGroup(group)
+            .name(optReq.name())
+            .build());
+        optionMap.put(optReq.name(), option);
+      }
+      groupOptionMaps.add(optionMap);
+    }
+
+    Set<List<String>> seenCombinations = new HashSet<>();
+
+    for (VariantRequest variantReq : request.variants()) {
+      List<String> combo = variantReq.optionNames();
+      if (!seenCombinations.add(combo)) {
+        throw new BusinessException(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+      }
+
+      String variantName = String.join(" / ", combo);
+
+      ProductVariant variant = productVariantRepo.save(ProductVariant.builder()
+          .product(product)
+          .name(variantName)
+          .stock(variantReq.stock())
+          .status(SaleStatus.ON_SALE)
+          .build());
+
+      for (int i = 0; i < combo.size(); i++) {
+        ProductOption option = groupOptionMaps.get(i).get(combo.get(i));
+        variantOptionMapRepo.save(VariantOptionMap.builder()
+            .productVariant(variant)
+            .productOption(option)
+            .build());
+      }
+    }
+  }
+
+  private void validatePrice(ProductCreateRequest request) {
+    if (request.price() < 0) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_PRICE);
+    }
+    if (request.discountRate() != null && (request.discountRate() < 0 || request.discountRate() > 100)) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
+    }
+  }
+
+  private void validateOptionVariantConsistency(ProductCreateRequest request) {
+    boolean hasOptionGroups = request.optionGroups() != null && !request.optionGroups().isEmpty();
+    boolean hasVariants = request.variants() != null && !request.variants().isEmpty();
+
+    if (hasOptionGroups != hasVariants) {
+      throw new BusinessException(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+    }
+    if (hasOptionGroups && request.stock() != null) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_STOCK_OPTION);
+    }
+    if (!hasOptionGroups && request.stock() == null) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_QUANTITY);
+    }
+  }
+
+  private void validateSortOrders(ProductCreateRequest request) {
+    if (request.images() != null) {
+      Set<Integer> seen = new HashSet<>();
+      for (ImageRequest img : request.images()) {
+        if (!seen.add(img.sortOrder())) {
+          throw new BusinessException(ErrorCode.PROD_DUPLICATE_SORT_ORDER);
+        }
+      }
+    }
+    if (request.optionGroups() != null) {
+      Set<Integer> seen = new HashSet<>();
+      for (OptionGroupRequest group : request.optionGroups()) {
+        if (!seen.add(group.sortOrder())) {
+          throw new BusinessException(ErrorCode.PROD_DUPLICATE_SORT_ORDER);
+        }
+      }
+    }
+  }
+
+  private void validateOptionNames(ProductCreateRequest request) {
+    if (request.optionGroups() == null || request.optionGroups().isEmpty()) {
+      return;
+    }
+
+    // 그룹명 중복 검사
+    Set<String> groupNames = new HashSet<>();
+    for (OptionGroupRequest group : request.optionGroups()) {
+      if (!groupNames.add(group.name())) {
+        throw new BusinessException(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+      }
+      // 그룹 내 옵션명 중복 검사
+      Set<String> optionNames = new HashSet<>();
+      for (var opt : group.options()) {
+        if (!optionNames.add(opt.name())) {
+          throw new BusinessException(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+        }
+      }
+    }
+
+    // sortOrder 오름차순 정렬된 그룹 리스트로 옵션 이름 셋 구성
+    List<Set<String>> groupOptionSets = request.optionGroups().stream()
+        .sorted((a, b) -> a.sortOrder().compareTo(b.sortOrder()))
+        .map(g -> g.options().stream()
+            .map(o -> o.name())
+            .collect(Collectors.toSet()))
+        .toList();
+
+    int groupCount = groupOptionSets.size();
+
+    for (VariantRequest variant : request.variants()) {
+      if (variant.optionNames().size() != groupCount) {
+        throw new BusinessException(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+      }
+      for (int i = 0; i < groupCount; i++) {
+        if (!groupOptionSets.get(i).contains(variant.optionNames().get(i))) {
+          throw new BusinessException(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+        }
+      }
+    }
+  }
+
+  private boolean hasOptions(ProductCreateRequest request) {
+    return request.optionGroups() != null && !request.optionGroups().isEmpty();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
@@ -127,9 +127,6 @@ public class ProductCreateService {
     }
 
     if (!hasOptions) {
-      if (request.stock() < 1) {
-        throw new BusinessException(ErrorCode.PROD_INVALID_QUANTITY);
-      }
       productVariantRepo.save(ProductVariant.builder()
           .product(product)
           .name("기본")
@@ -230,7 +227,7 @@ public class ProductCreateService {
     if (hasOptionGroups && request.stock() != null) {
       throw new BusinessException(ErrorCode.PROD_INVALID_STOCK_OPTION);
     }
-    if (!hasOptionGroups && request.stock() == null) {
+    if (!hasOptionGroups && (request.stock() == null || request.stock() < 1)) {
       throw new BusinessException(ErrorCode.PROD_INVALID_QUANTITY);
     }
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductService.java
@@ -158,7 +158,10 @@ public class ProductService {
         .status(product.getStatus().name())
         .likeCount(product.getLikeCount())
         .isLiked(false) // TODO: 로그인 사용자의 좋아요 여부 반영 필요 (PRODUCT_LIKE 테이블 조회)
-        .store(null) // TODO: Store 엔티티 구현 시 실제 스토어 정보 반환
+        .store(ProductDetailResponse.StoreInfo.builder()
+            .storeId(product.getStore().getId())
+            .storeName(product.getStore().getName())
+            .build())
         .images(images)
         .detail(detail)
         .optionGroups(optionGroups)
@@ -222,8 +225,10 @@ public class ProductService {
         .discountRate(product.getDiscountRate())
         .likeCount(product.getLikeCount())
         .status(product.getStatus().name())
-        // TODO: Store 엔티티 구현 시 product.getStore()를 통해 StoreInfo 생성하도록 수정
-        .store(null)
+        .store(ProductListResponse.StoreInfo.builder()
+            .storeId(product.getStore().getId())
+            .storeName(product.getStore().getName())
+            .build())
         .build();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/service/SearchService.java
@@ -10,6 +10,9 @@ import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse.ProductResult;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse.StoreInfo;
+import com.example.WonkaoTalk.domain.search.dto.SearchResponse.StoreResult;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +27,7 @@ public class SearchService {
 
   private final ProductRepo productRepository;
   private final CategoryRepo categoryRepository;
+  private final StoreRepo storeRepository;
 
   public SearchResponse search(SearchRequest request) {
     if (request.keyword() == null || request.keyword().isBlank()) {
@@ -78,13 +82,18 @@ public class SearchService {
         .map(this::toProductResult)
         .toList();
 
-    // TODO: Store 엔티티 구현 후 storeRepository.findByNameContaining(keyword)로 스토어 검색 결과 반환
     // TODO: ElasticSearch 등 검색 엔진 도입 시 동의어(예: 레드-빨강) 처리 및 스코어 기반 정렬 고도화 필요
-    return new SearchResponse(null, productResults, hasNext, nextCursorId, nextCursorSortValue);
+    List<StoreResult> storeResults = storeRepository.findByNameContaining(request.keyword())
+        .stream()
+        .map(s -> new StoreResult(s.getId(), s.getName(), s.getThumbnail(), s.getDescription()))
+        .toList();
+
+    return new SearchResponse(storeResults, productResults, hasNext, nextCursorId,
+        nextCursorSortValue);
   }
 
   private ProductResult toProductResult(Product product) {
-    // TODO: Store 엔티티 구현 시 product.getStore()로 StoreInfo 생성하도록 수정
+    Store store = product.getStore();
     return new ProductResult(
         product.getId(),
         product.getName(),
@@ -94,7 +103,7 @@ public class SearchService {
         product.getDiscountRate(),
         product.getLikeCount(),
         product.getStatus().name(),
-        new StoreInfo(product.getStoreId(), null)
+        new StoreInfo(store.getId(), store.getName())
     );
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/repo/SellerRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/repo/SellerRepo.java
@@ -10,4 +10,6 @@ public interface SellerRepo extends JpaRepository<Seller, Long> {
   boolean existsByBuzNo(String buzNo);
 
   Optional<Seller> findByAuth(Auth auth);
+
+  Optional<Seller> findByAuthId(Long authId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/store/repo/StoreRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/repo/StoreRepo.java
@@ -2,6 +2,7 @@ package com.example.WonkaoTalk.domain.store.repo;
 
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.store.entity.Store;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface StoreRepo extends JpaRepository<Store, Long> {
   Optional<Store> findBySeller(Seller seller);
 
   boolean existsByName(String name);
+
+  List<Store> findByNameContaining(String name);
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/image/service/ImageServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/image/service/ImageServiceTest.java
@@ -1,0 +1,136 @@
+package com.example.WonkaoTalk.domain.image.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.image.dto.PresignedUrlRequest;
+import com.example.WonkaoTalk.domain.image.dto.PresignedUrlResponse;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+
+  @Mock
+  private S3Presigner s3Presigner;
+
+  @InjectMocks
+  private ImageService imageService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(imageService, "bucket", "wonkao-talk");
+    ReflectionTestUtils.setField(imageService, "tempPrefix", "temp/");
+    ReflectionTestUtils.setField(imageService, "expiryMinutes", 15L);
+  }
+
+  // ── 성공 케이스 ────────────────────────────────────────────────────────────────
+
+  @ParameterizedTest(name = "{0} → contentType: {1}")
+  @CsvSource({
+      "photo.jpg,  image/jpeg",
+      "photo.jpeg, image/jpeg",
+      "photo.png,  image/png",
+      "photo.webp, image/webp",
+  })
+  @DisplayName("허용된 확장자는 올바른 contentType으로 Presigned URL을 발급한다")
+  void issuesPresignedUrl_withCorrectContentType(String filename, String expectedContentType)
+      throws Exception {
+    mockPresigner("http://localhost:9000/wonkao-talk/temp/test.jpg");
+
+    PresignedUrlResponse response = imageService.issuePresignedUrl(
+        new PresignedUrlRequest(filename));
+
+    assertThat(response.contentType()).isEqualTo(expectedContentType.trim());
+  }
+
+  @Test
+  @DisplayName("objectKey는 temp/ 접두사와 UUID를 포함한다")
+  void objectKey_startsWithTempPrefix() throws Exception {
+    mockPresigner("http://localhost:9000/wonkao-talk/temp/test.jpg");
+
+    PresignedUrlResponse response = imageService.issuePresignedUrl(
+        new PresignedUrlRequest("shirt.jpg"));
+
+    assertThat(response.objectKey()).startsWith("temp/");
+    assertThat(response.objectKey()).endsWith(".jpg");
+  }
+
+  @Test
+  @DisplayName("대문자 확장자도 허용된다")
+  void uppercaseExtension_isAccepted() throws Exception {
+    mockPresigner("http://localhost:9000/wonkao-talk/temp/test.jpg");
+
+    PresignedUrlResponse response = imageService.issuePresignedUrl(
+        new PresignedUrlRequest("photo.JPG"));
+
+    assertThat(response.contentType()).isEqualTo("image/jpeg");
+  }
+
+  @Test
+  @DisplayName("uploadUrl이 비어있지 않다")
+  void uploadUrl_isNotBlank() throws Exception {
+    mockPresigner("http://localhost:9000/wonkao-talk/temp/test.jpg?X-Amz-Signature=abc");
+
+    PresignedUrlResponse response = imageService.issuePresignedUrl(
+        new PresignedUrlRequest("photo.png"));
+
+    assertThat(response.uploadUrl()).isNotBlank();
+  }
+
+  // ── 실패 케이스 ────────────────────────────────────────────────────────────────
+
+  @ParameterizedTest(name = "파일명: {0}")
+  @ValueSource(strings = {"photo.gif", "photo.bmp", "photo.tiff", "photo.svg"})
+  @DisplayName("허용되지 않는 확장자는 IMAGE_INVALID_TYPE 예외를 던진다")
+  void throwsException_whenExtensionNotAllowed(String filename) {
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> imageService.issuePresignedUrl(new PresignedUrlRequest(filename)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.IMAGE_INVALID_TYPE);
+  }
+
+  @Test
+  @DisplayName("확장자가 없는 파일명은 IMAGE_INVALID_TYPE 예외를 던진다")
+  void throwsException_whenNoExtension() {
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> imageService.issuePresignedUrl(new PresignedUrlRequest("photoWithoutExt")));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.IMAGE_INVALID_TYPE);
+  }
+
+  @Test
+  @DisplayName("점으로 끝나는 파일명은 IMAGE_INVALID_TYPE 예외를 던진다")
+  void throwsException_whenFilenameEndsWithDot() {
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> imageService.issuePresignedUrl(new PresignedUrlRequest("photo.")));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.IMAGE_INVALID_TYPE);
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────────
+
+  private void mockPresigner(String url) throws Exception {
+    PresignedPutObjectRequest presigned = mock(PresignedPutObjectRequest.class);
+    when(presigned.url()).thenReturn(URI.create(url).toURL());
+    when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenReturn(presigned);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
@@ -22,6 +22,8 @@ import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.service.CartService;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.user.entity.User;
 import com.example.WonkaoTalk.domain.user.enums.Gender;
 import jakarta.persistence.EntityManager;
@@ -69,8 +71,9 @@ class CartServiceIntegrationTest {
     newUser = saveUser("새유저");
     newAuthId = newUser.getAuth().getId();
     category = saveCategory();
-    productA = saveProduct(category, "상품A", 10000, 8000);
-    productB = saveProduct(category, "상품B", 5000, 4000);
+    Store store = saveStore();
+    productA = saveProduct(store, category, "상품A", 10000, 8000);
+    productB = saveProduct(store, category, "상품B", 5000, 4000);
     variantA1 = saveVariant(productA, "옵션A-1", 10, SaleStatus.ON_SALE);
     variantA2 = saveVariant(productA, "옵션A-2", 5, SaleStatus.ON_SALE);
     variantB1 = saveVariant(productB, "옵션B-1", 20, SaleStatus.ON_SALE);
@@ -140,7 +143,8 @@ class CartServiceIntegrationTest {
   @Test
   @DisplayName("장바구니가 없을 때 addToCart 호출 시 Cart가 자동 생성된다")
   void addToCart_createsCart_whenCartNotExists() {
-    CartAddResponse response = cartService.addToCart(newAuthId, addRequest(productA.getId(), variantA1.getId(), 2));
+    CartAddResponse response = cartService.addToCart(newAuthId,
+        addRequest(productA.getId(), variantA1.getId(), 2));
 
     assertThat(response.getCartItemId()).isNotNull();
 
@@ -210,7 +214,8 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.addToCart(testAuthId, addRequest(productA.getId(), variantA2.getId(), 2))); // 4+2=6 > 5
+        () -> cartService.addToCart(testAuthId,
+            addRequest(productA.getId(), variantA2.getId(), 2))); // 4+2=6 > 5
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
   }
@@ -262,7 +267,8 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.updateCartItemQuantity(testAuthId, otherItem.getId(), quantityUpdateRequest(3)));
+        () -> cartService.updateCartItemQuantity(testAuthId, otherItem.getId(),
+            quantityUpdateRequest(3)));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }
@@ -278,7 +284,8 @@ class CartServiceIntegrationTest {
     em.clear();
 
     CartOptionUpdateResponse response =
-        cartService.updateCartItemOption(testAuthId, item.getId(), optionUpdateRequest(variantA2.getId()));
+        cartService.updateCartItemOption(testAuthId, item.getId(),
+            optionUpdateRequest(variantA2.getId()));
 
     assertThat(response.isMerged()).isFalse();
     assertThat(response.getCartItem().getVariantId()).isEqualTo(variantA2.getId());
@@ -301,7 +308,8 @@ class CartServiceIntegrationTest {
     em.clear();
 
     CartOptionUpdateResponse response =
-        cartService.updateCartItemOption(testAuthId, itemA1.getId(), optionUpdateRequest(variantA2.getId()));
+        cartService.updateCartItemOption(testAuthId, itemA1.getId(),
+            optionUpdateRequest(variantA2.getId()));
 
     assertThat(response.isMerged()).isTrue();
     assertThat(response.getCartItem().getVariantId()).isEqualTo(variantA2.getId());
@@ -325,7 +333,8 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.updateCartItemOption(testAuthId, itemA1.getId(), optionUpdateRequest(variantA2.getId())));
+        () -> cartService.updateCartItemOption(testAuthId, itemA1.getId(),
+            optionUpdateRequest(variantA2.getId())));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
   }
@@ -423,9 +432,32 @@ class CartServiceIntegrationTest {
     return cat;
   }
 
-  private Product saveProduct(Category cat, String name, int price, int discountedPrice) {
+  private Store saveStore() {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    Seller seller = Seller.builder()
+        .buzNo(String.valueOf(System.nanoTime()).substring(0, 10))
+        .name("테스트판매자")
+        .phone("010-0000-0000")
+        .auth(auth)
+        .build();
+    em.persist(seller);
+
+    Store store = Store.builder()
+        .name("테스트스토어")
+        .description("설명")
+        .phone("010-0000-0000")
+        .seller(seller)
+        .build();
+    em.persist(store);
+    return store;
+  }
+
+  private Product saveProduct(Store store, Category cat, String name, int price,
+      int discountedPrice) {
     Product p = new Product();
-    ReflectionTestUtils.setField(p, "storeId", 1L);
+    ReflectionTestUtils.setField(p, "store", store);
     ReflectionTestUtils.setField(p, "name", name);
     ReflectionTestUtils.setField(p, "category", cat);
     ReflectionTestUtils.setField(p, "price", price);

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductDetailIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductDetailIntegrationTest.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.product.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
@@ -14,6 +15,8 @@ import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +45,8 @@ class ProductDetailIntegrationTest {
   @BeforeEach
   void setUp() {
     category = saveCategory();
-    product = saveProduct(category);
+    Store store = saveStore();
+    product = saveProduct(store, category);
     em.flush();
     em.clear();
   }
@@ -137,9 +141,31 @@ class ProductDetailIntegrationTest {
     return cat;
   }
 
-  private Product saveProduct(Category cat) {
+  private Store saveStore() {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    Seller seller = Seller.builder()
+        .buzNo(String.valueOf(System.nanoTime()).substring(0, 10))
+        .name("테스트판매자")
+        .phone("010-0000-0000")
+        .auth(auth)
+        .build();
+    em.persist(seller);
+
+    Store store = Store.builder()
+        .name("테스트스토어")
+        .description("설명")
+        .phone("010-0000-0000")
+        .seller(seller)
+        .build();
+    em.persist(store);
+    return store;
+  }
+
+  private Product saveProduct(Store store, Category cat) {
     Product p = new Product();
-    ReflectionTestUtils.setField(p, "storeId", 1L);
+    ReflectionTestUtils.setField(p, "store", store);
     ReflectionTestUtils.setField(p, "name", "테스트상품");
     ReflectionTestUtils.setField(p, "category", cat);
     ReflectionTestUtils.setField(p, "price", 10000);

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductRepoCustomImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductRepoCustomImplTest.java
@@ -3,11 +3,14 @@ package com.example.WonkaoTalk.domain.product.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -32,10 +35,14 @@ class ProductRepoCustomImplTest {
   private ProductRepo productRepository;
 
   private Category category;
+  private Store store1;
+  private Store store2;
 
   @BeforeEach
   void setUp() {
     category = saveCategory("테스트카테고리");
+    store1 = saveStore("스토어1");
+    store2 = saveStore("스토어2");
   }
 
   // ── 기본 필터 ────────────────────────────────────────────────────────────────
@@ -43,8 +50,8 @@ class ProductRepoCustomImplTest {
   @Test
   @DisplayName("deletedAt이 있는 상품은 조회되지 않는다")
   void excludesDeletedProducts() {
-    saveProduct(1L, category, 10000, null, 0, null);
-    saveProduct(1L, category, 8000, null, 0, LocalDateTime.now()); // 삭제됨
+    saveProduct(store1, category, 10000, null, 0, null);
+    saveProduct(store1, category, 8000, null, 0, LocalDateTime.now()); // 삭제됨
     flushAndClear();
 
     List<Product> result = productRepository.findWithFilters(
@@ -57,15 +64,15 @@ class ProductRepoCustomImplTest {
   @Test
   @DisplayName("storeId로 필터링된다")
   void filtersProductsByStoreId() {
-    saveProduct(1L, category, 10000, null, 0, null);
-    saveProduct(2L, category, 8000, null, 0, null);
+    saveProduct(store1, category, 10000, null, 0, null);
+    saveProduct(store2, category, 8000, null, 0, null);
     flushAndClear();
 
     List<Product> result = productRepository.findWithFilters(
-        null, 1L, null, null, ProductSortType.POPULAR, null, null, 10);
+        null, store1.getId(), null, null, ProductSortType.POPULAR, null, null, 10);
 
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).getStoreId()).isEqualTo(1L);
+    assertThat(result.get(0).getStore().getId()).isEqualTo(store1.getId());
   }
 
   // ── 가격 필터 (할인가 기준) ──────────────────────────────────────────────────
@@ -74,9 +81,9 @@ class ProductRepoCustomImplTest {
   @DisplayName("minPrice 필터는 discountedPrice 기준으로 동작한다")
   void filtersProductsByMinDiscountedPrice() {
     // discountedPrice = 10000 * (100 - 20) / 100 = 8000
-    saveProduct(1L, category, 10000, 20, 0, null);
+    saveProduct(store1, category, 10000, 20, 0, null);
     // discountedPrice = 10000 * (100 - 0) / 100 = 10000
-    saveProduct(1L, category, 10000, null, 0, null);
+    saveProduct(store1, category, 10000, null, 0, null);
     flushAndClear();
 
     // minPrice=9000 → discountedPrice 10000짜리만 해당
@@ -91,9 +98,9 @@ class ProductRepoCustomImplTest {
   @DisplayName("maxPrice 필터는 discountedPrice 기준으로 동작한다")
   void filtersProductsByMaxDiscountedPrice() {
     // discountedPrice = 10000 * (100 - 20) / 100 = 8000
-    saveProduct(1L, category, 10000, 20, 0, null);
+    saveProduct(store1, category, 10000, 20, 0, null);
     // discountedPrice = 10000 * (100 - 0) / 100 = 10000
-    saveProduct(1L, category, 10000, null, 0, null);
+    saveProduct(store1, category, 10000, null, 0, null);
     flushAndClear();
 
     // maxPrice=9000 → discountedPrice 8000짜리만 해당
@@ -110,9 +117,9 @@ class ProductRepoCustomImplTest {
   @DisplayName("PRICE_ASC 정렬은 discountedPrice 오름차순이다")
   void sortsByDiscountedPriceAscending() {
     // discountedPrice: 7000, 5000, 7200
-    saveProduct(1L, category, 10000, 30, 0, null); // 10000 * 70 / 100 = 7000
-    saveProduct(1L, category, 5000, null, 0, null); // 5000
-    saveProduct(1L, category, 8000, 10, 0, null);  // 8000 * 90 / 100 = 7200
+    saveProduct(store1, category, 10000, 30, 0, null); // 10000 * 70 / 100 = 7000
+    saveProduct(store1, category, 5000, null, 0, null); // 5000
+    saveProduct(store1, category, 8000, 10, 0, null);  // 8000 * 90 / 100 = 7200
     flushAndClear();
 
     List<Product> result = productRepository.findWithFilters(
@@ -128,9 +135,9 @@ class ProductRepoCustomImplTest {
   @DisplayName("PRICE_DESC 정렬은 discountedPrice 내림차순이다")
   void sortsByDiscountedPriceDescending() {
     // discountedPrice: 7000, 5000, 7200
-    saveProduct(1L, category, 10000, 30, 0, null); // 7000
-    saveProduct(1L, category, 5000, null, 0, null); // 5000
-    saveProduct(1L, category, 8000, 10, 0, null);  // 7200
+    saveProduct(store1, category, 10000, 30, 0, null); // 7000
+    saveProduct(store1, category, 5000, null, 0, null); // 5000
+    saveProduct(store1, category, 8000, 10, 0, null);  // 7200
     flushAndClear();
 
     List<Product> result = productRepository.findWithFilters(
@@ -147,9 +154,9 @@ class ProductRepoCustomImplTest {
   @Test
   @DisplayName("PRICE_ASC 커서 이후의 항목만 조회된다")
   void returnsOnlyItemsAfterCursor_whenSortByPriceAsc() {
-    saveProduct(1L, category, 5000, null, 0, null);  // discountedPrice=5000
-    Product mid = saveProduct(1L, category, 8000, null, 0, null);  // discountedPrice=8000
-    saveProduct(1L, category, 12000, null, 0, null); // discountedPrice=12000
+    saveProduct(store1, category, 5000, null, 0, null);  // discountedPrice=5000
+    Product mid = saveProduct(store1, category, 8000, null, 0, null);  // discountedPrice=8000
+    saveProduct(store1, category, 12000, null, 0, null); // discountedPrice=12000
     Long midId = mid.getId();
     flushAndClear();
 
@@ -164,9 +171,9 @@ class ProductRepoCustomImplTest {
   @Test
   @DisplayName("동일한 discountedPrice 내에서 id 내림차순으로 tiebreak된다")
   void tiebreaksById_whenDiscountedPriceIsEqual() {
-    Product p1 = saveProduct(1L, category, 5000, null, 0, null);
-    Product p2 = saveProduct(1L, category, 5000, null, 0, null);
-    saveProduct(1L, category, 5000, null, 0, null);
+    Product p1 = saveProduct(store1, category, 5000, null, 0, null);
+    Product p2 = saveProduct(store1, category, 5000, null, 0, null);
+    saveProduct(store1, category, 5000, null, 0, null);
     Long p2Id = p2.getId();
     flushAndClear();
 
@@ -188,11 +195,33 @@ class ProductRepoCustomImplTest {
     return cat;
   }
 
-  private Product saveProduct(Long storeId, Category cat, int price, Integer discountRate,
+  private Store saveStore(String name) {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    Seller seller = Seller.builder()
+        .buzNo(String.valueOf(System.nanoTime()).substring(0, 10))
+        .name(name + "판매자")
+        .phone("010-0000-0000")
+        .auth(auth)
+        .build();
+    em.persist(seller);
+
+    Store store = Store.builder()
+        .name(name)
+        .description("설명")
+        .phone("010-0000-0000")
+        .seller(seller)
+        .build();
+    em.persist(store);
+    return store;
+  }
+
+  private Product saveProduct(Store store, Category cat, int price, Integer discountRate,
       int likeCount, LocalDateTime deletedAt) {
     int discountedPrice = discountRate != null ? price * (100 - discountRate) / 100 : price;
     Product product = new Product();
-    ReflectionTestUtils.setField(product, "storeId", storeId);
+    ReflectionTestUtils.setField(product, "store", store);
     ReflectionTestUtils.setField(product, "name", "상품-" + price);
     ReflectionTestUtils.setField(product, "category", cat);
     ReflectionTestUtils.setField(product, "price", price);

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/CategoryServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/CategoryServiceTest.java
@@ -1,0 +1,130 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.domain.product.dto.CategoryResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+  @Mock
+  private CategoryRepo categoryRepository;
+
+  @InjectMocks
+  private CategoryService categoryService;
+
+  // ── 정상 조회 ────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("최상위 카테고리만 있으면 children이 빈 배열로 반환된다")
+  void returnsRootWithEmptyChildren_whenNoChildExists() {
+    Category root = mockCategory(1L, "의류", 0, null);
+    when(categoryRepository.findAllWithParent()).thenReturn(List.of(root));
+
+    List<CategoryResponse> result = categoryService.getCategoryTree();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).id()).isEqualTo(1L);
+    assertThat(result.get(0).name()).isEqualTo("의류");
+    assertThat(result.get(0).depth()).isEqualTo(0);
+    assertThat(result.get(0).children()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("대분류 아래 소분류가 children 배열로 중첩된다")
+  void nestChildren_underParentCategory() {
+    Category parent = mockCategory(1L, "의류", 0, null);
+    Category child1 = mockCategory(2L, "상의", 1, parent);
+    Category child2 = mockCategory(3L, "하의", 1, parent);
+    when(categoryRepository.findAllWithParent()).thenReturn(List.of(parent, child1, child2));
+
+    List<CategoryResponse> result = categoryService.getCategoryTree();
+
+    assertThat(result).hasSize(1);
+    CategoryResponse clothing = result.get(0);
+    assertThat(clothing.children()).hasSize(2);
+    assertThat(clothing.children()).extracting(CategoryResponse::name)
+        .containsExactlyInAnyOrder("상의", "하의");
+  }
+
+  @Test
+  @DisplayName("소분류의 children은 항상 빈 배열이다")
+  void childrenOfLeaf_isAlwaysEmpty() {
+    Category parent = mockCategory(1L, "의류", 0, null);
+    Category child = mockCategory(2L, "상의", 1, parent);
+    when(categoryRepository.findAllWithParent()).thenReturn(List.of(parent, child));
+
+    List<CategoryResponse> result = categoryService.getCategoryTree();
+
+    CategoryResponse leaf = result.get(0).children().get(0);
+    assertThat(leaf.children()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("대분류가 여러 개면 각각 독립된 트리로 반환된다")
+  void returnsMultipleRoots_whenMultipleParentCategoriesExist() {
+    Category clothing = mockCategory(1L, "의류", 0, null);
+    Category books = mockCategory(2L, "도서", 0, null);
+    Category top = mockCategory(3L, "상의", 1, clothing);
+    Category dev = mockCategory(4L, "개발", 1, books);
+    when(categoryRepository.findAllWithParent()).thenReturn(List.of(clothing, books, top, dev));
+
+    List<CategoryResponse> result = categoryService.getCategoryTree();
+
+    assertThat(result).hasSize(2);
+    CategoryResponse clothingRes = result.stream()
+        .filter(r -> r.id().equals(1L)).findFirst().orElseThrow();
+    CategoryResponse booksRes = result.stream()
+        .filter(r -> r.id().equals(2L)).findFirst().orElseThrow();
+
+    assertThat(clothingRes.children()).hasSize(1);
+    assertThat(clothingRes.children().get(0).name()).isEqualTo("상의");
+    assertThat(booksRes.children()).hasSize(1);
+    assertThat(booksRes.children().get(0).name()).isEqualTo("개발");
+  }
+
+  @Test
+  @DisplayName("카테고리가 하나도 없으면 빈 리스트를 반환한다")
+  void returnsEmptyList_whenNoCategoriesExist() {
+    when(categoryRepository.findAllWithParent()).thenReturn(List.of());
+
+    List<CategoryResponse> result = categoryService.getCategoryTree();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("응답의 depth 값이 엔티티의 depth와 일치한다")
+  void depthField_matchesEntityDepth() {
+    Category parent = mockCategory(1L, "의류", 0, null);
+    Category child = mockCategory(2L, "상의", 1, parent);
+    when(categoryRepository.findAllWithParent()).thenReturn(List.of(parent, child));
+
+    List<CategoryResponse> result = categoryService.getCategoryTree();
+
+    assertThat(result.get(0).depth()).isEqualTo(0);
+    assertThat(result.get(0).children().get(0).depth()).isEqualTo(1);
+  }
+
+  // ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+  private Category mockCategory(Long id, String name, int depth, Category parent) {
+    Category category = mock(Category.class);
+    when(category.getId()).thenReturn(id);
+    when(category.getName()).thenReturn(name);
+    when(category.getDepth()).thenReturn(depth);
+    when(category.getParentCategory()).thenReturn(parent);
+    return category;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductCreateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductCreateServiceTest.java
@@ -1,0 +1,520 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.image.service.ImageService;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.ImageRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.OptionGroupRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.OptionRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest.VariantRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductCreateResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductImageRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductCreateServiceTest {
+
+  private static final Long AUTH_ID = 1L;
+  @Mock
+  private SellerRepo sellerRepo;
+  @Mock
+  private StoreRepo storeRepo;
+  @Mock
+  private CategoryRepo categoryRepo;
+  @Mock
+  private ProductRepo productRepo;
+  @Mock
+  private ProductDetailRepo productDetailRepo;
+  @Mock
+  private ProductImageRepo productImageRepo;
+  @Mock
+  private ProductOptionGroupRepo productOptionGroupRepo;
+  @Mock
+  private ProductOptionRepo productOptionRepo;
+  @Mock
+  private ProductVariantRepo productVariantRepo;
+  @Mock
+  private VariantOptionMapRepo variantOptionMapRepo;
+  @Mock
+  private ImageService imageService;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+  @InjectMocks
+  private ProductCreateService productCreateService;
+
+  @BeforeEach
+  void setUp() {
+    Seller seller = mock(Seller.class);
+    Store store = mock(Store.class);
+    Category category = mock(Category.class);
+
+    when(store.getId()).thenReturn(7L);
+    when(category.getId()).thenReturn(5L);
+
+    when(sellerRepo.findByAuthId(AUTH_ID)).thenReturn(Optional.of(seller));
+    when(storeRepo.findBySeller(seller)).thenReturn(Optional.of(store));
+    when(categoryRepo.findById(5L)).thenReturn(Optional.of(category));
+
+    when(productRepo.save(any(Product.class))).thenAnswer(inv -> {
+      Product p = inv.getArgument(0);
+      ReflectionTestUtils.setField(p, "id", 101L);
+      ReflectionTestUtils.setField(p, "createdAt", LocalDateTime.of(2026, 5, 11, 10, 0));
+      return p;
+    });
+    when(productDetailRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productImageRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productOptionGroupRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productOptionRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productVariantRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(variantOptionMapRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    when(imageService.validateAndGetProductUrl(anyString()))
+        .thenReturn("http://localhost:9000/wonkaotalk/products/test.jpg");
+  }
+
+  // ── 성공 케이스 ────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("옵션 없는 상품 등록에 성공한다")
+  void createProduct_noOption_success() {
+    ProductCreateRequest request = noOptionRequest();
+
+    ProductCreateResponse response = productCreateService.create(AUTH_ID, request);
+
+    assertThat(response.productId()).isEqualTo(101L);
+    assertThat(response.storeId()).isEqualTo(7L);
+    assertThat(response.name()).isEqualTo("테스트 상품");
+    assertThat(response.price()).isEqualTo(10000);
+    assertThat(response.discountRate()).isEqualTo(0);
+    assertThat(response.discountedPrice()).isEqualTo(10000);
+    assertThat(response.status()).isEqualTo("ON_SALE");
+    verify(productVariantRepo).save(any());
+  }
+
+  @Test
+  @DisplayName("옵션 있는 상품 등록에 성공한다")
+  void createProduct_withOption_success() {
+    ProductCreateRequest request = withOptionRequest();
+
+    ProductCreateResponse response = productCreateService.create(AUTH_ID, request);
+
+    assertThat(response.productId()).isEqualTo(101L);
+    verify(productOptionGroupRepo, atLeastOnce()).save(any());
+    verify(productOptionRepo, atLeastOnce()).save(any());
+    verify(productVariantRepo, atLeastOnce()).save(any());
+    verify(variantOptionMapRepo, atLeastOnce()).save(any());
+  }
+
+  @Test
+  @DisplayName("thumbnailKey가 없으면 thumbnail은 null이다")
+  void createProduct_noThumbnail_thumbnailIsNull() {
+    ProductCreateRequest request = noOptionRequest();
+
+    ProductCreateResponse response = productCreateService.create(AUTH_ID, request);
+
+    assertThat(response.thumbnail()).isNull();
+    verify(imageService, never()).validateAndGetProductUrl(any());
+  }
+
+  @Test
+  @DisplayName("thumbnailKey가 있으면 products/ URL로 변환된다")
+  void createProduct_withThumbnail_urlConverted() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "썸네일 상품", 5L,
+        "temp/550e8400-e29b-41d4-a716-446655440000.jpg",
+        10000, null, null, 100, null, null, null
+    );
+
+    ProductCreateResponse response = productCreateService.create(AUTH_ID, request);
+
+    assertThat(response.thumbnail()).isEqualTo(
+        "http://localhost:9000/wonkaotalk/products/test.jpg");
+  }
+
+  @Test
+  @DisplayName("detail이 있으면 ProductDetail이 저장된다")
+  void createProduct_withDetail_detailSaved() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상세 상품", 5L, null, 10000, null,
+        "<p>상품 설명입니다.</p>",
+        100, null, null, null
+    );
+
+    productCreateService.create(AUTH_ID, request);
+
+    verify(productDetailRepo).save(any());
+  }
+
+  @Test
+  @DisplayName("detail이 없으면 ProductDetail은 저장되지 않는다")
+  void createProduct_withoutDetail_detailNotSaved() {
+    productCreateService.create(AUTH_ID, noOptionRequest());
+
+    verify(productDetailRepo, never()).save(any());
+  }
+
+  // ── discountedPrice 계산 ───────────────────────────────────────────────────────
+
+  @ParameterizedTest(name = "price={0}, discountRate={1} → discountedPrice={2}")
+  @CsvSource({
+      "59000, 20, 47200",
+      "10000, 30, 7000",
+      "15000, 0,  15000",
+      "10000, 100, 0",
+      "3333,  10, 3000",
+  })
+  @DisplayName("discountedPrice가 올바르게 계산된다")
+  void discountedPrice_calculatedCorrectly(int price, int discountRate, int expected) {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "할인 상품", 5L, null, price, discountRate, null, 100, null, null, null
+    );
+
+    ProductCreateResponse response = productCreateService.create(AUTH_ID, request);
+
+    assertThat(response.discountedPrice()).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("discountRate가 없으면 discountedPrice는 price와 같다")
+  void discountedPrice_equalsPrice_whenNoDiscountRate() {
+    ProductCreateRequest request = noOptionRequest();
+
+    ProductCreateResponse response = productCreateService.create(AUTH_ID, request);
+
+    assertThat(response.discountedPrice()).isEqualTo(response.price());
+  }
+
+  // ── 조회 실패 ─────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("판매자를 찾을 수 없으면 SELLER_NOT_FOUND를 던진다")
+  void throwsException_whenSellerNotFound() {
+    when(sellerRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, noOptionRequest()));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("스토어를 찾을 수 없으면 PROD_STORE_NOT_FOUND를 던진다")
+  void throwsException_whenStoreNotFound() {
+    when(storeRepo.findBySeller(any())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, noOptionRequest()));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STORE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("카테고리를 찾을 수 없으면 PROD_CATEGORY_NOT_FOUND를 던진다")
+  void throwsException_whenCategoryNotFound() {
+    when(categoryRepo.findById(anyLong())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, noOptionRequest()));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_CATEGORY_NOT_FOUND);
+  }
+
+  // ── 가격/할인율 검증 ───────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("가격이 음수면 PROD_INVALID_PRICE를 던진다")
+  void throwsException_whenPriceIsNegative() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, -1, null, null, 100, null, null, null
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_PRICE);
+  }
+
+  @ParameterizedTest(name = "discountRate={0}")
+  @CsvSource({"-1", "101"})
+  @DisplayName("할인율이 0~100 범위를 벗어나면 PROD_INVALID_DISCOUNT_RATE를 던진다")
+  void throwsException_whenDiscountRateOutOfRange(int discountRate) {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 10000, discountRate, null, 100, null, null, null
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
+  }
+
+  // ── 재고 검증 ─────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("옵션 없는 상품에서 stock이 없으면 PROD_INVALID_QUANTITY를 던진다")
+  void throwsException_whenNoOptionAndNoStock() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 10000, null, null, null, null, null, null
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_QUANTITY);
+  }
+
+  @Test
+  @DisplayName("stock이 0이면 PROD_INVALID_QUANTITY를 던진다")
+  void throwsException_whenStockIsZero() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 10000, null, null, 0, null, null, null
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_QUANTITY);
+  }
+
+  // ── 옵션/variant 일관성 검증 ───────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("optionGroups가 있는데 stock도 함께 전달하면 PROD_INVALID_STOCK_OPTION을 던진다")
+  void throwsException_whenOptionGroupsAndStockBothPresent() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, 100,
+        null, colorGroups(), colorVariants()
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_STOCK_OPTION);
+  }
+
+  @Test
+  @DisplayName("optionGroups만 있고 variants가 없으면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenOnlyOptionGroupsPresent() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null,
+        null, colorGroups(), null
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  @Test
+  @DisplayName("variants만 있고 optionGroups가 없으면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenOnlyVariantsPresent() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null,
+        null, null, colorVariants()
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  @Test
+  @DisplayName("같은 상품 내 optionGroup 이름이 중복되면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenDuplicateGroupName() {
+    List<OptionGroupRequest> duplicateGroups = List.of(
+        new OptionGroupRequest("색상", 1, List.of(new OptionRequest("화이트"))),
+        new OptionGroupRequest("색상", 2, List.of(new OptionRequest("S")))
+    );
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        duplicateGroups,
+        List.of(new VariantRequest(List.of("화이트", "S"), 10))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  @Test
+  @DisplayName("같은 그룹 내 옵션 이름이 중복되면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenDuplicateOptionNameInGroup() {
+    List<OptionGroupRequest> groups = List.of(
+        new OptionGroupRequest("색상", 1, List.of(
+            new OptionRequest("화이트"),
+            new OptionRequest("화이트")
+        ))
+    );
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        groups,
+        List.of(new VariantRequest(List.of("화이트"), 10))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  @Test
+  @DisplayName("variant의 optionNames 개수가 optionGroups 개수와 다르면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenOptionNamesCountMismatch() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        colorGroups(),
+        List.of(new VariantRequest(List.of("화이트", "여분옵션"), 10))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  @Test
+  @DisplayName("variant의 optionName이 해당 그룹에 없으면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenOptionNameNotInGroup() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        colorGroups(),
+        List.of(new VariantRequest(List.of("존재하지않는색"), 10))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  @Test
+  @DisplayName("동일한 optionNames 조합의 variant가 중복이면 PROD_MISMATCH_VARIANT_OPTION을 던진다")
+  void throwsException_whenDuplicateVariantCombination() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        colorGroups(),
+        List.of(
+            new VariantRequest(List.of("화이트"), 50),
+            new VariantRequest(List.of("화이트"), 30)
+        )
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_MISMATCH_VARIANT_OPTION);
+  }
+
+  // ── sortOrder 검증 ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("이미지 sortOrder가 중복이면 PROD_DUPLICATE_SORT_ORDER를 던진다")
+  void throwsException_whenDuplicateImageSortOrder() {
+    List<ImageRequest> images = List.of(
+        new ImageRequest("temp/550e8400-e29b-41d4-a716-446655440000.jpg", 1),
+        new ImageRequest("temp/661f9511-f30c-52e5-b827-557766551111.jpg", 1)
+    );
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 10000, null, null, 100, images, null, null
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DUPLICATE_SORT_ORDER);
+  }
+
+  @Test
+  @DisplayName("optionGroup sortOrder가 중복이면 PROD_DUPLICATE_SORT_ORDER를 던진다")
+  void throwsException_whenDuplicateGroupSortOrder() {
+    List<OptionGroupRequest> groups = List.of(
+        new OptionGroupRequest("색상", 1, List.of(new OptionRequest("화이트"))),
+        new OptionGroupRequest("사이즈", 1, List.of(new OptionRequest("M")))
+    );
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        groups,
+        List.of(new VariantRequest(List.of("화이트", "M"), 10))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DUPLICATE_SORT_ORDER);
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────────
+
+  private ProductCreateRequest noOptionRequest() {
+    return new ProductCreateRequest(
+        "테스트 상품", 5L, null, 10000, null, null, 100, null, null, null
+    );
+  }
+
+  private ProductCreateRequest withOptionRequest() {
+    return new ProductCreateRequest(
+        "옵션 상품", 5L, null, 15000, null, null, null, null,
+        colorGroups(), colorVariants()
+    );
+  }
+
+  private List<OptionGroupRequest> colorGroups() {
+    return List.of(
+        new OptionGroupRequest("색상", 1, List.of(
+            new OptionRequest("화이트"),
+            new OptionRequest("블랙")
+        ))
+    );
+  }
+
+  private List<VariantRequest> colorVariants() {
+    return List.of(
+        new VariantRequest(List.of("화이트"), 50),
+        new VariantRequest(List.of("블랙"), 30)
+    );
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductServiceTest.java
@@ -25,6 +25,7 @@ import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
 import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -143,7 +144,8 @@ class ProductServiceTest {
     request.setSize(2);
 
     List<Product> products = mockProducts(3);
-    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(),
+        anyInt()))
         .thenReturn(products);
 
     ProductListResponse response = productService.getProductList(request);
@@ -161,7 +163,8 @@ class ProductServiceTest {
     request.setSize(5);
 
     List<Product> products = mockProducts(3);
-    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(),
+        anyInt()))
         .thenReturn(products);
 
     ProductListResponse response = productService.getProductList(request);
@@ -182,7 +185,8 @@ class ProductServiceTest {
 
     Product first = mockProduct(1L, 10000, 20, 8000, 42, LocalDateTime.now());
     Product second = mockProduct(2L, 5000, 0, 5000, 10, LocalDateTime.now());
-    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(),
+        anyInt()))
         .thenReturn(List.of(first, second));
 
     ProductListResponse response = productService.getProductList(request);
@@ -202,7 +206,8 @@ class ProductServiceTest {
 
     Product first = mockProduct(1L, 10000, 20, 8000, 5, createdAt);
     Product second = mockProduct(2L, 5000, 0, 5000, 3, LocalDateTime.now());
-    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(),
+        anyInt()))
         .thenReturn(List.of(first, second));
 
     ProductListResponse response = productService.getProductList(request);
@@ -220,7 +225,8 @@ class ProductServiceTest {
     // price=10000, discountRate=20 → discountedPrice=8000
     Product first = mockProduct(1L, 10000, 20, 8000, 5, LocalDateTime.now());
     Product second = mockProduct(2L, 15000, 0, 15000, 3, LocalDateTime.now());
-    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(), anyInt()))
+    when(productRepository.findWithFilters(any(), any(), any(), any(), any(), any(), any(),
+        anyInt()))
         .thenReturn(List.of(first, second));
 
     ProductListResponse response = productService.getProductList(request);
@@ -266,14 +272,16 @@ class ProductServiceTest {
   }
 
   @Test
-  @DisplayName("store는 항상 null을 반환한다")
-  void store_isAlwaysNull() {
+  @DisplayName("store 정보가 응답에 포함된다")
+  void store_isIncludedInResponse() {
     Product product = mockProduct(1L, 10000, 0, 10000, 0, LocalDateTime.now());
     when(productRepository.findById(1L)).thenReturn(Optional.of(product));
 
     ProductDetailResponse response = productService.getProductDetail(1L);
 
-    assertThat(response.getStore()).isNull();
+    assertThat(response.getStore()).isNotNull();
+    assertThat(response.getStore().getStoreId()).isEqualTo(10L);
+    assertThat(response.getStore().getStoreName()).isEqualTo("테스트스토어");
   }
 
   @Test
@@ -300,12 +308,14 @@ class ProductServiceTest {
     VariantOptionMap map2 = mock(VariantOptionMap.class);
     when(map2.getProductVariant()).thenReturn(variant);
     when(map2.getProductOption()).thenReturn(option2);
-    when(variantOptionMapRepository.findByProductVariantIdIn(List.of(10L))).thenReturn(List.of(map1, map2));
+    when(variantOptionMapRepository.findByProductVariantIdIn(List.of(10L))).thenReturn(
+        List.of(map1, map2));
 
     ProductDetailResponse response = productService.getProductDetail(1L);
 
     assertThat(response.getVariants()).hasSize(1);
-    assertThat(response.getVariants().get(0).getCombinationIds()).containsExactlyInAnyOrder(201L, 301L);
+    assertThat(response.getVariants().get(0).getCombinationIds()).containsExactlyInAnyOrder(201L,
+        301L);
   }
 
   // ── 헬퍼 ────────────────────────────────────────────────────────────────────
@@ -319,6 +329,10 @@ class ProductServiceTest {
 
   private Product mockProduct(Long id, int price, int discountRate, int discountedPrice,
       int likeCount, LocalDateTime createdAt) {
+    Store store = mock(Store.class);
+    when(store.getId()).thenReturn(10L);
+    when(store.getName()).thenReturn("테스트스토어");
+
     Product product = mock(Product.class);
     when(product.getId()).thenReturn(id);
     when(product.getName()).thenReturn("상품" + id);
@@ -328,6 +342,7 @@ class ProductServiceTest {
     when(product.getLikeCount()).thenReturn(likeCount);
     when(product.getCreatedAt()).thenReturn(createdAt);
     when(product.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    when(product.getStore()).thenReturn(store);
     return product;
   }
 

--- a/src/test/java/com/example/WonkaoTalk/domain/search/integration/SearchRepoCustomImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/integration/SearchRepoCustomImplTest.java
@@ -6,11 +6,14 @@ package com.example.WonkaoTalk.domain.search.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,10 +38,12 @@ class SearchRepositoryCustomImplTest {
   private ProductRepo productRepository;
 
   private Category category;
+  private Store store;
 
   @BeforeEach
   void setUp() {
     category = saveCategory("테스트카테고리");
+    store = saveStore("테스트스토어");
   }
 
   // ── 키워드 검색 ───────────────────────────────────────────────────────────────
@@ -220,11 +225,33 @@ class SearchRepositoryCustomImplTest {
     return cat;
   }
 
-  private Product saveProduct(String name, Long storeId, Category cat, int discountedPrice,
+  private Store saveStore(String name) {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    Seller seller = Seller.builder()
+        .buzNo(String.valueOf(System.nanoTime()).substring(0, 10))
+        .name(name + "판매자")
+        .phone("010-0000-0000")
+        .auth(auth)
+        .build();
+    em.persist(seller);
+
+    Store s = Store.builder()
+        .name(name)
+        .description("설명")
+        .phone("010-0000-0000")
+        .seller(seller)
+        .build();
+    em.persist(s);
+    return s;
+  }
+
+  private Product saveProduct(String name, Long ignoredStoreId, Category cat, int discountedPrice,
       int likeCount, SaleStatus status, LocalDateTime deletedAt) {
     Product product = new Product();
     ReflectionTestUtils.setField(product, "name", name);
-    ReflectionTestUtils.setField(product, "storeId", storeId);
+    ReflectionTestUtils.setField(product, "store", store);
     ReflectionTestUtils.setField(product, "category", cat);
     ReflectionTestUtils.setField(product, "price", discountedPrice);
     ReflectionTestUtils.setField(product, "discountRate", 0);

--- a/src/test/java/com/example/WonkaoTalk/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/service/SearchServiceTest.java
@@ -16,6 +16,8 @@ import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -39,6 +41,9 @@ class SearchServiceTest {
 
   @Mock
   private CategoryRepo categoryRepository;
+
+  @Mock
+  private StoreRepo storeRepository;
 
   @InjectMocks
   private SearchService searchService;
@@ -211,15 +216,24 @@ class SearchServiceTest {
   // ── 응답 구조 ────────────────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("stores는 항상 null이다")
-  void stores_isAlwaysNull() {
+  @DisplayName("stores는 키워드로 검색된 스토어 목록을 반환한다")
+  void stores_returnsMatchingStores() {
     SearchRequest request = defaultRequest("셔츠");
     when(productRepository.findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
         .thenReturn(List.of());
 
+    Store store = mock(Store.class);
+    when(store.getId()).thenReturn(1L);
+    when(store.getName()).thenReturn("셔츠스토어");
+    when(store.getThumbnail()).thenReturn("http://thumbnail.png");
+    when(store.getDescription()).thenReturn("셔츠 전문점");
+    when(storeRepository.findByNameContaining("셔츠")).thenReturn(List.of(store));
+
     SearchResponse response = searchService.search(request);
 
-    assertThat(response.stores()).isNull();
+    assertThat(response.stores()).hasSize(1);
+    assertThat(response.stores().get(0).storeId()).isEqualTo(1L);
+    assertThat(response.stores().get(0).storeName()).isEqualTo("셔츠스토어");
   }
 
   // ── 헬퍼 ────────────────────────────────────────────────────────────────────
@@ -230,10 +244,14 @@ class SearchServiceTest {
 
   private Product mockProduct(Long id, int price, int discountedPrice, int likeCount,
       LocalDateTime createdAt) {
+    Store store = mock(Store.class);
+    when(store.getId()).thenReturn(1L);
+    when(store.getName()).thenReturn("테스트스토어");
+
     Product product = mock(Product.class);
     when(product.getId()).thenReturn(id);
     when(product.getName()).thenReturn("상품" + id);
-    when(product.getStoreId()).thenReturn(1L);
+    when(product.getStore()).thenReturn(store);
     when(product.getPrice()).thenReturn(price);
     when(product.getDiscountedPrice()).thenReturn(discountedPrice);
     when(product.getDiscountRate()).thenReturn(0);


### PR DESCRIPTION
## 📌 관련 이슈
- #45 

## 📝 작업 내용
- 상품 등록 API, 이미지 등록 API(Presigned URL발급)를 추가했습니다.
- MiniO를 사용하여 이미지를 저장하는 기능을 추가했습니다. 추후에 S3로 교체하면 됩니다.

## ✅ 작업 결과 
- 테스트 결과
<img width="700" height="264" alt="스크린샷 2026-05-11 오후 11 18 18" src="https://github.com/user-attachments/assets/38b0afdb-6833-4a43-a555-10f1b7e73893" />
<img width="700" height="264" alt="스크린샷 2026-05-11 오후 11 17 54" src="https://github.com/user-attachments/assets/154e2a97-b3ba-439d-89f8-c17e8faa931e" />
- 구현 영상 (Slack에 올린 영상 참고)


## 🎸 기타
- SpringSecurity를 조금 건드렸습니다.
- StoreRepo에 메소드를 하나 추가했습니다. 검색에 씁니다
- SellerRepo에 메소드를 하나 추가했습니다. 상품 등록시 스토어 검색에 씁니다.
- docker-compose.yml파일에 새로운 컨테이너가 하나 생겼습니다.
- gitignore에 docker volume관련 폴더를 추가했습니다.