### PR TITLE
faet: 사용자 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
   // 유저 도메인
   USER_NOT_FOUND(404, "USER-NOT-FOUND-ID", "해당 사용자 ID를 찾을 수 없습니다."),
+  USER_SELF_REF(400, "USER-SELF-REF", "자기 자신을 참조 할 수 없습니다."),
   // 친구 도메인
   FRND_SELF_REF(400, "FRND-SELF-REF", "자기 자신을 참조 할 수 없습니다."),
   FRND_REGISTERED_ALREADY(400, "FRND-REGISTERED-ALREADY", "이미 친구로 등록된 사용자입니다."),

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
   // 유저 도메인
   USER_NOT_FOUND(404, "USER-NOT-FOUND-ID", "해당 사용자 ID를 찾을 수 없습니다."),
   USER_SELF_REF(400, "USER-SELF-REF", "자기 자신을 참조 할 수 없습니다."),
+  USER_REGISTERED_PHONE(409, "USER-REGISTERED-PHONE", "이미 등록 된 전화번호입니다."),
   // 친구 도메인
   FRND_SELF_REF(400, "FRND-SELF-REF", "자기 자신을 참조 할 수 없습니다."),
   FRND_REGISTERED_ALREADY(400, "FRND-REGISTERED-ALREADY", "이미 친구로 등록된 사용자입니다."),

