### PR TITLE
refactor: product도메인의 기능 확장

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - ./kafka/data:/var/lib/kafka/data
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: wonkao-talk-minio
     ports:
       - "9000:9000"  # API

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -11,7 +11,7 @@ import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.SummaryDto;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
-import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class OrderService {
 
-  private final ProductVariantRepository productVariantRepository;
+  private final ProductVariantRepo productVariantRepo;
 
   // 주문 생성 로직 작성
   // 응답값으로 Order로 생성 요청한 값들의 성공적으로 생성 되었는지만 전달해주면됨.
@@ -91,7 +91,7 @@ public class OrderService {
   // variantId 목록으로 ProductVariant 조회 후 Map으로 변환
   public Map<Long, ProductVariant> findVariantMapByIds(List<Long> variantIds) {
 
-    List<ProductVariant> variants = productVariantRepository.findAllById(variantIds);
+    List<ProductVariant> variants = productVariantRepo.findAllById(variantIds);
 
     return variants.stream().collect(Collectors.toMap(
         ProductVariant::getId,

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -79,4 +79,8 @@ public class Product {
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
+
+  public boolean isOnSale() {
+    return this.status == SaleStatus.ON_SALE;
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -61,4 +61,8 @@ public class ProductVariant {
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
+
+  public boolean isSellable() {
+    return this.product.isOnSale() && this.status == SaleStatus.ON_SALE;
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,14 +15,32 @@ public interface ProductVariantRepo extends JpaRepository<ProductVariant, Long> 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE ProductVariant pv " +
       "SET pv.stock = pv.stock - :quantity, " +
-      "pv.status = CASE WHEN (pv.stock - :quantity) = 0 THEN com.example.WonkaoTalk.domain.product.enums.SaleStatus.OUT_OF_STOCK ELSE pv.status END " +
+      "pv.status = CASE WHEN (pv.stock - :quantity) = 0 AND pv.status = :onSale THEN :outOfStock ELSE pv.status END " +
       "WHERE pv.id = :id AND pv.stock >= :quantity")
-  int decreaseStockAtomic(@Param("id") Long id, @Param("quantity") int quantity);
+  int decreaseStock(
+      @Param("id") Long id,
+      @Param("quantity") int quantity,
+      @Param("onSale") SaleStatus onSale,
+      @Param("outOfStock") SaleStatus outOfStock
+  );
 
   @Modifying(clearAutomatically = true)
   @Query("UPDATE ProductVariant pv " +
       "SET pv.stock = pv.stock + :quantity, " +
-      "pv.status = CASE WHEN pv.status = com.example.WonkaoTalk.domain.product.enums.SaleStatus.OUT_OF_STOCK THEN com.example.WonkaoTalk.domain.product.enums.SaleStatus.ON_SALE ELSE pv.status END " +
+      "pv.status = CASE WHEN pv.status = :outOfStock THEN :onSale ELSE pv.status END " +
       "WHERE pv.id = :id")
-  void increaseStockAtomic(@Param("id") Long id, @Param("quantity") int quantity);
+  int increaseStock(
+      @Param("id") Long id,
+      @Param("quantity") int quantity,
+      @Param("outOfStock") SaleStatus outOfStock,
+      @Param("onSale") SaleStatus onSale
+  );
+
+  default int decreaseStockAtomic(Long id, int quantity) {
+    return decreaseStock(id, quantity, SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK);
+  }
+
+  default int increaseStockAtomic(Long id, int quantity) {
+    return increaseStock(id, quantity, SaleStatus.OUT_OF_STOCK, SaleStatus.ON_SALE);
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
@@ -12,12 +12,16 @@ public interface ProductVariantRepo extends JpaRepository<ProductVariant, Long> 
   List<ProductVariant> findByProductId(Long productId);
 
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE ProductVariant pv SET pv.stock = pv.stock - :quantity " +
+  @Query("UPDATE ProductVariant pv " +
+      "SET pv.stock = pv.stock - :quantity, " +
+      "pv.status = CASE WHEN (pv.stock - :quantity) = 0 THEN com.example.WonkaoTalk.domain.product.enums.SaleStatus.OUT_OF_STOCK ELSE pv.status END " +
       "WHERE pv.id = :id AND pv.stock >= :quantity")
   int decreaseStockAtomic(@Param("id") Long id, @Param("quantity") int quantity);
 
   @Modifying(clearAutomatically = true)
-  @Query("UPDATE ProductVariant pv SET pv.stock = pv.stock + :quantity " +
+  @Query("UPDATE ProductVariant pv " +
+      "SET pv.stock = pv.stock + :quantity, " +
+      "pv.status = CASE WHEN pv.status = com.example.WonkaoTalk.domain.product.enums.SaleStatus.OUT_OF_STOCK THEN com.example.WonkaoTalk.domain.product.enums.SaleStatus.ON_SALE ELSE pv.status END " +
       "WHERE pv.id = :id")
   void increaseStockAtomic(@Param("id") Long id, @Param("quantity") int quantity);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
@@ -3,8 +3,21 @@ package com.example.WonkaoTalk.domain.product.repo;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductVariantRepo extends JpaRepository<ProductVariant, Long> {
 
   List<ProductVariant> findByProductId(Long productId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE ProductVariant pv SET pv.stock = pv.stock - :quantity " +
+      "WHERE pv.id = :id AND pv.stock >= :quantity")
+  int decreaseStockAtomic(@Param("id") Long id, @Param("quantity") int quantity);
+
+  @Modifying(clearAutomatically = true)
+  @Query("UPDATE ProductVariant pv SET pv.stock = pv.stock + :quantity " +
+      "WHERE pv.id = :id")
+  void increaseStockAtomic(@Param("id") Long id, @Param("quantity") int quantity);
 }

--- a/src/test/java/com/example/WonkaoTalk/config/TestContainerConfig.java
+++ b/src/test/java/com/example/WonkaoTalk/config/TestContainerConfig.java
@@ -34,7 +34,7 @@ public class TestContainerConfig {
 
   @Bean
   public GenericContainer<?> minioContainer(ConfigurableEnvironment environment) {
-    GenericContainer<?> minio = new GenericContainer<>("minio/minio:latest")
+    GenericContainer<?> minio = new GenericContainer<>("minio/minio:RELEASE.2025-09-07T16-13-09Z")
         .withEnv("MINIO_ROOT_USER", "minioadmin")
         .withEnv("MINIO_ROOT_PASSWORD", "minioadmin")
         .withCommand("server /data")

--- a/src/test/java/com/example/WonkaoTalk/config/TestContainerConfig.java
+++ b/src/test/java/com/example/WonkaoTalk/config/TestContainerConfig.java
@@ -1,9 +1,13 @@
 package com.example.WonkaoTalk.config;
 
 import com.redis.testcontainers.RedisContainer;
+import java.util.Map;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
@@ -27,4 +31,32 @@ public class TestContainerConfig {
   public KafkaContainer kafkaContainer() {
     return new KafkaContainer("apache/kafka:4.0.0");
   }
+
+  @Bean
+  public GenericContainer<?> minioContainer(ConfigurableEnvironment environment) {
+    GenericContainer<?> minio = new GenericContainer<>("minio/minio:latest")
+        .withEnv("MINIO_ROOT_USER", "minioadmin")
+        .withEnv("MINIO_ROOT_PASSWORD", "minioadmin")
+        .withCommand("server /data")
+        .withExposedPorts(9000);
+
+    minio.start();
+
+    String endpoint = String.format("http://%s:%d", minio.getHost(), minio.getMappedPort(9000));
+
+    Map<String, Object> properties = Map.of(
+        "storage.endpoint", endpoint,
+        "storage.access-key", "minioadmin",
+        "storage.secret-key", "minioadmin",
+        "storage.bucket", "wonkao-talk",
+        "storage.region", "ap-northeast-2",
+        "storage.temp-prefix", "temp/",
+        "storage.presigned-expiry-minutes", 15
+    );
+
+    environment.getPropertySources().addFirst(new MapPropertySource("minio-test-properties", properties));
+
+    return minio;
+  }
 }
+

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductVariantRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductVariantRepoTest.java
@@ -1,0 +1,146 @@
+package com.example.WonkaoTalk.domain.product.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Import(TestContainerConfig.class)
+@Transactional
+class ProductVariantRepoTest {
+
+  @Autowired
+  private EntityManager em;
+
+  @Autowired
+  private ProductVariantRepo productVariantRepo;
+
+  private ProductVariant variant;
+
+  @BeforeEach
+  void setUp() {
+    Category category = saveCategory("테스트카테고리");
+    Store store = saveStore("테스트스토어");
+    Product product = saveProduct(store, category, "테스트상품", 10000);
+    variant = saveVariant(product, "테스트옵션", 10);
+    flushAndClear();
+  }
+
+  // ── 재고 관리 (Atomic) ───────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("재고를 성공적으로 감소시키면 1을 반환하고 DB에 반영된다")
+  void decreaseStockAtomic_Success() {
+    // when
+    int updatedCount = productVariantRepo.decreaseStockAtomic(variant.getId(), 5);
+
+    // then
+    assertThat(updatedCount).isEqualTo(1);
+
+    ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
+    assertThat(updated.getStock()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("재고가 부족하면 감소시키지 않고 0을 반환한다")
+  void decreaseStockAtomic_Fail_InsufficientStock() {
+    // when
+    int updatedCount = productVariantRepo.decreaseStockAtomic(variant.getId(), 11);
+
+    // then
+    assertThat(updatedCount).isEqualTo(0);
+
+    ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
+    assertThat(updated.getStock()).isEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("재고를 성공적으로 증가시킨다")
+  void increaseStockAtomic_Success() {
+    // when
+    productVariantRepo.increaseStockAtomic(variant.getId(), 5);
+
+    // then
+    ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
+    assertThat(updated.getStock()).isEqualTo(15);
+  }
+
+  // ── 헬퍼 ─────────────────────────────────────────────────────────────────────
+
+  private Category saveCategory(String name) {
+    Category cat = new Category();
+    ReflectionTestUtils.setField(cat, "name", name);
+    ReflectionTestUtils.setField(cat, "depth", 1);
+    em.persist(cat);
+    return cat;
+  }
+
+  private Store saveStore(String name) {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    Seller seller = Seller.builder()
+        .buzNo(String.valueOf(System.nanoTime()).substring(0, 10))
+        .name(name + "판매자")
+        .phone("010-0000-0000")
+        .auth(auth)
+        .build();
+    em.persist(seller);
+
+    Store store = Store.builder()
+        .name(name)
+        .description("설명")
+        .phone("010-0000-0000")
+        .seller(seller)
+        .build();
+    em.persist(store);
+    return store;
+  }
+
+  private Product saveProduct(Store store, Category cat, String name, int price) {
+    Product product = Product.builder()
+        .store(store)
+        .name(name)
+        .category(cat)
+        .price(price)
+        .discountedPrice(price)
+        .status(SaleStatus.ON_SALE)
+        .likeCount(0)
+        .build();
+    em.persist(product);
+    return product;
+  }
+
+  private ProductVariant saveVariant(Product product, String name, int stock) {
+    ProductVariant v = ProductVariant.builder()
+        .product(product)
+        .name(name)
+        .stock(stock)
+        .status(SaleStatus.ON_SALE)
+        .build();
+    em.persist(v);
+    return v;
+  }
+
+  private void flushAndClear() {
+    em.flush();
+    em.clear();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductVariantRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductVariantRepoTest.java
@@ -46,18 +46,51 @@ class ProductVariantRepoTest {
   // ── 재고 관리 (Atomic) ───────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("재고를 성공적으로 감소시키면 1을 반환하고 DB에 반영된다")
-  void decreaseStockAtomic_Success() {
+  @DisplayName("재고가 0이 되면 상태가 OUT_OF_STOCK으로 변경된다")
+  void decreaseStockAtomic_ChangesStatusToOutOfStock_WhenStockHitsZero() {
     // when
-    int updatedCount = productVariantRepo.decreaseStockAtomic(variant.getId(), 5);
+    int updatedCount = productVariantRepo.decreaseStockAtomic(variant.getId(), 10);
 
     // then
     assertThat(updatedCount).isEqualTo(1);
 
     ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
-    assertThat(updated.getStock()).isEqualTo(5);
+    assertThat(updated.getStock()).isEqualTo(0);
+    assertThat(updated.getStatus()).isEqualTo(SaleStatus.OUT_OF_STOCK);
   }
 
+  @Test
+  @DisplayName("OUT_OF_STOCK 상태에서 재고가 증가하면 ON_SALE로 변경된다")
+  void increaseStockAtomic_ChangesStatusToOnSale_WhenPreviouslyOutOfStock() {
+    // given (재고를 0으로 만들어 OUT_OF_STOCK 상태로 변경)
+    productVariantRepo.decreaseStockAtomic(variant.getId(), 10);
+    flushAndClear();
+
+    // when
+    productVariantRepo.increaseStockAtomic(variant.getId(), 5);
+
+    // then
+    ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
+    assertThat(updated.getStock()).isEqualTo(5);
+    assertThat(updated.getStatus()).isEqualTo(SaleStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("STOP_SALE 상태에서는 재고가 증가해도 상태가 변경되지 않는다")
+  void increaseStockAtomic_DoesNotChangeStatus_WhenStopSale() {
+    // given (상태를 STOP_SALE로 변경)
+    ProductVariant v = productVariantRepo.findById(variant.getId()).orElseThrow();
+    ReflectionTestUtils.setField(v, "status", SaleStatus.STOP_SALE);
+    em.persist(v);
+    flushAndClear();
+
+    // when
+    productVariantRepo.increaseStockAtomic(variant.getId(), 5);
+
+    // then
+    ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
+    assertThat(updated.getStatus()).isEqualTo(SaleStatus.STOP_SALE);
+  }
   @Test
   @DisplayName("재고가 부족하면 감소시키지 않고 0을 반환한다")
   void decreaseStockAtomic_Fail_InsufficientStock() {

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductVariantRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/ProductVariantRepoTest.java
@@ -91,6 +91,25 @@ class ProductVariantRepoTest {
     ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
     assertThat(updated.getStatus()).isEqualTo(SaleStatus.STOP_SALE);
   }
+
+  @Test
+  @DisplayName("STOP_SALE 상태에서는 재고가 0이 되어도 상태가 변경되지 않는다")
+  void decreaseStockAtomic_DoesNotChangeStatus_WhenStopSale() {
+    // given (상태를 STOP_SALE로 변경)
+    ProductVariant v = productVariantRepo.findById(variant.getId()).orElseThrow();
+    ReflectionTestUtils.setField(v, "status", SaleStatus.STOP_SALE);
+    em.persist(v);
+    flushAndClear();
+
+    // when (재고를 0으로 만듬)
+    productVariantRepo.decreaseStockAtomic(variant.getId(), 10);
+
+    // then
+    ProductVariant updated = productVariantRepo.findById(variant.getId()).orElseThrow();
+    assertThat(updated.getStock()).isEqualTo(0);
+    assertThat(updated.getStatus()).isEqualTo(SaleStatus.STOP_SALE);
+  }
+
   @Test
   @DisplayName("재고가 부족하면 감소시키지 않고 0을 반환한다")
   void decreaseStockAtomic_Fail_InsufficientStock() {


### PR DESCRIPTION
## 📌 관련 이슈
- #56 

## 📝 작업 내용
- 원자적 업데이트 방법을 사용하는 재고 증감 메소드를 추가했습니다.
- 테스트 컨테이너에 MiniO컨테이너를 추가했습니다. 
- 판매 상태를 확인할 수 있는 메소드를 추가했습니다.

## ✅ 작업 결과 
- 테스트 결과
<img width="854" height="255" alt="스크린샷 2026-05-13 오전 10 09 50" src="https://github.com/user-attachments/assets/a1390ccc-1d7a-4957-b2c9-ac9b14c562da" />

## 🎸 기타
- 기존 로직은 아무것도 건드리지 않고, 메소드만 추가했습니다.
- 원자적 업데이트를 사용하여 재고 증감 로직을 구현했습니다. 실행 결과가 1이면 재고가 있던거고, 실행 결과가 0이되면 재고가 없다는 취급입니다. (요컨대, 수정할 때 재고가 없으면 행의 수정이 일어나지 않으므로 update 결과가 0이 되는 느낌입니다). 비관적락도 고려를 해 보긴 했는데 성능 상에서는 이런 방식이 낫다고 생각했습니다.
- 판매 상태의 경우, 각 옵션 별로 독립적인 판매 상태를 가질 수 있으나, 부모(Product)의 판매상태가 ON_SALE이 아니면 모든 옵션이 판매 불가 상태로 판정되도록 구성했습니다.