### PR TITLE
feat: WebSocket & STOMP 실시간 통신 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,6 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // WebSocket & STOMP
-    implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    
     // --- Data Storage & Messaging ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // WebSocket & STOMP
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    
     // --- Data Storage & Messaging ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/example/WonkaoTalk/common/config/WebSocketConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.example.WonkaoTalk.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*"); //.withSockJS();
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/sub");
+    registry.setApplicationDestinationPrefixes("/pub");
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/common/config/WebSocketConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/WebSocketConfig.java
@@ -12,6 +12,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // TODO: 현재 모두 허용해뒀으나 추후 제한해야 함 .withSockJS()도 연동시 활성화
     registry.addEndpoint("/ws").setAllowedOriginPatterns("*"); //.withSockJS();
   }
 

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                 "/api/v1/search",
                 "/api/v1/auth/login",
                 "/api/v1/sellers/signup",
-                "/api/v1/chats/**"
+                "/api/v1/chats/**",
+                "/ws/**"
             ).permitAll() // 인증 없이 접근 허용
             .requestMatchers(
                 "/api/v1/auth/logout",

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -59,8 +61,14 @@ public class ChatMessageService {
 
     ChatMessageResponse response = ChatMessageResponse.from(chatMessage);
 
-    messagingTemplate.convertAndSend("/sub/chat/room/" + chatRoomId, response);
-    return ChatMessageResponse.from(chatMessage);
+    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+      @Override
+      public void afterCommit() {
+        messagingTemplate.convertAndSend("/sub/chat/room/" + chatRoomId, response);
+      }
+    });
+
+    return response;
   }
 
   @Transactional

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class ChatMessageService {
   private final ChatMessageRepo chatMessageRepo;
   private final ChatRoomRepo chatRoomRepo;
   private final ChatParticipantRepo chatParticipantRepo;
+  private final SimpMessagingTemplate messagingTemplate;
 
   @Transactional
   public ChatMessageResponse sendMessage(Long userId, Long chatRoomId, ChatMessageRequest request) {
@@ -52,11 +54,12 @@ public class ChatMessageService {
         .build();
 
     chatMessageRepo.saveAndFlush(chatMessage);
-
     chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
-
     participant.updateLastReadMessage(chatMessage);
 
+    ChatMessageResponse response = ChatMessageResponse.from(chatMessage);
+
+    messagingTemplate.convertAndSend("/sub/chat/room/" + chatRoomId, response);
     return ChatMessageResponse.from(chatMessage);
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- #46 

## 📝 작업 내용
- 의존성 추가 및 설정 파일 작성 (/sub 수신 /pub 발신)
- 메시지 수신 때 구독 중인 유저들에게 실시간으로 오게 변경

## ✅ 작업 결과 
<img width="620" height="519" alt="image" src="https://github.com/user-attachments/assets/d5f18c1e-0198-4772-8843-4769a51b95f5" />
<img width="701" height="423" alt="image" src="https://github.com/user-attachments/assets/0effe24d-3dcf-481e-bfc3-cd254d8cdb5a" />

## 🎸 기타
- 송수신을 모두 소켓으로 하지 않고 송신은 기존 REST API, 수신은 WebSocket으로 분리
- 현재는 /ws/엔드포인트를 열어뒀는데 다음 PR에서 검증 로직 추가 예정