### PR TITLE
Feat/79 Pg사 결제 연동 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 HELP.md
+.env
+.env.*
+!.env.example
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -71,6 +71,19 @@ public enum ErrorCode {
   SHIP_CANNOT_DELETE_DEFAULT(409, "SHIP-CANNOT-DELETE-DEFAULT", "기본 배송지는 삭제할 수 없습니다. 먼저 다른 배송지를 기본으로 설정해 주세요."),
 
   // 주문 도메인
+  ORDER_NOT_FOUND(404, "ORDER-NOT-FOUND", "주문을 찾을 수 없습니다."),
+
+  // 결제 도메인
+  PAYMENT_NOT_FOUND(404, "PAYMENT-NOT-FOUND", "결제 정보를 찾을 수 없습니다."),
+  PAYMENT_FORBIDDEN(403, "PAYMENT-FORBIDDEN", "해당 결제에 접근할 권한이 없습니다."),
+  PAYMENT_INVALID_STATUS(409, "PAYMENT-INVALID-STATUS", "현재 결제 상태에서는 처리할 수 없습니다."),
+  PAYMENT_AMOUNT_MISMATCH(400, "PAYMENT-AMOUNT-MISMATCH", "결제 금액이 일치하지 않습니다."),
+  PAYMENT_ORDER_MISMATCH(400, "PAYMENT-ORDER-MISMATCH", "결제 주문번호가 일치하지 않습니다."),
+  PAYMENT_APPROVAL_FAILED(502, "PAYMENT-APPROVAL-FAILED", "결제 승인에 실패했습니다."),
+  PAYMENT_CLIENT_KEY_NOT_CONFIGURED(500, "PAYMENT-CLIENT-KEY-NOT-CONFIGURED",
+      "토스페이먼츠 클라이언트 키가 설정되지 않았습니다."),
+  PAYMENT_SECRET_KEY_NOT_CONFIGURED(500, "PAYMENT-SECRET-KEY-NOT-CONFIGURED",
+      "토스페이먼츠 시크릿 키가 설정되지 않았습니다."),
 
   // 채팅 도메인
   ROOM_NOT_FOUND(404, "CHAT-NOT-FOUND-ROOM", "존재하지 않는 채팅방입니다."),

--- a/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.order.controller;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
@@ -10,9 +11,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,10 +26,10 @@ public class OrderController {
 
   @PostMapping
   public ResponseEntity<ApiResponse<OrderCreateResponse>> createOrder(
-      @RequestHeader("X-User-Id") Long userId,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody OrderCreateRequest requestDto
   ) {
-    OrderCreateResponse responseDto = orderService.createOrder(userId, requestDto);
+    OrderCreateResponse responseDto = orderService.createOrder(userDetails.getUserId(), requestDto);
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success("주문이 생성되었습니다.", responseDto));
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/OrderItem.java
@@ -39,7 +39,7 @@ public class OrderItem {
   private String optionSummary;
 
   @Column(name = "product_amount", nullable = false)
-  private Integer productAmount;
+  private Long productAmount;
 
   @Column
   private Integer quantity;
@@ -49,7 +49,7 @@ public class OrderItem {
       ProductVariant productVariant,
       String productName,
       String optionSummary,
-      Integer productAmount,
+      Long productAmount,
       Integer quantity
   ) {
     this.order = order;
@@ -65,7 +65,7 @@ public class OrderItem {
       ProductVariant productVariant,
       String productName,
       String optionSummary,
-      Integer productAmount,
+      Long productAmount,
       Integer quantity
   ) {
     return new OrderItem(

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/OrderItem.java
@@ -10,9 +10,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "order_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderItem {
 
   @Id
@@ -38,4 +43,38 @@ public class OrderItem {
 
   @Column
   private Integer quantity;
+
+  private OrderItem(
+      Order order,
+      ProductVariant productVariant,
+      String productName,
+      String optionSummary,
+      Integer productAmount,
+      Integer quantity
+  ) {
+    this.order = order;
+    this.productVariant = productVariant;
+    this.productName = productName;
+    this.optionSummary = optionSummary;
+    this.productAmount = productAmount;
+    this.quantity = quantity;
+  }
+
+  public static OrderItem createOrderItem(
+      Order order,
+      ProductVariant productVariant,
+      String productName,
+      String optionSummary,
+      Integer productAmount,
+      Integer quantity
+  ) {
+    return new OrderItem(
+        order,
+        productVariant,
+        productName,
+        optionSummary,
+        productAmount,
+        quantity
+    );
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderItemRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderItemRepo.java
@@ -1,8 +1,11 @@
 package com.example.WonkaoTalk.domain.order.repo;
 
+import com.example.WonkaoTalk.domain.order.entity.Order;
 import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderItemRepo extends JpaRepository<OrderItem, Long> {
 
+  List<OrderItem> findByOrder(Order order);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -10,6 +10,8 @@ import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.OrderPreviewItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.SummaryDto;
 import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
 import com.example.WonkaoTalk.domain.payment.service.PaymentService;
@@ -41,6 +43,7 @@ public class OrderService {
 
   private final ProductVariantRepo productVariantRepo;
   private final OrderRepo orderRepo;
+  private final OrderItemRepo orderItemRepo;
 
   private final PaymentService paymentService;
 
@@ -105,6 +108,7 @@ public class OrderService {
 
     // 이렇게 객체 새로 생성해서 부여하는 방식이 옳은 방식일지 고민해볼 필요 있을듯
     Order savedOrder = orderRepo.save(order);
+    orderItemRepo.saveAll(createOrderItems(savedOrder, orderItems, productVariants));
 
     // TODO: Delivery 생성
 
@@ -290,6 +294,23 @@ public class OrderService {
     long finalAmount = originalAmount - discountAmount;
 
     return new SummaryDto(originalAmount, discountAmount, finalAmount);
+  }
+
+  private List<OrderItem> createOrderItems(
+      Order order,
+      List<OrderPreviewItemDto> items,
+      Map<Long, ProductVariant> variantMap
+  ) {
+    return items.stream()
+        .map(item -> OrderItem.createOrderItem(
+            order,
+            variantMap.get(item.variantId()),
+            item.productName(),
+            item.variantName(),
+            Math.toIntExact(item.discountedPrice()),
+            item.quantity()
+        ))
+        .toList();
   }
 
   // 주문 번호 생성

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -307,7 +307,7 @@ public class OrderService {
             variantMap.get(item.variantId()),
             item.productName(),
             item.variantName(),
-            Math.toIntExact(item.discountedPrice()),
+            item.discountedPrice(),
             item.quantity()
         ))
         .toList();

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/client/TossPaymentConfirmResult.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/client/TossPaymentConfirmResult.java
@@ -1,0 +1,20 @@
+package com.example.WonkaoTalk.domain.payment.client;
+
+public record TossPaymentConfirmResult(
+    String paymentKey,
+    String orderId,
+    String status,
+    String method,
+    Long totalAmount,
+    String approvedAt,
+    Receipt receipt
+) {
+
+  public record Receipt(String url) {
+
+  }
+
+  public String receiptUrl() {
+    return receipt == null ? null : receipt.url();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/client/TossPaymentsClient.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/client/TossPaymentsClient.java
@@ -1,0 +1,66 @@
+package com.example.WonkaoTalk.domain.payment.client;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.payment.config.TossPaymentsProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+@RequiredArgsConstructor
+public class TossPaymentsClient {
+
+  private final TossPaymentsProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public TossPaymentConfirmResult confirm(String paymentKey, String orderId, Long amount,
+      String idempotencyKey) {
+    if (properties.getSecretKey() == null || properties.getSecretKey().isBlank()) {
+      throw new BusinessException(ErrorCode.PAYMENT_SECRET_KEY_NOT_CONFIGURED);
+    }
+
+    try {
+      return RestClient.create(properties.getBaseUrl())
+          .post()
+          .uri("/v1/payments/confirm")
+          .header(HttpHeaders.AUTHORIZATION, authorizationHeader())
+          .header("Idempotency-Key", idempotencyKey)
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(Map.of(
+              "paymentKey", paymentKey,
+              "orderId", orderId,
+              "amount", amount
+          ))
+          .retrieve()
+          .body(TossPaymentConfirmResult.class);
+    } catch (RestClientResponseException e) {
+      throw toTossException(e);
+    }
+  }
+
+  private String authorizationHeader() {
+    String token = Base64.getEncoder()
+        .encodeToString((properties.getSecretKey() + ":").getBytes(StandardCharsets.UTF_8));
+    return "Basic " + token;
+  }
+
+  private TossPaymentsException toTossException(RestClientResponseException e) {
+    try {
+      JsonNode root = objectMapper.readTree(e.getResponseBodyAsString());
+      String code = root.path("code").asText("TOSS_PAYMENT_ERROR");
+      String message = root.path("message").asText("토스페이먼츠 결제 승인에 실패했습니다.");
+      return new TossPaymentsException(code, message);
+    } catch (Exception ignored) {
+      return new TossPaymentsException("TOSS_PAYMENT_ERROR", "토스페이먼츠 결제 승인에 실패했습니다.");
+    }
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/client/TossPaymentsException.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/client/TossPaymentsException.java
@@ -1,0 +1,14 @@
+package com.example.WonkaoTalk.domain.payment.client;
+
+import lombok.Getter;
+
+@Getter
+public class TossPaymentsException extends RuntimeException {
+
+  private final String code;
+
+  public TossPaymentsException(String code, String message) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/config/TossPaymentsProperties.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/config/TossPaymentsProperties.java
@@ -1,0 +1,19 @@
+package com.example.WonkaoTalk.domain.payment.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "tosspayments")
+public class TossPaymentsProperties {
+
+  private String clientKey = "";
+  private String secretKey = "";
+  private String baseUrl = "https://api.tosspayments.com";
+  private String successUrl = "";
+  private String failUrl = "";
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/controller/PaymentController.java
@@ -1,0 +1,58 @@
+package com.example.WonkaoTalk.domain.payment.controller;
+
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentCheckoutResponse;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmRequest;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmResponse;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentFailRequest;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentFailResponse;
+import com.example.WonkaoTalk.domain.payment.service.PaymentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+  private final PaymentService paymentService;
+
+  @GetMapping("/{paymentId}/checkout")
+  public ResponseEntity<ApiResponse<PaymentCheckoutResponse>> getCheckout(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long paymentId
+  ) {
+    PaymentCheckoutResponse response = paymentService.getCheckout(userDetails.getUserId(),
+        paymentId);
+    return ResponseEntity.ok(ApiResponse.success("결제창 호출 정보가 조회되었습니다.", response));
+  }
+
+  @PostMapping("/confirm")
+  public ResponseEntity<ApiResponse<PaymentConfirmResponse>> confirm(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody PaymentConfirmRequest request
+  ) {
+    PaymentConfirmResponse response = paymentService.confirm(userDetails.getUserId(), request);
+    return ResponseEntity.ok(ApiResponse.success("결제가 승인되었습니다.", response));
+  }
+
+  @PostMapping("/{paymentId}/fail")
+  public ResponseEntity<ApiResponse<PaymentFailResponse>> fail(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long paymentId,
+      @Valid @RequestBody PaymentFailRequest request
+  ) {
+    PaymentFailResponse response = paymentService.fail(userDetails.getUserId(), paymentId,
+        request);
+    return ResponseEntity.ok(ApiResponse.success("결제 실패 정보가 저장되었습니다.", response));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentCheckoutResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentCheckoutResponse.java
@@ -1,0 +1,13 @@
+package com.example.WonkaoTalk.domain.payment.dto;
+
+public record PaymentCheckoutResponse(
+    Long paymentId,
+    String clientKey,
+    String tossOrderId,
+    Long amount,
+    String orderName,
+    String successUrl,
+    String failUrl
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentConfirmRequest.java
@@ -1,0 +1,13 @@
+package com.example.WonkaoTalk.domain.payment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record PaymentConfirmRequest(
+    @NotBlank String paymentKey,
+    @NotBlank String orderId,
+    @NotNull @Positive Long amount
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentConfirmResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentConfirmResponse.java
@@ -1,0 +1,15 @@
+package com.example.WonkaoTalk.domain.payment.dto;
+
+public record PaymentConfirmResponse(
+    Long paymentId,
+    Long orderId,
+    String tossOrderId,
+    String paymentKey,
+    Long amount,
+    String status,
+    String method,
+    String approvedAt,
+    String receiptUrl
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentFailRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentFailRequest.java
@@ -1,0 +1,11 @@
+package com.example.WonkaoTalk.domain.payment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentFailRequest(
+    String orderId,
+    @NotBlank String code,
+    @NotBlank String message
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentFailResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/dto/PaymentFailResponse.java
@@ -1,0 +1,11 @@
+package com.example.WonkaoTalk.domain.payment.dto;
+
+public record PaymentFailResponse(
+    Long paymentId,
+    String tossOrderId,
+    String status,
+    String failCode,
+    String failMessage
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
@@ -1,8 +1,10 @@
 package com.example.WonkaoTalk.domain.payment.repo;
 
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepo extends JpaRepository<Payment, Long> {
 
+  Optional<Payment> findByTossOrderId(String tossOrderId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
@@ -249,7 +249,6 @@ public class PaymentService {
   }
 
   private String generateTossOrderId(String orderNumber) {
-//    return orderNumber + "-PAY-" + UUID.randomUUID();
     String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
     return orderNumber + "PAY" + uuid;
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
@@ -1,13 +1,31 @@
 package com.example.WonkaoTalk.domain.payment.service;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentConfirmResult;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentsClient;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentsException;
+import com.example.WonkaoTalk.domain.payment.config.TossPaymentsProperties;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentCheckoutResponse;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmRequest;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmResponse;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentFailRequest;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentFailResponse;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
 import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,8 +33,13 @@ import org.springframework.stereotype.Service;
 public class PaymentService {
 
   private final PaymentRepo paymentRepo;
+  private final OrderItemRepo orderItemRepo;
+  private final ProductVariantRepo productVariantRepo;
+  private final TossPaymentsProperties tossPaymentsProperties;
+  private final TossPaymentsClient tossPaymentsClient;
 
   // 주문 생성
+  @Transactional
   public Payment createReadyPayment(Order order) {
     // 토스 주문 번호 만들기
     String tossOrderId = generateTossOrderId(order.getOrderNumber());
@@ -38,8 +61,197 @@ public class PaymentService {
 
   }
 
+  // 결제 정보 전달
+  @Transactional
+  public PaymentCheckoutResponse getCheckout(Long userId, Long paymentId) {
+    // 토스페이 환경 설정 검증
+    if (tossPaymentsProperties.getClientKey() == null
+        || tossPaymentsProperties.getClientKey().isBlank()) {
+      throw new BusinessException(ErrorCode.PAYMENT_CLIENT_KEY_NOT_CONFIGURED);
+    }
+
+    Payment payment = getPayment(paymentId);
+    validateOwner(payment, userId);
+
+    // 결제 상태인지 확인
+    if (payment.getStatus() != PaymentStatus.READY
+        && payment.getStatus() != PaymentStatus.PENDING) {
+      throw new BusinessException(ErrorCode.PAYMENT_INVALID_STATUS);
+    }
+
+    // 결제대기 상태 변경
+    payment.markPending();
+
+    return new PaymentCheckoutResponse(
+        payment.getPaymentId(),
+        tossPaymentsProperties.getClientKey(),
+        payment.getTossOrderId(),
+        payment.getTotalAmount(),
+        payment.getOrder().getOrderTitle(),
+        tossPaymentsProperties.getSuccessUrl(),
+        tossPaymentsProperties.getFailUrl()
+    );
+  }
+
+  // 결제 승인
+  @Transactional
+  public PaymentConfirmResponse confirm(Long userId, PaymentConfirmRequest request) {
+    Payment payment = paymentRepo.findByTossOrderId(request.orderId())
+        .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    // 결제 최종 승인 전 재검증
+    validateOwner(payment, userId);
+    validateConfirmable(payment, request);
+
+    try {
+      // 토스 승인 전에 재고를 원자적으로 차감한다. 차감 실패 시 승인 요청을 보내지 않는다.
+      decreaseStocks(payment.getOrder());
+
+      // 토스 페이먼츠로 confirm api 요청
+      TossPaymentConfirmResult result = tossPaymentsClient.confirm(
+          request.paymentKey(),
+          request.orderId(),
+          payment.getTotalAmount(),
+          payment.getIdempotencyKey()
+      );
+      validateTossConfirmResult(payment, result);
+
+      payment.markPaid(result.paymentKey());
+      payment.getOrder().markPaid();
+
+      return new PaymentConfirmResponse(
+          payment.getPaymentId(),
+          payment.getOrder().getOrderId(),
+          payment.getTossOrderId(),
+          payment.getPaymentKey(),
+          payment.getTotalAmount(),
+          payment.getStatus().name(),
+          result.method(),
+          result.approvedAt(),
+          result.receiptUrl()
+      );
+    } catch (TossPaymentsException e) {
+      // 에러 로깅 처리
+      log.warn(
+          "TossPayments confirm failed. paymentId={}, tossOrderId={}, tossCode={}, tossMessage={}",
+          payment.getPaymentId(), payment.getTossOrderId(), e.getCode(), e.getMessage());
+      payment.markFailed(e.getCode(), e.getMessage());
+      payment.getOrder().markPaymentFailed();
+      throw new BusinessException(ErrorCode.PAYMENT_APPROVAL_FAILED);
+    }
+  }
+
+  // 재고 감소 처리
+  private void decreaseStocks(Order order) {
+    List<OrderItem> orderItems = orderItemRepo.findByOrder(order);
+
+    for (OrderItem orderItem : orderItems) {
+      int updatedCount = productVariantRepo.decreaseStockAtomic(
+          orderItem.getProductVariant().getId(),
+          orderItem.getQuantity()
+      );
+
+      if (updatedCount != 1) {
+        throw new BusinessException(ErrorCode.PROD_STOCK_INSUFFICIENT);
+      }
+    }
+  }
+
+  // 결제 최종 승인 전 취소 시
+  // TODO: 추후.. Pending 상태인 결제를 일괄 정리하는 로직도 필요..
+  @Transactional
+  public PaymentFailResponse fail(Long userId, Long paymentId, PaymentFailRequest request) {
+    Payment payment = findPaymentForFail(paymentId, request);
+    validateOwner(payment, userId);
+
+    if ("PAY_PROCESS_CANCELED".equals(request.code())) {
+      payment.markCanceled(request.code(), request.message());
+      payment.getOrder().markPaymentCanceled();
+    } else {
+      payment.markFailed(request.code(), request.message());
+      payment.getOrder().markPaymentFailed();
+    }
+
+    return new PaymentFailResponse(
+        payment.getPaymentId(),
+        payment.getTossOrderId(),
+        payment.getStatus().name(),
+        payment.getFailCode(),
+        payment.getFailMessage()
+    );
+  }
+
+  // 결제 정보 가지고 오기
+  private Payment getPayment(Long paymentId) {
+    return paymentRepo.findById(paymentId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+  }
+
+  // 취소 처리해애햘 결제 정보 찾기
+  private Payment findPaymentForFail(Long paymentId, PaymentFailRequest request) {
+    if (request.orderId() == null || request.orderId().isBlank()) {
+      return getPayment(paymentId);
+    }
+    Payment payment = paymentRepo.findByTossOrderId(request.orderId())
+        .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    if (!Objects.equals(payment.getPaymentId(), paymentId)) {
+      throw new BusinessException(ErrorCode.PAYMENT_ORDER_MISMATCH);
+    }
+    return payment;
+  }
+
+  // 주문자 확인
+  // TODO: Payment에서 Userid를 알기 위한 depth가 깊어서 추후 고민해야할 부분임.
+  private void validateOwner(Payment payment, Long userId) {
+    if (!Objects.equals(payment.getOrder().getUser().getId(), userId)) {
+      throw new BusinessException(ErrorCode.PAYMENT_FORBIDDEN);
+    }
+  }
+
+  // 승인 전 주문 금액, id, 상태값 검증
+  private void validateConfirmable(Payment payment, PaymentConfirmRequest request) {
+    if (payment.getStatus() != PaymentStatus.READY
+        && payment.getStatus() != PaymentStatus.PENDING) {
+      throw new BusinessException(ErrorCode.PAYMENT_INVALID_STATUS);
+    }
+    if (!payment.getTossOrderId().equals(request.orderId())) {
+      payment.markInvalid("ORDER_ID_MISMATCH", "결제 주문번호가 일치하지 않습니다.");
+      payment.getOrder().markPaymentFailed();
+      throw new BusinessException(ErrorCode.PAYMENT_ORDER_MISMATCH);
+    }
+    if (!payment.getTotalAmount().equals(request.amount())) {
+      payment.markInvalid("AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다.");
+      payment.getOrder().markPaymentFailed();
+      throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+    }
+  }
+
+  // toss 측 승인 결과 확인
+  private void validateTossConfirmResult(Payment payment, TossPaymentConfirmResult result) {
+    if (result == null) {
+      payment.markInvalid("EMPTY_TOSS_RESPONSE", "토스페이먼츠 승인 응답이 비어있습니다.");
+      payment.getOrder().markPaymentFailed();
+      throw new BusinessException(ErrorCode.PAYMENT_APPROVAL_FAILED);
+    }
+    if (!payment.getTossOrderId().equals(result.orderId())) {
+      payment.markInvalid("TOSS_ORDER_ID_MISMATCH", "토스페이먼츠 승인 주문번호가 일치하지 않습니다.");
+      payment.getOrder().markPaymentFailed();
+      throw new BusinessException(ErrorCode.PAYMENT_ORDER_MISMATCH);
+    }
+    if (!payment.getTotalAmount().equals(result.totalAmount())) {
+      payment.markInvalid("TOSS_AMOUNT_MISMATCH", "토스페이먼츠 승인 금액이 일치하지 않습니다.");
+      payment.getOrder().markPaymentFailed();
+      throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+    }
+    if (!"DONE".equals(result.status())) {
+      payment.markFailed("TOSS_STATUS_NOT_DONE", "토스페이먼츠 결제 상태가 DONE이 아닙니다.");
+      throw new BusinessException(ErrorCode.PAYMENT_APPROVAL_FAILED);
+    }
+  }
+
   private String generateTossOrderId(String orderNumber) {
-    return orderNumber + "-PAY-" + UUID.randomUUID();
+//    return orderNumber + "-PAY-" + UUID.randomUUID();
+    String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+    return orderNumber + "PAY" + uuid;
   }
 
   private String generateIdempotencyKey() {

--- a/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
@@ -1,15 +1,34 @@
 package com.example.WonkaoTalk.domain.payment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentConfirmResult;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentsClient;
+import com.example.WonkaoTalk.domain.payment.config.TossPaymentsProperties;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentCheckoutResponse;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmRequest;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmResponse;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
 import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
 import com.example.WonkaoTalk.domain.payment.entity.PgProvider;
 import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +41,18 @@ public class PaymentServiceTest {
 
   @Mock
   private PaymentRepo paymentRepo;
+
+  @Mock
+  private OrderItemRepo orderItemRepo;
+
+  @Mock
+  private ProductVariantRepo productVariantRepo;
+
+  @Mock
+  private TossPaymentsProperties tossPaymentsProperties;
+
+  @Mock
+  private TossPaymentsClient tossPaymentsClient;
 
   @InjectMocks
   private PaymentService paymentService;
@@ -41,9 +72,104 @@ public class PaymentServiceTest {
     //then
     assertThat(payment.getOrder()).isEqualTo(order);
     assertThat(payment.getPgProvider()).isEqualTo(PgProvider.TOSS_PAYMENTS);
-    assertThat(payment.getTossOrderId()).startsWith("ORD-1234-PAY-");
+    assertThat(payment.getTossOrderId()).startsWith("ORD-1234PAY");
     assertThat(payment.getIdempotencyKey()).isNotBlank();
     assertThat(payment.getTotalAmount()).isEqualTo(35000L);
     assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY);
+  }
+
+  @Test
+  @DisplayName("결제창 호출 정보를 조회하면 Payment를 PENDING 상태로 변경한다.")
+  public void getCheckout_MarkPaymentPendingAndReturnCheckoutInfo() {
+    // given
+    Order order = mockOrder(1L, "초콜릿 외 1건");
+    Payment payment = Payment.createReadyPayment(order, "ORD-1234-PAY-abc", "idem-key", 35000L,
+        LocalDateTime.now());
+    when(paymentRepo.findById(10L)).thenReturn(Optional.of(payment));
+    when(tossPaymentsProperties.getClientKey()).thenReturn("test_ck_123");
+    when(tossPaymentsProperties.getSuccessUrl()).thenReturn("http://localhost:3000/success");
+    when(tossPaymentsProperties.getFailUrl()).thenReturn("http://localhost:3000/fail");
+
+    // when
+    PaymentCheckoutResponse response = paymentService.getCheckout(1L, 10L);
+
+    // then
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+    assertThat(response.clientKey()).isEqualTo("test_ck_123");
+    assertThat(response.tossOrderId()).isEqualTo("ORD-1234-PAY-abc");
+    assertThat(response.amount()).isEqualTo(35000L);
+    assertThat(response.orderName()).isEqualTo("초콜릿 외 1건");
+  }
+
+  @Test
+  @DisplayName("결제 승인 금액이 DB 금액과 다르면 토스 승인 요청 전에 INVALID 상태로 변경한다.")
+  public void confirm_ThrowsExceptionWhenAmountMismatch() {
+    // given
+    Order order = mockOrder(1L, "초콜릿 외 1건");
+    Payment payment = Payment.createReadyPayment(order, "ORD-1234-PAY-abc", "idem-key", 35000L,
+        LocalDateTime.now());
+    PaymentConfirmRequest request = new PaymentConfirmRequest("payment-key",
+        "ORD-1234-PAY-abc", 30000L);
+    when(paymentRepo.findByTossOrderId("ORD-1234-PAY-abc")).thenReturn(Optional.of(payment));
+
+    // when & then
+    assertThatThrownBy(() -> paymentService.confirm(1L, request))
+        .isInstanceOf(BusinessException.class);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.INVALID);
+    verify(order).markPaymentFailed();
+    verifyNoInteractions(tossPaymentsClient);
+  }
+
+  @Test
+  @DisplayName("토스 결제 승인 성공 시 Payment와 Order를 결제 완료 상태로 변경한다.")
+  public void confirm_MarkPaymentAndOrderPaidWhenTossConfirmSuccess() {
+    // given
+    Order order = mockOrder(1L, "초콜릿 외 1건");
+    Payment payment = Payment.createReadyPayment(order, "ORD-1234-PAY-abc", "idem-key", 35000L,
+        LocalDateTime.now());
+    ProductVariant variant = mock(ProductVariant.class);
+    OrderItem orderItem = mock(OrderItem.class);
+    PaymentConfirmRequest request = new PaymentConfirmRequest("payment-key",
+        "ORD-1234-PAY-abc", 35000L);
+    TossPaymentConfirmResult result = new TossPaymentConfirmResult(
+        "payment-key",
+        "ORD-1234-PAY-abc",
+        "DONE",
+        "카드",
+        35000L,
+        "2026-05-16T12:00:00+09:00",
+        new TossPaymentConfirmResult.Receipt("https://receipt.example")
+    );
+    when(paymentRepo.findByTossOrderId("ORD-1234-PAY-abc")).thenReturn(Optional.of(payment));
+    when(orderItemRepo.findByOrder(order)).thenReturn(List.of(orderItem));
+    when(orderItem.getProductVariant()).thenReturn(variant);
+    when(orderItem.getQuantity()).thenReturn(2);
+    when(variant.getId()).thenReturn(100L);
+    when(productVariantRepo.decreaseStockAtomic(100L, 2)).thenReturn(1);
+    when(tossPaymentsClient.confirm("payment-key", "ORD-1234-PAY-abc", 35000L, "idem-key"))
+        .thenReturn(result);
+
+    // when
+    PaymentConfirmResponse response = paymentService.confirm(1L, request);
+
+    // then
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+    assertThat(payment.getPaymentKey()).isEqualTo("payment-key");
+    assertThat(response.status()).isEqualTo("PAID");
+    assertThat(response.method()).isEqualTo("카드");
+    assertThat(response.receiptUrl()).isEqualTo("https://receipt.example");
+    verify(productVariantRepo).decreaseStockAtomic(100L, 2);
+    verify(order).markPaid();
+  }
+
+  private Order mockOrder(Long userId, String orderTitle) {
+    User user = mock(User.class);
+    when(user.getId()).thenReturn(userId);
+
+    Order order = mock(Order.class);
+    when(order.getUser()).thenReturn(user);
+    lenient().when(order.getOrderTitle()).thenReturn(orderTitle);
+    lenient().when(order.getOrderId()).thenReturn(20L);
+    return order;
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #79 

## 📝 작업 내용
- 토스페이먼츠 결제 승인/실패 API 추가
- 토스 confirm API 호출 로직 추가
- 주문 생성 시 OrderItem 저장
- 결제 승인 전 재고 차감 처리
- 주문 생성 API에서 인증 객체 기반으로 사용자 식별
- Tosspayment Properties 파일로 PG사 결제 키 정보 일관적으로 처리 

## ✅ 작업 결과
<img width="742" height="315" alt="image" src="https://github.com/user-attachments/assets/dc6117a6-9a23-4a15-ad8e-21bc5ae12972" /> 
<img width="751" height="313" alt="image" src="https://github.com/user-attachments/assets/fff0b5d3-1c78-4c5d-8a8c-863ec4bde9fd" />


## 🎸 기타
- close #79 