### PR TITLE
feat: 판매자 정보 조회 / 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
@@ -6,8 +6,10 @@ import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.seller.dto.SellerRegisterRequest;
+import com.example.WonkaoTalk.domain.seller.dto.SellerResponse;
 import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpRequest;
 import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpResponse;
+import com.example.WonkaoTalk.domain.seller.dto.SellerUpdateRequest;
 import com.example.WonkaoTalk.domain.seller.service.SellerService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -49,6 +53,25 @@ public class SellerController {
     SellerSignUpResponse response = sellerService.registerSeller(authId, request);
 
     return ResponseEntity.ok(ApiResponse.success("판매자 등록이 완료되었습니다.", response));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<SellerResponse>> getMySellerInfo(
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    SellerResponse response = sellerService.getSellerInfo(userDetails.getSellerId());
+
+    return ResponseEntity.ok(ApiResponse.success("판매자 정보를 조회했습니다.", response));
+  }
+
+  @PatchMapping
+  public ResponseEntity<ApiResponse<SellerResponse>> updateMyInfo(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody SellerUpdateRequest request
+  ) {
+    SellerResponse response = sellerService.updateSellerInfo(userDetails.getSellerId(), request);
+
+    return ResponseEntity.ok(ApiResponse.success("판매자 정보 수정이 완료되었습니다.", response));
   }
 
   @DeleteMapping("/withdraw")

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerRegisterRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerRegisterRequest.java
@@ -2,6 +2,7 @@ package com.example.WonkaoTalk.domain.seller.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
@@ -12,10 +13,12 @@ public record SellerRegisterRequest(
         message = "사업자 번호는 숫자 10자리여야 합니다."
     ) String buzNo,
 
+    @Size(max = 50)
     @NotBlank(message = "사업장명은 필수입니다.")
     String name,
 
     @NotBlank(message = "사업장 연락처는 필수입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$")
     String phone
 ) {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerResponse.java
@@ -1,0 +1,22 @@
+package com.example.WonkaoTalk.domain.seller.dto;
+
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import lombok.Builder;
+
+@Builder
+public record SellerResponse(
+    Long sellerId,
+    String name,
+    String phone,
+    String buzNo
+) {
+
+  public static SellerResponse from(Seller seller) {
+    return SellerResponse.builder()
+        .sellerId(seller.getId())
+        .name(seller.getName())
+        .phone(seller.getPhone())
+        .buzNo(seller.getBuzNo())
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerSignUpRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerSignUpRequest.java
@@ -2,6 +2,7 @@ package com.example.WonkaoTalk.domain.seller.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
@@ -27,10 +28,12 @@ public record SellerSignUpRequest(
         message = "사업자 번호는 숫자 10자리여야 합니다."
     ) String buzNo,
 
+    @Size(max = 50)
     @NotBlank(message = "사업장명은 필수입니다.")
     String name,
 
     @NotBlank(message = "사업장 연락처는 필수입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$")
     String phone
 
 ) {

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerUpdateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.seller.dto;
+
+public record SellerUpdateRequest(
+    String name,
+    String phone
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerUpdateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerUpdateRequest.java
@@ -1,7 +1,13 @@
 package com.example.WonkaoTalk.domain.seller.dto;
 
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record SellerUpdateRequest(
+    @Size(max = 50)
     String name,
+
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$")
     String phone
 ) {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/entity/Seller.java
@@ -69,4 +69,9 @@ public class Seller {
     this.phone = "000-0000-0000";
     this.deletedAt = LocalDateTime.now();
   }
+
+  public void update(String name, String phone) {
+    this.name = name;
+    this.phone = phone;
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/service/SellerService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/service/SellerService.java
@@ -7,14 +7,17 @@ import com.example.WonkaoTalk.domain.auth.enums.Role;
 import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
 import com.example.WonkaoTalk.domain.seller.dto.SellerRegisterRequest;
+import com.example.WonkaoTalk.domain.seller.dto.SellerResponse;
 import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpRequest;
 import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpResponse;
+import com.example.WonkaoTalk.domain.seller.dto.SellerUpdateRequest;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerService {
 
   private final AuthService authService;
-  private final AuthRepo authRepo;
+  private final AuthRepo authRepo; //TODO: authRepo 의존성 제거
   private final SellerRepo sellerRepo;
 
   @Transactional
@@ -74,6 +77,25 @@ public class SellerService {
     sellerRepo.save(seller);
 
     return SellerSignUpResponse.of(seller, auth.getRole());
+  }
+
+  @Transactional(readOnly = true)
+  public SellerResponse getSellerInfo(Long sellerId) {
+    Seller seller = findSeller(sellerId);
+
+    return SellerResponse.from(seller);
+  }
+
+  @Transactional
+  public SellerResponse updateSellerInfo(Long sellerId, SellerUpdateRequest request) {
+    Seller seller = findSeller(sellerId);
+
+    String name = StringUtils.hasText(request.name()) ? request.name() : seller.getName();
+    String phone = StringUtils.hasText(request.phone()) ? request.phone() : seller.getPhone();
+
+    seller.update(name, phone);
+
+    return SellerResponse.from(seller);
   }
 
   @Transactional

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/service/SellerService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/service/SellerService.java
@@ -81,6 +81,9 @@ public class SellerService {
 
   @Transactional(readOnly = true)
   public SellerResponse getSellerInfo(Long sellerId) {
+    if (sellerId == null) {
+      throw new BusinessException(ErrorCode.SELLER_NOT_FOUND);
+    }
     Seller seller = findSeller(sellerId);
 
     return SellerResponse.from(seller);
@@ -88,6 +91,9 @@ public class SellerService {
 
   @Transactional
   public SellerResponse updateSellerInfo(Long sellerId, SellerUpdateRequest request) {
+    if (sellerId == null) {
+      throw new BusinessException(ErrorCode.SELLER_NOT_FOUND);
+    }
     Seller seller = findSeller(sellerId);
 
     String name = StringUtils.hasText(request.name()) ? request.name() : seller.getName();

--- a/src/test/java/com/example/WonkaoTalk/domain/seller/service/SellerServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/seller/service/SellerServiceTest.java
@@ -10,16 +10,20 @@ import com.example.WonkaoTalk.domain.auth.enums.Role;
 import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
 import com.example.WonkaoTalk.domain.seller.dto.SellerRegisterRequest;
+import com.example.WonkaoTalk.domain.seller.dto.SellerResponse;
 import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpRequest;
+import com.example.WonkaoTalk.domain.seller.dto.SellerUpdateRequest;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class SellerServiceTest {
@@ -34,6 +38,18 @@ class SellerServiceTest {
   @Mock
   private AuthService authService;
 
+  private Seller seller;
+
+  @BeforeEach
+  void setUp() {
+    seller = Seller.builder()
+        .name("침착맨스토어")
+        .phone("02-3456-7890")
+        .buzNo("1234567890")
+        .build();
+    ReflectionTestUtils.setField(seller, "id", 1L);
+  }
+
   @Test
   @DisplayName("기존 사용자의 판매자 등록 성공")
   public void registerSellerSuccess() {
@@ -41,7 +57,7 @@ class SellerServiceTest {
     Long authId = 1L;
     SellerRegisterRequest request = SellerRegisterRequest.builder()
         .buzNo("1234567890")
-        .name("Store1")
+        .name("판매자1")
         .phone("010-1234-5678")
         .build();
 
@@ -68,8 +84,9 @@ class SellerServiceTest {
     SellerSignUpRequest request = SellerSignUpRequest.builder()
         .email("test@gmail.com")
         .password("Qwer1234")
+        .passwordCheck("Qwer1234")
         .buzNo("1234567890")
-        .name("Store1")
+        .name("판매자1")
         .phone("010-1234-5678")
         .build();
 
@@ -91,4 +108,34 @@ class SellerServiceTest {
 
   }
 
+  @Test
+  @DisplayName("판매자 정보 조회 성공")
+  public void getMySellerInfoSuccess() {
+    //given
+    given(sellerRepo.findById(1L)).willReturn(Optional.of(seller));
+
+    //when
+    SellerResponse response = sellerService.getSellerInfo(1L);
+
+    //then
+    assertThat(response.sellerId()).isEqualTo(1L);
+    assertThat(response.name()).isEqualTo("침착맨스토어");
+    assertThat(response.buzNo()).isEqualTo("1234567890");
+  }
+
+  @Test
+  @DisplayName("판매자 정보 수정 성공")
+  public void updateSellerInfoSuccess() {
+    //given
+    SellerUpdateRequest request = new SellerUpdateRequest("이병건스토어", "010-1111-1111");
+    given(sellerRepo.findById(1L)).willReturn(Optional.of(seller));
+
+    //when
+    SellerResponse response = sellerService.updateSellerInfo(1L, request);
+
+    //then
+    assertThat(response.sellerId()).isEqualTo(1L);
+    assertThat(response.name()).isEqualTo("이병건스토어");
+    assertThat(response.phone()).isEqualTo("010-1111-1111");
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #67 

## 📝 작업 내용
- 판매자 정보 조회 / 수정 로직 작성
- SellerController 엔드포인트 추가
- Service코드 성공 case 단위 테스트 작성

## ✅ 작업 결과 
<img width="610" height="235" alt="image" src="https://github.com/user-attachments/assets/1a862d61-d5f4-4ecc-bcd1-752ac289e6d9" />

## 🎸 기타
사용자 정보 조회 / 수정이랑 동일한 코드입니다.
작성하다가 확인해보니 SellerService에도 auth도메인 의존성이 있어서 나중에 의존성 해결 TODO 추가했습니다.