--- a/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
@@ -6,6 +6,8 @@ import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.user.dto.UserResponse;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchRequest;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpRequest;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserUpdateRequest;
@@ -74,6 +76,17 @@ public class UserController {
     accountWithdraw.withdrawUser(userDetails.getAuthId(), userDetails.getUsername(), accessToken);
 
     return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", null));
+  }
+
+  @PostMapping("/search")
+  public ResponseEntity<ApiResponse<UserSearchResponse>> searchUserByPhone(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody UserSearchRequest request
+  ) {
+    UserSearchResponse response = userService.findUserByPhone(userDetails.getUserId(),
+        request.phone());
+
+    return ResponseEntity.ok(ApiResponse.success("사용자 검색이 완료되었습니다.", response));
   }
 
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchRequest.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UserSearchRequest(
+    @NotBlank
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호를 입력해주세요.")
     String phone
 ) {

--- a/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record UserSearchRequest(
     @NotBlank
-    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호를 입력해주세요.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식(000-0000-0000)이 아닙니다.")
     String phone
 ) {
 

--- a/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchRequest.java
@@ -1,0 +1,10 @@
+package com.example.WonkaoTalk.domain.user.dto;
+
+import jakarta.validation.constraints.Pattern;
+
+public record UserSearchRequest(
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호를 입력해주세요.")
+    String phone
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSearchResponse.java
@@ -1,0 +1,21 @@
+package com.example.WonkaoTalk.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserSearchResponse(
+    Long userId,
+    String phone,
+    String nickname,
+    String image
+) {
+
+  public static UserSearchResponse of(Long userId, String phone, String nickname, String image) {
+    return UserSearchResponse.builder()
+        .userId(userId)
+        .phone(phone)
+        .nickname(nickname)
+        .image(image)
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
@@ -56,7 +56,7 @@ public class User {
   @Column(nullable = false)
   private String name;
 
-  @Column(nullable = false, length = 13)
+  @Column(nullable = false, length = 13, unique = true)
   private String phone;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
@@ -19,6 +19,8 @@ public interface UserRepo extends JpaRepository<User, Long> {
 
   boolean existsByAuthId(Long authId);
 
+  boolean existByPhone(String phone);
+
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT u FROM User u WHERE u.id = :userId")
   Optional<User> findByIdForUpdate(@Param("userId") Long userId);

--- a/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
@@ -15,6 +15,8 @@ public interface UserRepo extends JpaRepository<User, Long> {
 
   Optional<User> findByAuthId(Long authId);
 
+  Optional<User> findByPhone(String phone);
+
   boolean existsByAuthId(Long authId);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/repo/UserRepo.java
@@ -19,7 +19,7 @@ public interface UserRepo extends JpaRepository<User, Long> {
 
   boolean existsByAuthId(Long authId);
 
-  boolean existByPhone(String phone);
+  boolean existsByPhone(String phone);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT u FROM User u WHERE u.id = :userId")

--- a/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
 import com.example.WonkaoTalk.domain.user.dto.UserResponse;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpRequest;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserUpdateRequest;
@@ -88,5 +89,18 @@ public class UserService {
     return userRepo.existsByAuthId(authId);
   }
 
+  @Transactional(readOnly = true)
+  public UserSearchResponse findUserByPhone(Long userId, String phone) {
+    User targetUser = userRepo.findByPhone(phone)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+    if (targetUser.getId().equals(userId)) {
+      throw new BusinessException(ErrorCode.USER_SELF_REF);
+    }
+
+    return UserSearchResponse.of(targetUser.getId(), targetUser.getPhone(),
+        targetUser.getNickname(),
+        targetUser.getImage());
+  }
 
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
@@ -34,6 +34,10 @@ public class UserService {
       throw new BusinessException(ErrorCode.AUTH_MISMATCH_PASSWORD);
     }
 
+    if (userRepo.existByPhone(request.phone())) {
+      throw new BusinessException(ErrorCode.USER_REGISTERED_PHONE);
+    }
+
     Auth auth = authService.createAuthLocal(request.email(), request.password(), Role.USER);
 
     User user = User.builder()

--- a/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
       throw new BusinessException(ErrorCode.AUTH_MISMATCH_PASSWORD);
     }
 
-    if (userRepo.existByPhone(request.phone())) {
+    if (userRepo.existsByPhone(request.phone())) {
       throw new BusinessException(ErrorCode.USER_REGISTERED_PHONE);
     }
 

--- a/src/test/java/com/example/WonkaoTalk/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/user/service/UserServiceTest.java
@@ -10,6 +10,8 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
 import com.example.WonkaoTalk.domain.user.dto.UserResponse;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchRequest;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpRequest;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserUpdateRequest;
@@ -111,5 +113,32 @@ class UserServiceTest {
     assertThat(response.marketingAgree()).isTrue();
     assertThat(user.getNickname()).isEqualTo("침병건");
     assertThat(user.isMarketingAgree()).isTrue();
+  }
+
+  @Test
+  @DisplayName("사용자 정보 검색 성공")
+  public void searchUserByPhoneSuccess() {
+    //given
+    User targetUser = User.builder()
+        .nickname("통닭천사")
+        .name("이병건")
+        .phone("010-2222-2222")
+        .image("default.png")
+        .gender(Gender.FEMALE)
+        .birthDate(LocalDate.of(2001, 4, 13))
+        .marketingAgree(false)
+        .build();
+    ReflectionTestUtils.setField(targetUser, "id", 2L);
+
+    UserSearchRequest request = new UserSearchRequest("010-2222-2222");
+    given(userRepo.findByPhone(request.phone())).willReturn(Optional.of(targetUser));
+
+    //when
+    UserSearchResponse response = userService.findUserByPhone(user.getId(), request.phone());
+
+    //then
+    assertThat(response.userId()).isEqualTo(2L);
+    assertThat(response.nickname()).isEqualTo("통닭천사");
+    assertThat(response.phone()).isEqualTo("010-2222-2222");
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #73 

## 📝 작업 내용
- 사용자 검색 로직 작성
- 전화번호 유니크 제약조건 추가
- 회원가입 시 전화번호 중복 검사 로직 추가
- 사용자 검색 단위 테스트 작성

## ✅ 작업 결과 
<img width="660" height="170" alt="image" src="https://github.com/user-attachments/assets/87c8f0e7-aae4-43e7-887b-8c960f3b0e44" />


## 🎸 기타
원래 이메일로 검색기능을 하려다가 User도메인 내부에서 해결하려고 전화번호에 유니크 제약을 추가해서 전화번호로 사용자 검색을 하도록 만들었습니다.
