### PR TITLE
feat: Store도메인 등록 / 수정/ 삭제 / 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
             ).hasRole("USER")
             .requestMatchers(
                 "/api/v1/sellers/**",
+                "/api/v1/stores/**",
                 "/api/v1/images/**"
             ).hasRole("SELLER")
 

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -31,10 +31,16 @@ public enum ErrorCode {
   FRND_SELF_REF(400, "FRND-SELF-REF", "자기 자신을 참조 할 수 없습니다."),
   FRND_REGISTERED_ALREADY(400, "FRND-REGISTERED-ALREADY", "이미 친구로 등록된 사용자입니다."),
   FRND_NOT_FOUND(404, "FRND-NOT-FOUND", "친구 정보를 찾을 수 없습니다."),
+
   // 판매자 도메인
   SELLER_NOT_FOUND(404, "SELLER-NOT-FOUND", "해당 판매자 ID를 찾을 수 없습니다."),
   SELLER_REGISTERED_ACCOUNT(400, "SELLER-REGISTERED-ACCOUNT", "이미 사업자 등록된 계정입니다."),
   SELLER_DUPLICATE_BUZNO(409, "SELLER-DUPLICATE-BUZNO", "이미 등록된 사업자 번호입니다."),
+
+  // 스토어 도메인
+  STORE_EXISTS_ALREADY(409, "STORE-EXISTS-ALREADY", "이미 등록된 스토어가 존재합니다."),
+  STORE_NOT_FOUND(404, "STORE-NOT-FOUND", "스토어를 찾을 수 없습니다."),
+
   // 상품 도메인
   PROD_INVALID_PRICE_RANGE(400, "PROD-INVALID-PRICE-RANGE", "최소 가격은 최대 가격보다 클 수 없습니다."),
   PROD_INVALID_SORT(400, "PROD-INVALID-SORT", "허용되지 않는 정렬 기준입니다."),
@@ -50,7 +56,8 @@ public enum ErrorCode {
   PROD_INVALID_QUANTITY(400, "PROD-INVALID-QUANTITY", "수량은 최소 1개 이상이어야 합니다."),
   PROD_INVALID_PRICE(400, "PROD-INVALID-PRICE", "가격은 0 이상이어야 합니다."),
   PROD_INVALID_DISCOUNT_RATE(400, "PROD-INVALID-DISCOUNT-RATE", "할인율은 0에서 100 사이여야 합니다."),
-  PROD_MISMATCH_VARIANT_OPTION(400, "PROD-MISMATCH-VARIANT-OPTION", "variant의 옵션 이름이 등록된 옵션 목록과 일치하지 않습니다."),
+  PROD_MISMATCH_VARIANT_OPTION(400, "PROD-MISMATCH-VARIANT-OPTION",
+      "variant의 옵션 이름이 등록된 옵션 목록과 일치하지 않습니다."),
   PROD_INVALID_STOCK_OPTION(400, "PROD-INVALID-STOCK-OPTION", "옵션이 있는 상품은 stock을 직접 입력할 수 없습니다."),
   PROD_DUPLICATE_SORT_ORDER(400, "PROD-DUPLICATE-SORT-ORDER", "sortOrder 값이 중복되었습니다."),
 

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -40,7 +40,7 @@ public enum ErrorCode {
   // 스토어 도메인
   STORE_EXISTS_ALREADY(409, "STORE-EXISTS-ALREADY", "이미 등록된 스토어가 존재합니다."),
   STORE_NOT_FOUND(404, "STORE-NOT-FOUND", "스토어를 찾을 수 없습니다."),
-
+  STORE_EXISTS_NAME(409, "STORE-EXISTS-NAME", "이미 존재하는 스토어 이름입니다"),
   // 상품 도메인
   PROD_INVALID_PRICE_RANGE(400, "PROD-INVALID-PRICE-RANGE", "최소 가격은 최대 가격보다 클 수 없습니다."),
   PROD_INVALID_SORT(400, "PROD-INVALID-SORT", "허용되지 않는 정렬 기준입니다."),

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/service/SellerService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/service/SellerService.java
@@ -89,5 +89,9 @@ public class SellerService {
     return sellerRepo.existsByAuthId(authId);
   }
 
-
+  @Transactional(readOnly = true)
+  public Seller findSeller(Long sellerId) {
+    return sellerRepo.findById(sellerId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,6 +42,16 @@ public class StoreController {
         .body(ApiResponse.success("스토어 등록이 완료되었습니다.", response));
   }
 
+  @GetMapping
+  public ResponseEntity<ApiResponse<StoreResponse>> getStore(
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    Seller seller = sellerService.findSeller(userDetails.getSellerId());
+    StoreResponse response = storeService.getStore(seller);
+
+    return ResponseEntity.ok(ApiResponse.success("스토어 정보 조회가 완료되었습니다.", response));
+  }
+
   @PatchMapping
   public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -49,7 +60,7 @@ public class StoreController {
     Seller seller = sellerService.findSeller(userDetails.getSellerId());
     StoreResponse response = storeService.updateStore(seller, request);
 
-    return ResponseEntity.ok(ApiResponse.success("스토어 정보수정이 완료되었습니다.", response));
+    return ResponseEntity.ok(ApiResponse.success("스토어 정보 수정이 완료되었습니다.", response));
   }
 
   @DeleteMapping

--- a/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
@@ -1,6 +1,22 @@
 package com.example.WonkaoTalk.domain.store.controller;
 
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.service.SellerService;
+import com.example.WonkaoTalk.domain.store.dto.StoreCreateRequest;
+import com.example.WonkaoTalk.domain.store.dto.StoreResponse;
+import com.example.WonkaoTalk.domain.store.dto.StoreUpdateRequest;
+import com.example.WonkaoTalk.domain.store.service.StoreService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +25,40 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/stores")
 public class StoreController {
 
+  private final StoreService storeService;
+  private final SellerService sellerService;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<StoreResponse>> createStore(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody StoreCreateRequest request
+  ) {
+
+    Seller seller = sellerService.findSeller(userDetails.getSellerId());
+    StoreResponse response = storeService.createStore(seller, request);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success("스토어 등록이 완료되었습니다.", response));
+  }
+
+  @PatchMapping
+  public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody StoreUpdateRequest request
+  ) {
+    Seller seller = sellerService.findSeller(userDetails.getSellerId());
+    StoreResponse response = storeService.updateStore(seller, request);
+
+    return ResponseEntity.ok(ApiResponse.success("스토어 정보수정이 완료되었습니다.", response));
+  }
+
+  @DeleteMapping
+  public ResponseEntity<ApiResponse<StoreResponse>> deleteStore(
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    Seller seller = sellerService.findSeller(userDetails.getSellerId());
+    storeService.deleteStore(seller);
+
+    return ResponseEntity.ok(ApiResponse.success("스토어 삭제가 완료되었습니다.", null));
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/store/dto/StoreCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/dto/StoreCreateRequest.java
@@ -1,0 +1,19 @@
+package com.example.WonkaoTalk.domain.store.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record StoreCreateRequest(
+    @NotBlank(message = "스토어 이름은 필수 입력값입니다.")
+    String name,
+
+    String description,
+
+    @NotBlank(message = "전화번호는 필수 입력값입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식을 입력해주세요.")
+    String phone,
+
+    String thumbnail
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/store/dto/StoreResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/dto/StoreResponse.java
@@ -1,0 +1,27 @@
+package com.example.WonkaoTalk.domain.store.dto;
+
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import lombok.Builder;
+
+@Builder
+public record StoreResponse(
+    Long id,
+    Long sellerId,
+    String name,
+    String description,
+    String phone,
+    String thumbnail
+) {
+
+  public static StoreResponse from(Store store) {
+    return StoreResponse.builder()
+        .id(store.getId())
+        .sellerId(store.getSeller().getId())
+        .name(store.getName())
+        .description(store.getDescription())
+        .phone(store.getPhone())
+        .thumbnail(store.getThumbnail())
+        .build();
+  }
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/store/dto/StoreUpdateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/dto/StoreUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.example.WonkaoTalk.domain.store.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+public record StoreUpdateRequest(
+    String name,
+
+    String description,
+
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식을 입력해주세요.")
+    String phone,
+
+    String thumbnail
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/store/entity/Store.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/entity/Store.java
@@ -1,9 +1,12 @@
 package com.example.WonkaoTalk.domain.store.entity;
 
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.enums.StoreStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -52,6 +55,11 @@ public class Store {
   @Column(nullable = false)
   private String thumbnail = "http://defaultThumbnail.png";
 
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private StoreStatus status = StoreStatus.ACTIVE;
+
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "seller_id", nullable = false, unique = true) // 현재 스토어와 판매자는 1대1 연관
   private Seller seller;
@@ -79,6 +87,7 @@ public class Store {
     this.description = "DELETED";
     this.phone = "000-0000-0000";
     this.thumbnail = "http://defaultThumbnail.png";
+    this.status = StoreStatus.DELETED;
     this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/store/enums/StoreStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/enums/StoreStatus.java
@@ -1,0 +1,7 @@
+package com.example.WonkaoTalk.domain.store.enums;
+
+public enum StoreStatus {
+  ACTIVE,
+  PENDING, // 나중에 스토어 등록 승인 대기 절차가 생긴다면?
+  DELETED
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/store/repo/StoreRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/repo/StoreRepo.java
@@ -10,6 +10,8 @@ public interface StoreRepo extends JpaRepository<Store, Long> {
 
   Optional<Store> findBySeller(Seller seller);
 
+  Optional<Store> findBySellerId(Long sellerId);
+
   boolean existsByName(String name);
 
   List<Store> findByNameContaining(String name);

--- a/src/main/java/com/example/WonkaoTalk/domain/store/repo/StoreRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/repo/StoreRepo.java
@@ -10,8 +10,6 @@ public interface StoreRepo extends JpaRepository<Store, Long> {
 
   Optional<Store> findBySeller(Seller seller);
 
-  Optional<Store> findBySellerId(Long sellerId);
-
   boolean existsByName(String name);
 
   List<Store> findByNameContaining(String name);

--- a/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
@@ -54,7 +54,13 @@ public class StoreService {
     Store store = storeRepo.findBySeller(seller)
         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
-    store.updateInfo(request.name(), request.description(), request.phone(), request.thumbnail());
+    String name = request.name() != null ? request.name() : store.getName();
+    String description =
+        request.description() != null ? request.description() : store.getDescription();
+    String phone = request.phone() != null ? request.phone() : store.getPhone();
+    String thumbnail = request.thumbnail() != null ? request.thumbnail() : store.getThumbnail();
+
+    store.updateInfo(name, description, phone, thumbnail);
     return StoreResponse.from(store);
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
@@ -1,9 +1,17 @@
 package com.example.WonkaoTalk.domain.store.service;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.dto.StoreCreateRequest;
+import com.example.WonkaoTalk.domain.store.dto.StoreResponse;
+import com.example.WonkaoTalk.domain.store.dto.StoreUpdateRequest;
+import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,5 +20,37 @@ public class StoreService {
 
   private final StoreRepo storeRepo;
 
+  @Transactional
+  public StoreResponse createStore(Seller seller, StoreCreateRequest request) {
+    storeRepo.findBySeller(seller).ifPresent(s -> {
+      throw new BusinessException(ErrorCode.STORE_EXISTS_ALREADY);
+    });
 
+    Store store = Store.builder()
+        .name(request.name())
+        .description(request.description())
+        .phone(request.phone())
+        .seller(seller)
+        .build();
+
+    Store savedStore = storeRepo.save(store);
+    return StoreResponse.from(savedStore);
+  }
+
+  @Transactional
+  public StoreResponse updateStore(Long sellerId, StoreUpdateRequest request) {
+    Store store = storeRepo.findBySellerId(sellerId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+    store.updateInfo(request.name(), request.description(), request.phone(), request.thumbnail());
+    return StoreResponse.from(store);
+  }
+
+  @Transactional
+  public void deleteStore(Long sellerId) {
+    Store store = storeRepo.findBySellerId(sellerId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+    store.deleteStore();
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.store.service;
 
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,5 +9,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class StoreService {
+
+  private final StoreRepo storeRepo;
+
 
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
@@ -26,6 +26,10 @@ public class StoreService {
       throw new BusinessException(ErrorCode.STORE_EXISTS_ALREADY);
     });
 
+    if (storeRepo.existsByName(request.name())) {
+      throw new BusinessException(ErrorCode.STORE_EXISTS_NAME);
+    }
+
     Store store = Store.builder()
         .name(request.name())
         .description(request.description())
@@ -38,8 +42,8 @@ public class StoreService {
   }
 
   @Transactional
-  public StoreResponse updateStore(Long sellerId, StoreUpdateRequest request) {
-    Store store = storeRepo.findBySellerId(sellerId)
+  public StoreResponse updateStore(Seller seller, StoreUpdateRequest request) {
+    Store store = storeRepo.findBySeller(seller)
         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
     store.updateInfo(request.name(), request.description(), request.phone(), request.thumbnail());
@@ -47,8 +51,8 @@ public class StoreService {
   }
 
   @Transactional
-  public void deleteStore(Long sellerId) {
-    Store store = storeRepo.findBySellerId(sellerId)
+  public void deleteStore(Seller seller) {
+    Store store = storeRepo.findBySeller(seller)
         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
     store.deleteStore();

--- a/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
@@ -41,6 +41,14 @@ public class StoreService {
     return StoreResponse.from(savedStore);
   }
 
+  @Transactional(readOnly = true)
+  public StoreResponse getStore(Seller seller) {
+    Store store = storeRepo.findBySeller(seller)
+        .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
+
+    return StoreResponse.from(store);
+  }
+
   @Transactional
   public StoreResponse updateStore(Seller seller, StoreUpdateRequest request) {
     Store store = storeRepo.findBySeller(seller)

--- a/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/service/StoreService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -30,10 +31,14 @@ public class StoreService {
       throw new BusinessException(ErrorCode.STORE_EXISTS_NAME);
     }
 
+    String thumbnail =
+        request.thumbnail() != null ? request.thumbnail() : "http://defaultThumbnail.png";
+    
     Store store = Store.builder()
         .name(request.name())
         .description(request.description())
         .phone(request.phone())
+        .thumbnail(thumbnail)
         .seller(seller)
         .build();
 
@@ -54,11 +59,16 @@ public class StoreService {
     Store store = storeRepo.findBySeller(seller)
         .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND));
 
-    String name = request.name() != null ? request.name() : store.getName();
+    if (storeRepo.existsByName(request.name())) {
+      throw new BusinessException(ErrorCode.STORE_EXISTS_NAME);
+    }
+
+    String name = StringUtils.hasText(request.name()) ? request.name() : store.getName();
     String description =
-        request.description() != null ? request.description() : store.getDescription();
-    String phone = request.phone() != null ? request.phone() : store.getPhone();
-    String thumbnail = request.thumbnail() != null ? request.thumbnail() : store.getThumbnail();
+        StringUtils.hasText(request.description()) ? request.description() : store.getDescription();
+    String phone = StringUtils.hasText(request.phone()) ? request.phone() : store.getPhone();
+    String thumbnail =
+        StringUtils.hasText(request.thumbnail()) ? request.thumbnail() : store.getThumbnail();
 
     store.updateInfo(name, description, phone, thumbnail);
     return StoreResponse.from(store);

--- a/src/test/java/com/example/WonkaoTalk/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/store/service/StoreServiceTest.java
@@ -1,0 +1,133 @@
+package com.example.WonkaoTalk.domain.store.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.dto.StoreCreateRequest;
+import com.example.WonkaoTalk.domain.store.dto.StoreResponse;
+import com.example.WonkaoTalk.domain.store.dto.StoreUpdateRequest;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+  @InjectMocks
+  private StoreService storeService;
+
+  @Mock
+  private StoreRepo storeRepo;
+
+  private Seller seller;
+  private Store store;
+
+  @BeforeEach
+  void setUp() {
+    Auth auth = Auth.builder().build();
+    seller = Seller.builder()
+        .buzNo("1234567890")
+        .name("사업자")
+        .phone("02-3456-7890")
+        .auth(auth)
+        .build();
+    ReflectionTestUtils.setField(seller, "id", 1L);
+
+    store = Store.builder()
+        .name("스토어1")
+        .description("설명")
+        .phone("02-1111-1111")
+        .thumbnail("기본 썸네일")
+        .seller(seller)
+        .build();
+    ReflectionTestUtils.setField(store, "id", 1L);
+  }
+
+  @Test
+  @DisplayName("스토어 생성 성공")
+  public void createStoreSuccess() {
+    //given
+    StoreCreateRequest request = new StoreCreateRequest("스토어", "설명", "02-3456-7890", "썸네일");
+
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.empty());
+    given(storeRepo.existsByName(request.name())).willReturn(false);
+
+    Store savedStore = Store.builder()
+        .name(request.name())
+        .description(request.description())
+        .phone(request.phone())
+        .thumbnail(request.thumbnail())
+        .seller(seller)
+        .build();
+    ReflectionTestUtils.setField(savedStore, "id", 2L);
+    given(storeRepo.save(any(Store.class))).willReturn(savedStore);
+
+    //when
+    StoreResponse response = storeService.createStore(seller, request);
+
+    //then
+    assertThat(response).isNotNull();
+    assertThat(response.name()).isEqualTo("스토어");
+    assertThat(response.sellerId()).isEqualTo(seller.getId());
+    verify(storeRepo).save(any(Store.class));
+  }
+
+  @Test
+  @DisplayName("스토어 조회 성공")
+  public void getStoreSuccess() {
+    // given
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.of(store));
+
+    // when
+    StoreResponse response = storeService.getStore(seller);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.name()).isEqualTo("스토어1");
+    assertThat(response.id()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("스토어 수정 성공")
+  public void updateStoreSuccess() {
+    // given
+    StoreUpdateRequest request = new StoreUpdateRequest("새 스토어", "새 설명", null, null);
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.of(store));
+
+    // when
+    StoreResponse response = storeService.updateStore(seller, request);
+
+    // then
+    assertThat(response.name()).isEqualTo("새 스토어");
+    assertThat(response.description()).isEqualTo("새 설명");
+    assertThat(response.phone()).isEqualTo("02-1111-1111");
+    assertThat(response.thumbnail()).isEqualTo("기본 썸네일");
+  }
+
+  @Test
+  @DisplayName("스토어 삭제(Soft Delete) 성공")
+  public void deleteStoreSuccess() {
+    // given
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.of(store));
+
+    // when
+    storeService.deleteStore(seller);
+
+    // then
+    assertThat(store.getName()).contains("삭제된 스토어");
+    assertThat(store.getDescription()).isEqualTo("DELETED");
+    assertThat(store.getPhone()).isEqualTo("000-0000-0000");
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #59 

## 📝 작업 내용
- 스토어 등록 시 중복 된 이름이 존재하는지 체크 후 예외 처리
- 정보 수정 시 requestBody의 빈 필드 값이 존재할 경우 기존 값으로 유지
- SecurityConfig 설정으로 SELLER 권한 소유자만 /stores엔드포인트 접근 가능하도록 설정
- 등록 / 수정 / 삭제 / 조회 기능 별 단위 테스트 코드 작성

## ✅ 작업 결과 
<img width="609" height="233" alt="image" src="https://github.com/user-attachments/assets/41df861a-0d14-4c97-88f4-ecb98d748605" />


## 🎸 기타

