### PR TITLE
refactor: 상품 목록 조회시 상태가 STOP_SALE인 상품은 표시되지 않도록 수정

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -81,6 +81,6 @@ public class Product {
   private LocalDateTime deletedAt;
 
   public boolean isOnSale() {
-    return this.status == SaleStatus.ON_SALE;
+    return this.deletedAt == null && this.status == SaleStatus.ON_SALE;
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
@@ -42,6 +42,7 @@ public class ProductRepoCustomImpl implements ProductRepoCustom {
 
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.isNull(p.get("deletedAt")));
+    predicates.add(cb.notEqual(p.get("status"), SaleStatus.STOP_SALE));
 
     p.fetch("store", JoinType.LEFT);
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
@@ -42,7 +42,7 @@ public class ProductRepoCustomImpl implements ProductRepoCustom {
 
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.isNull(p.get("deletedAt")));
-    predicates.add(cb.notEqual(p.get("status"), SaleStatus.STOP_SALE));
+    predicates.add(p.get("status").in(SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK));
 
     p.fetch("store", JoinType.LEFT);
 
@@ -87,7 +87,7 @@ public class ProductRepoCustomImpl implements ProductRepoCustom {
 
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.isNull(p.get("deletedAt")));
-    predicates.add(cb.notEqual(p.get("status"), SaleStatus.STOP_SALE));
+    predicates.add(p.get("status").in(SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK));
 
     p.fetch("store", JoinType.LEFT);
     // TODO: ElasticSearch 등 검색 엔진 도입 시 동의어(예: 레드-빨강) 처리 및 스코어 기반 정렬로 교체 필요

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
@@ -410,13 +410,15 @@ class CartServiceIntegrationTest {
 
   // ── 헬퍼 ─────────────────────────────────────────────────────────────────────
 
+  private int userSeq = 0;
+
   private User saveUser(String nickname) {
     Auth auth = Auth.builder().build();
     em.persist(auth);
     User user = User.builder()
         .nickname(nickname)
         .name("테스트")
-        .phone("010-0000-0000")
+        .phone(String.format("010-%04d-%04d", ++userSeq, userSeq))
         .gender(Gender.NONE)
         .auth(auth)
         .build();


### PR DESCRIPTION
## 📌 관련 이슈
- #77 

## 📝 작업 내용
- 상품 목록 조회 / 검색 결과 조회시 상태가 STOP_SALE인 상품은 표시되지 않도록 수정했습니다.

## ✅ 작업 결과 
- 기존 테스트 결과에는 변화가 없습니다.

## 🎸 기타
- 상품 Status에 'DELETED'라는 상태가 없기 때문에, 삭제 검증은 deletedAt의 null 여부로 판단합니다. 설령 나중에 추가된다고 하더라도 결과가 변하지는 않습니다.
- 재고 소진(OUT_OF_STOCK)은 표시가 되는 것이 일반적일 것 같아 이건 제외하지 않았습니다.
