### PR TITLE
Feat/53 주문 생성 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+### AI 문서 ###
+docs/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
@@ -1,14 +1,18 @@
 package com.example.WonkaoTalk.domain.order.controller;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
+import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,16 +23,15 @@ public class OrderController {
 
   private final OrderService orderService;
 
-//  @PostMapping
-//  public ResponseEntity<ApiResponse<Void>> createOrder(
-//      // Todo: 추후 진행
-//      @RequestHeader("X-User-Id") Long userId,
-//      @Valid @RequestBody OrderCreateRequest requestDto
-//  ) {
-//    orderService.createOrder(userId, requestDto);
-//    return ResponseEntity.status(HttpStatus.CREATED)
-//        .body(ApiResponse.success("주문이 생성되었습니다.", null));
-//  }
+  @PostMapping
+  public ResponseEntity<ApiResponse<OrderCreateResponse>> createOrder(
+      @RequestHeader("X-User-Id") Long userId,
+      @Valid @RequestBody OrderCreateRequest requestDto
+  ) {
+    OrderCreateResponse responseDto = orderService.createOrder(userId, requestDto);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success("주문이 생성되었습니다.", responseDto));
+  }
 
   @PostMapping("/preview")
   public ResponseEntity<ApiResponse<OrderPreviewResponse>> previewOrder(

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateRequest.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.order.dto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -13,7 +14,11 @@ public record OrderCreateRequest(
 
     @Valid
     @NotNull
-    DeliveryRequest delivery
+    DeliveryRequest delivery,
+
+    // TODO: 포인트 도메인 구현 후 보유 포인트/사용 정책 검증 추가
+    @Min(0)
+    Long pointUsedAmount
 ) {
 
   // 일단은 static으로 선언해서 사용. -> 아직은 해당 DTO에서만 사용하기때문..(요청의 일부)

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateRequest.java
@@ -1,9 +1,9 @@
 package com.example.WonkaoTalk.domain.order.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
@@ -18,6 +18,7 @@ public record OrderCreateRequest(
 
     // TODO: 포인트 도메인 구현 후 보유 포인트/사용 정책 검증 추가
     @Min(0)
+    @NotNull
     Long pointUsedAmount
 ) {
 
@@ -41,5 +42,6 @@ public record OrderCreateRequest(
       // 메모는 필수사항이 아님
       String memo
   ) {
+
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateResponse.java
@@ -1,11 +1,29 @@
 package com.example.WonkaoTalk.domain.order.dto;
 
 public record OrderCreateResponse(
-    Long orderId,
-    String orderNumber,
-    String orderTitle,
-    Long originalAmount,
-    Long discountAmount,
-    Long finalAmount
+    OrderCreateInfoDto orderInfo,
+    PaymentCreateInfoDto paymentInfo
 ) {
+
+  public record OrderCreateInfoDto(
+      Long orderId,
+      String orderNumber,
+      String orderTitle,
+      Long originalAmount,
+      Long discountAmount,
+      Long pointUsedAmount,
+      Long finalAmount
+  ) {
+
+  }
+
+  // Toss에 요청할때 사용할 정보 따로 뻄. (front에서 처리하기 쉽게하려고..)
+  public record PaymentCreateInfoDto(
+      Long paymentId,
+      String tossOrderId, // Memo: pgOrderId로 할까 고민중...
+      Long amount,
+      String orderName
+  ) {
+
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderPreviewResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderPreviewResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record OrderPreviewResponse(
     List<OrderPreviewItemDto> items,
     SummaryDto summary
+    // TODO: 사용 가능한 포인트 계산해서 같이 보내주기
 ) {
 
   public record OrderPreviewItemDto(
@@ -20,6 +21,7 @@ public record OrderPreviewResponse(
       Long itemDiscountAmount,
       Long itemFinalAmount
   ) {
+
   }
 
   public record SummaryDto(
@@ -27,5 +29,6 @@ public record OrderPreviewResponse(
       Long discountAmount,
       Long finalAmount
   ) {
+
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
@@ -1,15 +1,22 @@
 package com.example.WonkaoTalk.domain.order.entity;
 
+import com.example.WonkaoTalk.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -17,6 +24,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
 
   @Id
@@ -27,9 +36,9 @@ public class Order {
   @Column(name = "order_number", nullable = false)
   private String orderNumber;
 
-  @Column(name = "user_id")
-  // TODO: User Entity가 만들어 지면 타입 변경 필요
-  private Long userId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "order_status", nullable = false)
@@ -40,6 +49,9 @@ public class Order {
 
   @Column(name = "discount_amount")
   private Long discountAmount;
+
+  @Column(name = "point_used_amount", nullable = false)
+  private Long pointUsedAmount;
 
   @Column(name = "final_amount", nullable = false)
   private Long finalAmount;
@@ -58,20 +70,38 @@ public class Order {
 
   public static Order createOrder(
       String orderNumber,
-      Long userId,
+      User user,
       Long originalAmount,
       Long discountAmount,
+      Long pointUsedAmount,
       Long finalAmount,
       String orderTitle
   ) {
     Order order = new Order();
     order.orderNumber = orderNumber;
-    order.userId = userId;
+    order.user = user;
     order.orderStatus = OrderStatus.CREATED;
     order.originalAmount = originalAmount;
     order.discountAmount = discountAmount;
+    order.pointUsedAmount = pointUsedAmount;
     order.finalAmount = finalAmount;
     order.orderTitle = orderTitle;
     return order;
+  }
+
+  public void markPaymentPending() {
+    this.orderStatus = OrderStatus.PAYMENT_PENDING;
+  }
+
+  public void markPaid() {
+    this.orderStatus = OrderStatus.PAID;
+  }
+
+  public void markPaymentFailed() {
+    this.orderStatus = OrderStatus.PAYMENT_FAILED;
+  }
+
+  public void markPaymentCanceled() {
+    this.orderStatus = OrderStatus.PAYMENT_CANCELED;
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
@@ -44,10 +44,10 @@ public class Order {
   @Column(name = "order_status", nullable = false)
   private OrderStatus orderStatus;
 
-  @Column(name = "original_amount")
+  @Column(name = "original_amount", nullable = false)
   private Long originalAmount;
 
-  @Column(name = "discount_amount")
+  @Column(name = "discount_amount", nullable = false)
   private Long discountAmount;
 
   @Column(name = "point_used_amount", nullable = false)
@@ -64,9 +64,22 @@ public class Order {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
-  @Column(name = "title")
+  @Column(name = "title", nullable = false)
   // 주문 명 (xx외 2건)
   private String orderTitle;
+
+  private Order(String orderNumber, User user, OrderStatus orderStatus,
+      Long originalAmount, Long discountAmount, Long pointUsedAmount, Long finalAmount,
+      String orderTitle) {
+    this.orderNumber = orderNumber;
+    this.user = user;
+    this.orderStatus = orderStatus;
+    this.originalAmount = originalAmount;
+    this.discountAmount = discountAmount;
+    this.pointUsedAmount = pointUsedAmount;
+    this.finalAmount = finalAmount;
+    this.orderTitle = orderTitle;
+  }
 
   public static Order createOrder(
       String orderNumber,
@@ -77,16 +90,16 @@ public class Order {
       Long finalAmount,
       String orderTitle
   ) {
-    Order order = new Order();
-    order.orderNumber = orderNumber;
-    order.user = user;
-    order.orderStatus = OrderStatus.CREATED;
-    order.originalAmount = originalAmount;
-    order.discountAmount = discountAmount;
-    order.pointUsedAmount = pointUsedAmount;
-    order.finalAmount = finalAmount;
-    order.orderTitle = orderTitle;
-    return order;
+    return new Order(
+        orderNumber,
+        user,
+        OrderStatus.CREATED,
+        originalAmount,
+        discountAmount,
+        pointUsedAmount,
+        finalAmount,
+        orderTitle
+    );
   }
 
   public void markPaymentPending() {

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
@@ -33,7 +33,7 @@ public class Order {
   @Column(name = "order_id")
   private Long orderId;
 
-  @Column(name = "order_number", nullable = false)
+  @Column(name = "order_number", nullable = false, unique = true)
   private String orderNumber;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/OrderStatus.java
@@ -1,8 +1,11 @@
 package com.example.WonkaoTalk.domain.order.entity;
 
 public enum OrderStatus {
-  CREATED,
-  PAID,
-  CANCELED,
-  COMPLETED
+  CREATED,            // 주문 생성됨, 아직 결제 시도 전 또는 결제 준비 상태
+  PAYMENT_PENDING,    // PG 결제창 진행 중
+  PAID,               // 결제 완료
+  PAYMENT_FAILED,     // 결제 실패
+  PAYMENT_CANCELED,   // 사용자가 결제창에서 취소
+  CANCELED,           // 결제 완료 후 주문 취소
+  COMPLETED           // 구매 확정 또는 주문 완료
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderRepo.java
@@ -4,4 +4,6 @@ import com.example.WonkaoTalk.domain.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepo extends JpaRepository<Order, Long> {
+
+  boolean existsByOrderNumber(String orderNumber);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -39,7 +39,7 @@ public class OrderService {
 
   private final UserRepo userRepo;
 
-  private final ProductVariantRepo productVariantRepository;
+  private final ProductVariantRepo productVariantRepo;
   private final OrderRepo orderRepo;
 
   private final PaymentService paymentService;

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -3,19 +3,27 @@ package com.example.WonkaoTalk.domain.order.service;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
+import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.OrderPreviewItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.SummaryDto;
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.service.PaymentService;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
-import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepository;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,14 +35,103 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class OrderService {
 
-  private final ProductVariantRepository productVariantRepository;
+  private final UserRepo userRepo;
+
+  private final ProductVariantRepo productVariantRepository;
+  private final OrderRepo orderRepo;
+
+  private final PaymentService paymentService;
 
   // 주문 생성 로직 작성
   // 응답값으로 Order로 생성 요청한 값들의 성공적으로 생성 되었는지만 전달해주면됨.
   // 주문 생성 시 재고 차감 진행. 만약 주문이 실패로 끝나면 재고 원상복귀.
-  public void createOrder(Long userId,
-      OrderCreateRequest dto) {
-    // 주문 번호 생
+  @Transactional(rollbackFor = BusinessException.class)
+  public OrderCreateResponse createOrder(Long userId,
+      OrderCreateRequest requestDto) {
+    // 유저 정보 검색
+    User user = userRepo.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+    // 1. variantId 중복 검증
+    validateDuplicateVariant(requestDto.items());
+
+    // 2. ProductVariant 조회
+    List<Long> requestVariantIds = extractVariantIds(requestDto.items());
+    Map<Long, ProductVariant> productVariants = findVariantMapByIds(requestVariantIds);
+
+    // 3. 조회하지 않는 variantId 검증 에러처리
+    validateVariantExist(requestVariantIds, productVariants);
+
+    // 4. 판매자 상태 확인 -> 지금은 그냥 하드코딩 더미데이터로 해결하기
+    validateSellerStatus();
+
+    // 추가. 상품 상태 확인
+    validateVariantSaleStatus(productVariants);
+
+    // 5. 재고 상태 확인 (요청 수량에 맞게 주문할 수 있는지)
+    validateVariantStock(requestDto.items(), productVariants);
+    // TODO: 재고 감소로직 있어야함. (임시 컬럼만들어서 진행하던지 뭘 하던지 할듯..)
+
+    // 7. 주문 금액 계산 -> 금액 계산위해 item 생성
+    List<OrderPreviewItemDto> orderItems = createOrderPreviewItems(requestDto.items(),
+        productVariants);
+
+    SummaryDto summaryDto = createSummary(orderItems);
+
+    // 8. 포인트 사용 금액 검증
+    // TODO: 포인트 도메인 구현 전까지 pointUsedAmount는 0만 허용하거나 0으로 처리
+    Long pointUsedAmount = 0L;
+//    Long pointUsedAmount = requestDto.pointUsedAmount() == 0 ? 0L : requestDto.pointUsedAmount();
+    // TODO : 포인트 값 차감시키기.
+
+    // 9. Order 생성
+    String orderNumber = generateOrderNumber();
+    String orderTitle = generateOrderTitle(orderItems);
+
+    Order order = Order.createOrder(
+        orderNumber,
+        user,
+        summaryDto.originalAmount(),
+        summaryDto.discountAmount(),
+        pointUsedAmount,
+        summaryDto.finalAmount(),
+        orderTitle
+    );
+
+    // 주문 생성완료 + 결제 대기상태
+    order.markPaymentPending();
+
+    // 이렇게 객체 새로 생성해서 부여하는 방식이 옳은 방식일지 고민해볼 필요 있을듯
+    Order savedOrder = orderRepo.save(order);
+
+    // TODO: Delivery 생성
+
+    // 12. Payment 생성
+    // status = READY
+    // tossOrderId 생성
+    // idempotencyKey 생성
+    // totalAmount = order.finalAmount
+    Payment payment = paymentService.createReadyPayment(savedOrder);
+
+    // 13. 주문 생성 응답 반환
+    // orderId, orderNumber, paymentId, tossOrderId, amount, orderName
+    return new OrderCreateResponse(
+        new OrderCreateResponse.OrderCreateInfoDto(
+            savedOrder.getOrderId(),
+            savedOrder.getOrderNumber(),
+            savedOrder.getOrderTitle(),
+            savedOrder.getOriginalAmount(),
+            savedOrder.getDiscountAmount(),
+            savedOrder.getPointUsedAmount(),
+            savedOrder.getFinalAmount()
+        ),
+        new OrderCreateResponse.PaymentCreateInfoDto(
+            payment.getPaymentId(),
+            payment.getTossOrderId(),
+            payment.getTotalAmount(),
+            savedOrder.getOrderTitle()
+        )
+    );
   }
 
   // 이때는 결제가 이루어지지 않기때문에 재고 조회에 대한 lock을 크게 고려하지 않아도 될듯.
@@ -191,6 +288,20 @@ public class OrderService {
     long finalAmount = originalAmount - discountAmount;
 
     return new SummaryDto(originalAmount, discountAmount, finalAmount);
+  }
+
+  // 주문 번호 생성
+  private String generateOrderNumber() {
+    return "ORD-" + UUID.randomUUID();
+  }
+
+  // 주문 제목 생성
+  private String generateOrderTitle(List<OrderPreviewItemDto> items) {
+    if (items.size() == 1) {
+      return items.getFirst().productName();
+    }
+
+    return items.getFirst().productName() + " 외 " + (items.size() - 1) + "건";
   }
 
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -19,6 +19,8 @@ import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
 import com.example.WonkaoTalk.domain.user.entity.User;
 import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +87,7 @@ public class OrderService {
     // TODO : 포인트 값 차감시키기.
 
     // 9. Order 생성
-    String orderNumber = generateOrderNumber();
+    String orderNumber = generateUniqueOrderNumber();
     String orderTitle = generateOrderTitle(orderItems);
 
     Order order = Order.createOrder(
@@ -292,7 +294,23 @@ public class OrderService {
 
   // 주문 번호 생성
   private String generateOrderNumber() {
-    return "ORD-" + UUID.randomUUID();
+    String timestamp = LocalDateTime.now()
+        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
+
+    String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6).toUpperCase();
+    return "ORD-" + timestamp + "-" + uuid;
+  }
+
+  // 주문번호 unique 검증
+  private String generateUniqueOrderNumber() {
+    for (int i = 0; i < 5; i++) {
+      String orderNumber = generateOrderNumber();
+
+      if (!orderRepo.existsByOrderNumber(orderNumber)) {
+        return orderNumber;
+      }
+    }
+    throw new BusinessException(ErrorCode.SERVER_ERROR);
   }
 
   // 주문 제목 생성

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/entity/Payment.java
@@ -95,7 +95,8 @@ public class Payment {
       Order order,
       String tossOrderId,
       String idempotencyKey,
-      Long totalAmount
+      Long totalAmount,
+      LocalDateTime requestAt
   ) {
     return new Payment(
         order,
@@ -104,7 +105,7 @@ public class Payment {
         idempotencyKey,
         totalAmount,
         PaymentStatus.READY,
-        LocalDateTime.now()
+        requestAt
     );
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/entity/Payment.java
@@ -1,0 +1,130 @@
+package com.example.WonkaoTalk.domain.payment.entity;
+
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Payment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "payment_id")
+  private Long paymentId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id", nullable = false)
+  private Order order;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "pg_provider", nullable = false)
+  private PgProvider pgProvider;
+
+  @Column(name = "toss_order_id", nullable = false, unique = true)
+  private String tossOrderId;
+
+  @Column(name = "payment_key", unique = true)
+  private String paymentKey;
+
+  @Column(name = "idempotency_key", nullable = false, unique = true)
+  private String idempotencyKey;
+
+  @Column(name = "total_amount", nullable = false)
+  private Long totalAmount;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private PaymentStatus status;
+
+  @Column(name = "fail_code")
+  private String failCode;
+
+  @Column(name = "fail_message")
+  private String failMessage;
+
+  @Column(nullable = false)
+  private LocalDateTime requestedAt;
+
+  @Column(name = "approved_at")
+  private LocalDateTime approvedAt;
+
+  @Column(name = "failed_at")
+  private LocalDateTime failedAt;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  public static Payment createReadyPayment(
+      Order order,
+      String tossOrderId,
+      String idempotencyKey,
+      Long totalAmount
+  ) {
+    Payment payment = new Payment();
+    payment.order = order;
+    payment.pgProvider = PgProvider.TOSS_PAYMENTS;
+    payment.tossOrderId = tossOrderId;
+    payment.idempotencyKey = idempotencyKey;
+    payment.totalAmount = totalAmount;
+    payment.status = PaymentStatus.READY;
+    payment.requestedAt = LocalDateTime.now();
+    return payment;
+  }
+
+  public void markPending() {
+    this.status = PaymentStatus.PENDING;
+  }
+
+  public void markPaid(String paymentKey) {
+    this.paymentKey = paymentKey;
+    this.status = PaymentStatus.PAID;
+    this.approvedAt = LocalDateTime.now();
+  }
+
+  public void markFailed(String failCode, String failMessage) {
+    this.failCode = failCode;
+    this.failMessage = failMessage;
+    this.status = PaymentStatus.FAILED;
+    this.failedAt = LocalDateTime.now();
+  }
+
+  public void markCanceled(String failCode, String failMessage) {
+    this.failCode = failCode;
+    this.failMessage = failMessage;
+    this.status = PaymentStatus.CANCELED;
+    this.failedAt = LocalDateTime.now();
+  }
+
+  public void markInvalid(String failCode, String failMessage) {
+    this.failCode = failCode;
+    this.failMessage = failMessage;
+    this.status = PaymentStatus.INVALID;
+    this.failedAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/entity/Payment.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/entity/Payment.java
@@ -63,7 +63,7 @@ public class Payment {
   @Column(name = "fail_message")
   private String failMessage;
 
-  @Column(nullable = false)
+  @Column(name = "requested_at", nullable = false)
   private LocalDateTime requestedAt;
 
   @Column(name = "approved_at")
@@ -80,21 +80,32 @@ public class Payment {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
+  private Payment(Order order, PgProvider pgProvider, String tossOrderId, String idempotencyKey,
+      Long totalAmount, PaymentStatus status, LocalDateTime requestedAt) {
+    this.order = order;
+    this.pgProvider = pgProvider;
+    this.tossOrderId = tossOrderId;
+    this.idempotencyKey = idempotencyKey;
+    this.totalAmount = totalAmount;
+    this.status = status;
+    this.requestedAt = requestedAt;
+  }
+
   public static Payment createReadyPayment(
       Order order,
       String tossOrderId,
       String idempotencyKey,
       Long totalAmount
   ) {
-    Payment payment = new Payment();
-    payment.order = order;
-    payment.pgProvider = PgProvider.TOSS_PAYMENTS;
-    payment.tossOrderId = tossOrderId;
-    payment.idempotencyKey = idempotencyKey;
-    payment.totalAmount = totalAmount;
-    payment.status = PaymentStatus.READY;
-    payment.requestedAt = LocalDateTime.now();
-    return payment;
+    return new Payment(
+        order,
+        PgProvider.TOSS_PAYMENTS,
+        tossOrderId,
+        idempotencyKey,
+        totalAmount,
+        PaymentStatus.READY,
+        LocalDateTime.now()
+    );
   }
 
   public void markPending() {

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,10 @@
+package com.example.WonkaoTalk.domain.payment.entity;
+
+public enum PaymentStatus {
+  READY,
+  PENDING,
+  PAID,
+  FAILED,
+  CANCELED,
+  INVALID
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/entity/PgProvider.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/entity/PgProvider.java
@@ -1,0 +1,5 @@
+package com.example.WonkaoTalk.domain.payment.entity;
+
+public enum PgProvider {
+  TOSS_PAYMENTS
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.payment.repo;
+
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepo extends JpaRepository<Payment, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
@@ -1,0 +1,44 @@
+package com.example.WonkaoTalk.domain.payment.service;
+
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentService {
+
+  private final PaymentRepo paymentRepo;
+
+  // 주문 생성
+  public Payment createReadyPayment(Order order) {
+    // 토스 주문 번호 만들기
+    String tossOrderId = generateTossOrderId(order.getOrderNumber());
+
+    // 멱등키 만들기
+    String idempotencyKey = generateIdempotencyKey();
+
+    Payment payment = Payment.createReadyPayment(
+        order,
+        tossOrderId,
+        idempotencyKey,
+        order.getFinalAmount()
+    );
+
+    return paymentRepo.save(payment);
+
+  }
+
+  private String generateTossOrderId(String orderNumber) {
+    return orderNumber + "-PAY-" + UUID.randomUUID();
+  }
+
+  private String generateIdempotencyKey() {
+    return UUID.randomUUID().toString();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.payment.service;
 import com.example.WonkaoTalk.domain.order.entity.Order;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
 import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,11 +24,14 @@ public class PaymentService {
     // 멱등키 만들기
     String idempotencyKey = generateIdempotencyKey();
 
+    LocalDateTime requestAt = LocalDateTime.now();
+
     Payment payment = Payment.createReadyPayment(
         order,
         tossOrderId,
         idempotencyKey,
-        order.getFinalAmount()
+        order.getFinalAmount(),
+        requestAt
     );
 
     return paymentRepo.save(payment);

--- a/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,49 @@
+package com.example.WonkaoTalk.domain.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
+import com.example.WonkaoTalk.domain.payment.entity.PgProvider;
+import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentServiceTest {
+
+  @Mock
+  private PaymentRepo paymentRepo;
+
+  @InjectMocks
+  private PaymentService paymentService;
+
+  @Test
+  @DisplayName("결제 준비 Payment를 READY 상태로 생성한다.")
+  public void createReadyPayment_CreatePaymentWithReadyStatus() {
+    //given
+    Order order = mock(Order.class);
+    when(order.getOrderNumber()).thenReturn("ORD-1234");
+    when(order.getFinalAmount()).thenReturn(35000L);
+    when(paymentRepo.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    //when
+    Payment payment = paymentService.createReadyPayment(order);
+
+    //then
+    assertThat(payment.getOrder()).isEqualTo(order);
+    assertThat(payment.getPgProvider()).isEqualTo(PgProvider.TOSS_PAYMENTS);
+    assertThat(payment.getTossOrderId()).startsWith("ORD-1234-PAY-");
+    assertThat(payment.getIdempotencyKey()).isNotBlank();
+    assertThat(payment.getTotalAmount()).isEqualTo(35000L);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #53 

## 📝 작업 내용
- 주문 생성
- Payment 생성
- - Payment Entity, repo, Service 생성
- 주문 생성 시 로직
1. Order 생성 -> PaymentReady 상태
2. Payment 생성 -> Pending 상태
3. Client에  tossOrderId, amount, orderName 반환

## ✅ 작업 결과 
- 주문서 생성에서 이미 테스트한 로직들이 많아 True 테스트 1건만 추가
<img width="1275" height="275" alt="image" src="https://github.com/user-attachments/assets/27ac1f3d-89f1-473e-8e4d-b9a0430dd294" />

## 🎸 기타

- close #53 
