### PR TITLE
refactor: AuthService 트랜잭션 / 비트랜잭션 클래스 분리

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -76,8 +76,6 @@ public class SecurityConfig {
 
   @Bean
   public PasswordEncoder passwordEncoder() {
-    // BCrypt의 경우 보안 성능이 강력하나 해시 연산 속도가 느림. 현재 서비스 로직 상 Transaction 내에서 암호화를 진행 해 병목 발생 가능성 높음.
-    // TODO: service 클래스 분리 작업 필수
     return new BCryptPasswordEncoder();
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -93,7 +93,7 @@ public class AuthController {
 
   @PostMapping("/reissue")
   public ResponseEntity<ApiResponse<LoginResponse>> reissueToken(
-      @CookieValue(value = "refreshToken", required = false) String refreshToken
+      @CookieValue(value = "refresh-token", required = false) String refreshToken
   ) {
     if (refreshToken == null || refreshToken.isEmpty()) {
       throw new BusinessException(ErrorCode.AUTH_MISSING_TOKEN);

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/AuthUserInfoDto.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/AuthUserInfoDto.java
@@ -1,0 +1,20 @@
+package com.example.WonkaoTalk.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AuthUserInfoDto(
+    String profileName,
+    Long userId,
+    Long sellerId
+) {
+
+  public static AuthUserInfoDto of(String profileName, Long userId, Long sellerId) {
+    return AuthUserInfoDto.builder()
+        .profileName(profileName)
+        .userId(userId)
+        .sellerId(sellerId)
+        .build();
+  }
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/repo/AuthLocalRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/repo/AuthLocalRepo.java
@@ -4,12 +4,17 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AuthLocalRepo extends JpaRepository<AuthLocal, Long> {
 
   Optional<AuthLocal> findByEmail(String email);
 
   Optional<AuthLocal> findByAuth(Auth auth);
+
+  @Query("select al from AuthLocal al join fetch al.auth where al.email = :email")
+  Optional<AuthLocal> findByEmailWithAuth(@Param("email") String email);
 
   boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandService.java
@@ -1,0 +1,108 @@
+package com.example.WonkaoTalk.domain.auth.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
+import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
+import com.example.WonkaoTalk.domain.auth.enums.Role;
+import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
+import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandService {
+
+  private final AuthRepo authRepo;
+  private final AuthLocalRepo authLocalRepo;
+  private final LoginHistoryRepo loginHistoryRepo;
+  private final UserRepo userRepo;
+  private final SellerRepo sellerRepo;
+
+  @Transactional(readOnly = true)
+  public boolean existsByEmail(String email) {
+    return authLocalRepo.existsByEmail(email);
+  }
+
+  @Transactional
+  public Auth saveAuthLocal(String email, String encodedPassword, Role role) {
+    if (authLocalRepo.existsByEmail(email)) {
+      throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
+    }
+
+    Auth auth = Auth.builder().role(role).build();
+    Auth savedAuth = authRepo.save(auth);
+
+    AuthLocal authLocal = AuthLocal.builder()
+        .auth(savedAuth)
+        .email(email)
+        .passwordHash(encodedPassword)
+        .failedAttemptsCount(0)
+        .build();
+    authLocalRepo.save(authLocal);
+
+    return savedAuth;
+  }
+
+  @Transactional(readOnly = true)
+  public AuthLocal getAuthLocalByEmail(String email) {
+    return authLocalRepo.findByEmailWithAuth(email)
+        .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_EMAIL));
+  }
+
+  @Transactional
+  public void saveLoginHistory(Auth auth, LoginStatus status, String userAgent, String ipAddress) {
+    LoginHistory history = LoginHistory.builder()
+        .auth(auth)
+        .ipAddress(ipAddress)
+        .userAgent(userAgent)
+        .status(status)
+        .build();
+    loginHistoryRepo.save(history);
+  }
+
+  @Transactional
+  public void withdrawAuth(Long authId) {
+    Auth auth = authRepo.findById(authId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_NOT_FOUND));
+    authLocalRepo.findByAuth(auth).ifPresent(AuthLocal::withdraw);
+    auth.withdraw();
+  }
+
+  @Transactional(readOnly = true)
+  public String extractProfileNameByRole(Auth auth) {
+    Role role = auth.getRole();
+
+    if (role == Role.USER || role == Role.USER_SELLER) {
+      return userRepo.findByAuth(auth).map(User::getNickname)
+          .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    } else if (role == Role.SELLER) {
+      return sellerRepo.findByAuth(auth).map(Seller::getName)
+          .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+    } else if (role == Role.ADMIN) {
+      return "관리자";
+    }
+    return "알 수 없는 사용자";
+  }
+
+  @Transactional(readOnly = true)
+  public Long extractUserIdIfPresent(Auth auth) {
+    return (auth.getRole() == Role.USER || auth.getRole() == Role.USER_SELLER)
+        ? userRepo.findByAuth(auth).map(User::getId).orElse(null) : null;
+  }
+
+  @Transactional(readOnly = true)
+  public Long extractSellerIdIfPresent(Auth auth) {
+    return (auth.getRole() == Role.SELLER || auth.getRole() == Role.USER_SELLER)
+        ? sellerRepo.findByAuth(auth).map(Seller::getId).orElse(null) : null;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandService.java
@@ -2,6 +2,7 @@ package com.example.WonkaoTalk.domain.auth.service;
 
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.dto.AuthUserInfoDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
@@ -79,30 +80,25 @@ public class AuthCommandService {
   }
 
   @Transactional(readOnly = true)
-  public String extractProfileNameByRole(Auth auth) {
+  public AuthUserInfoDto getAuthUserInfo(Auth auth) {
     Role role = auth.getRole();
-
+    String profileName = "Unknown";
+    Long userId = null;
+    Long sellerId = null;
     if (role == Role.USER || role == Role.USER_SELLER) {
-      return userRepo.findByAuth(auth).map(User::getNickname)
+      User user = userRepo.findByAuth(auth)
           .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    } else if (role == Role.SELLER) {
-      return sellerRepo.findByAuth(auth).map(Seller::getName)
-          .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
-    } else if (role == Role.ADMIN) {
-      return "관리자";
+      profileName = user.getNickname();
+      userId = user.getId();
     }
-    return "알 수 없는 사용자";
-  }
-
-  @Transactional(readOnly = true)
-  public Long extractUserIdIfPresent(Auth auth) {
-    return (auth.getRole() == Role.USER || auth.getRole() == Role.USER_SELLER)
-        ? userRepo.findByAuth(auth).map(User::getId).orElse(null) : null;
-  }
-
-  @Transactional(readOnly = true)
-  public Long extractSellerIdIfPresent(Auth auth) {
-    return (auth.getRole() == Role.SELLER || auth.getRole() == Role.USER_SELLER)
-        ? sellerRepo.findByAuth(auth).map(Seller::getId).orElse(null) : null;
+    if (auth.getRole() == Role.SELLER || auth.getRole() == Role.USER_SELLER) {
+      Seller seller = sellerRepo.findByAuth(auth)
+          .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+      if (role == Role.SELLER) {
+        profileName = seller.getName();
+      }
+      sellerId = seller.getId();
+    }
+    return AuthUserInfoDto.of(profileName, userId, sellerId);
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
@@ -10,112 +10,72 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
-import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
 import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
-import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
-import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
-import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
-import com.example.WonkaoTalk.domain.seller.entity.Seller;
-import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
-import com.example.WonkaoTalk.domain.user.entity.User;
-import com.example.WonkaoTalk.domain.user.repo.UserRepo;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AuthService {
 
-  private final AuthRepo authRepo;
-  private final AuthLocalRepo authLocalRepo;
-  private final LoginHistoryRepo loginHistoryRepo;
-  private final UserRepo userRepo;
-  private final SellerRepo sellerRepo;
+  private final AuthCommandService authCommandService;
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisService redisService;
 
-  @Transactional(readOnly = true)
   public EmailCheckResponse validateEmail(EmailCheckRequest request) {
-    boolean exists = authLocalRepo.existsByEmail(request.email());
-
-    return EmailCheckResponse.from(!exists);
+    return EmailCheckResponse.from(!authCommandService.existsByEmail(request.email()));
   }
 
-  @Transactional
   public Auth createAuthLocal(String email, String password, Role role) {
-    if (authLocalRepo.existsByEmail(email)) {
+    if (authCommandService.existsByEmail(email)) {
       throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
     }
-
-    Auth auth = Auth.builder()
-        .role(role)
-        .build();
-    Auth savedAuth = authRepo.save(auth);
-
     String encodedPassword = passwordEncoder.encode(password);
-    AuthLocal authLocal = AuthLocal.builder()
-        .auth(savedAuth)
-        .email(email)
-        .passwordHash(encodedPassword)
-        .failedAttemptsCount(0)
-        .build();
-    authLocalRepo.save(authLocal);
 
-    return savedAuth;
+    return authCommandService.saveAuthLocal(email, encodedPassword, role);
   }
 
-  @Transactional
   public TokenDto login(LoginRequest request, HttpServletRequest httpRequest) {
     // TODO: 로그인 실패 횟수에 따른 계정 잠금이나 추가인증 기능 구현
-    AuthLocal authLocal = authLocalRepo.findByEmail(request.email())
-        .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_EMAIL));
-
+    AuthLocal authLocal = authCommandService.getAuthLocalByEmail(request.email());
     Auth auth = authLocal.getAuth();
 
+    String userAgent = httpRequest.getHeader("User-Agent");
+    String ipAddress = extractIpAddress(httpRequest);
+
     if (!passwordEncoder.matches(request.password(), authLocal.getPasswordHash())) {
-      saveLoginHistory(auth, LoginStatus.FAILURE, httpRequest);
+      authCommandService.saveLoginHistory(auth, LoginStatus.FAILURE, userAgent, ipAddress);
       throw new BusinessException(ErrorCode.AUTH_MISMATCH_PASSWORD);
     }
 
     TokenDto dto = publishToken(authLocal.getEmail(), auth);
 
-    saveLoginHistory(auth, LoginStatus.SUCCESS, httpRequest);
+    authCommandService.saveLoginHistory(auth, LoginStatus.SUCCESS, userAgent, ipAddress);
 
     return dto;
-
   }
 
-  @Transactional
   public void logout(String accessToken, String email) {
     invalidateToken(email, accessToken);
   }
 
-  @Transactional
   public void withdraw(Long authId) {
-    Auth auth = authRepo.findById(authId)
-        .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_NOT_FOUND));
-
-    authLocalRepo.findByAuth(auth).ifPresent(AuthLocal::withdraw);
-
-    auth.withdraw();
+    authCommandService.withdrawAuth(authId);
   }
 
-  @Transactional(readOnly = true)
   public TokenDto reissueToken(String refreshToken) {
     if (!jwtTokenProvider.validateToken(refreshToken)) {
       throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
     }
 
     String email = jwtTokenProvider.getEmailFromToken(refreshToken);
-
     String redisKey = "RT:" + email;
     String storedRefreshToken = redisService.getValues(redisKey);
 
@@ -124,48 +84,26 @@ public class AuthService {
       throw new BusinessException(ErrorCode.AUTH_SUSPECT_THEFT_TOKEN);
     }
 
-    AuthLocal authLocal = authLocalRepo.findByEmail(email)
-        .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_NOT_FOUND));
+    AuthLocal authLocal = authCommandService.getAuthLocalByEmail(email);
     Auth auth = authLocal.getAuth();
 
     return publishToken(authLocal.getEmail(), auth);
   }
 
-  private void saveLoginHistory(Auth auth, LoginStatus status, HttpServletRequest request) {
-    String userAgent = request.getHeader("User-Agent");
-    String ipAddress = request.getHeader("X-Forwarded-For");
-    // 프록시나 로드밸런서를 거쳤을 경우 대비
-    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
-      ipAddress = request.getRemoteAddr();
-    } else {
-      ipAddress = ipAddress.split(",")[0].trim();
-    }
-
-    LoginHistory history = LoginHistory.builder()
-        .auth(auth)
-        .ipAddress(ipAddress)
-        .userAgent(userAgent)
-        .status(status)
-        .build();
-
-    loginHistoryRepo.save(history);
-  }
-
   private TokenDto publishToken(String email, Auth auth) {
-    String profileName = extractProfileNameByRole(auth);
+    String profileName = authCommandService.extractProfileNameByRole(auth);
     String role = auth.getRole().name();
-    Long userId = extractUserIdIfPresent(auth);
-    Long sellerId = extractSellerIdIfPresent(auth);
-    String accessToken =
-        jwtTokenProvider.createAccessToken(email, auth.getId(), userId, sellerId, role);
+    Long userId = authCommandService.extractUserIdIfPresent(auth);
+    Long sellerId = authCommandService.extractSellerIdIfPresent(auth);
+
+    String accessToken = jwtTokenProvider.createAccessToken(email, auth.getId(), userId, sellerId,
+        role);
     String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
     long refreshExpirationTime = jwtTokenProvider.getRefreshTokenValidTime();
     long accessExpirationTime = jwtTokenProvider.getAccessTokenValidTime();
 
-    redisService.setValues("RT:" + email, refreshToken,
-        Duration.ofMillis(refreshExpirationTime)
-    );
+    redisService.setValues("RT:" + email, refreshToken, Duration.ofMillis(refreshExpirationTime));
 
     return TokenDto.of(accessToken, refreshToken, accessExpirationTime, refreshExpirationTime, auth,
         profileName);
@@ -183,40 +121,11 @@ public class AuthService {
     redisService.setValues("BlackList:" + accessToken, "logout", Duration.ofMillis(expiration));
   }
 
-  private String extractProfileNameByRole(Auth auth) {
-    Role role = auth.getRole();
-
-    if (role == Role.USER || role == Role.USER_SELLER) {
-      return userRepo.findByAuth(auth)
-          .map(User::getNickname)
-          .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    } else if (role == Role.SELLER) {
-      return sellerRepo.findByAuth(auth)
-          .map(Seller::getName)
-          .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
-    } else if (role == Role.ADMIN) {
-      return "관리자";
+  private String extractIpAddress(HttpServletRequest request) {
+    String ipAddress = request.getHeader("X-Forwarded-For");
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      return request.getRemoteAddr();
     }
-    return "알 수 없는 사용자";
-  }
-
-  private Long extractUserIdIfPresent(Auth auth) {
-    Role role = auth.getRole();
-    if (role == Role.USER || role == Role.USER_SELLER) {
-      return userRepo.findByAuth(auth)
-          .map(User::getId)
-          .orElse(null);
-    }
-    return null;
-  }
-
-  private Long extractSellerIdIfPresent(Auth auth) {
-    Role role = auth.getRole();
-    if (role == Role.SELLER || role == Role.USER_SELLER) {
-      return sellerRepo.findByAuth(auth)
-          .map(Seller::getId)
-          .orElse(null);
-    }
-    return null;
+    return ipAddress.split(",")[0].trim();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.example.WonkaoTalk.common.config.security.jwt.JwtTokenProvider;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.redis.RedisService;
+import com.example.WonkaoTalk.domain.auth.dto.AuthUserInfoDto;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
 import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
@@ -91,13 +92,11 @@ public class AuthService {
   }
 
   private TokenDto publishToken(String email, Auth auth) {
-    String profileName = authCommandService.extractProfileNameByRole(auth);
+    AuthUserInfoDto dto = authCommandService.getAuthUserInfo(auth);
     String role = auth.getRole().name();
-    Long userId = authCommandService.extractUserIdIfPresent(auth);
-    Long sellerId = authCommandService.extractSellerIdIfPresent(auth);
 
-    String accessToken = jwtTokenProvider.createAccessToken(email, auth.getId(), userId, sellerId,
-        role);
+    String accessToken = jwtTokenProvider.createAccessToken(email, auth.getId(), dto.userId(),
+        dto.sellerId(), role);
     String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
     long refreshExpirationTime = jwtTokenProvider.getRefreshTokenValidTime();
@@ -106,7 +105,7 @@ public class AuthService {
     redisService.setValues("RT:" + email, refreshToken, Duration.ofMillis(refreshExpirationTime));
 
     return TokenDto.of(accessToken, refreshToken, accessExpirationTime, refreshExpirationTime, auth,
-        profileName);
+        dto.profileName());
   }
 
   public void invalidateToken(String email, String accessToken) {

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -19,14 +20,10 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
-import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
-import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
-import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
 import com.example.WonkaoTalk.domain.user.entity.User;
-import com.example.WonkaoTalk.domain.user.repo.UserRepo;
 import java.time.Duration;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,13 +42,7 @@ class AuthServiceTest {
   private AuthService authService;
 
   @Mock
-  private AuthRepo authRepo;
-  @Mock
-  private AuthLocalRepo authLocalRepo;
-  @Mock
-  private LoginHistoryRepo loginHistoryRepo;
-  @Mock
-  private UserRepo userRepo;
+  private AuthCommandService authCommandService;
   @Mock
   private PasswordEncoder passwordEncoder;
   @Mock
@@ -73,7 +64,7 @@ class AuthServiceTest {
   public void checkEmailAvailable() {
     //given
     EmailCheckRequest request = new EmailCheckRequest("test@test.com");
-    given(authLocalRepo.existsByEmail(request.email())).willReturn(false);
+    given(authCommandService.existsByEmail(request.email())).willReturn(false);
 
     //when
     EmailCheckResponse response = authService.validateEmail(request);
@@ -90,11 +81,11 @@ class AuthServiceTest {
     String password = "Qwer1234";
     Role role = Role.USER;
 
-    given(authLocalRepo.existsByEmail(email)).willReturn(false);
+    given(authCommandService.existsByEmail(email)).willReturn(false);
     given(passwordEncoder.encode(password)).willReturn("EncodedPassword");
 
     Auth auth = Auth.builder().role(role).build();
-    given(authRepo.save(any(Auth.class))).willReturn(auth);
+    given(authCommandService.saveAuthLocal(email, "EncodedPassword", role)).willReturn(auth);
 
     //when
     Auth savedAuth = authService.createAuthLocal(email, password, role);
@@ -102,8 +93,7 @@ class AuthServiceTest {
     //then
     assertThat(savedAuth).isNotNull();
     assertThat(savedAuth.getRole()).isEqualTo(Role.USER);
-    verify(authRepo).save(any(Auth.class));
-    verify(authLocalRepo).save(any(AuthLocal.class));
+    verify(authCommandService).saveAuthLocal(email, "EncodedPassword", role);
   }
 
   @Test
@@ -111,7 +101,7 @@ class AuthServiceTest {
   public void createAuthFailedByDuplicateEmail() {
     //given
     String email = "test@test.com";
-    given(authLocalRepo.existsByEmail(email)).willReturn(true);
+    given(authCommandService.existsByEmail(email)).willReturn(true);
 
     //when & then
     BusinessException e = assertThrows(BusinessException.class, () -> {
@@ -138,13 +128,15 @@ class AuthServiceTest {
 
     User user = User.builder().nickname("침착맨").build();
 
-    given(authLocalRepo.findByEmail(anyString())).willReturn(Optional.of(authLocal));
+    given(authCommandService.getAuthLocalByEmail(anyString())).willReturn(authLocal);
     given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-    given(userRepo.findByAuth(any(Auth.class))).willReturn(Optional.of(user));
 
-    given(jwtTokenProvider.createAccessToken(anyString(), any(Long.class), any(Long.class),
-        any(Long.class), anyString()))
-        .willReturn("mockAccessToken");
+    given(authCommandService.extractProfileNameByRole(any(Auth.class))).willReturn("침착맨");
+    given(authCommandService.extractUserIdIfPresent(any(Auth.class))).willReturn(1L);
+    given(authCommandService.extractSellerIdIfPresent(any(Auth.class))).willReturn(null);
+
+    given(jwtTokenProvider.createAccessToken(anyString(), any(Long.class), nullable(Long.class),
+        nullable(Long.class), anyString())).willReturn("mockAccessToken");
     given(jwtTokenProvider.createRefreshToken(anyString())).willReturn("mockRefreshToken");
     given(jwtTokenProvider.getRefreshTokenValidTime()).willReturn(1209600000L);
     given(jwtTokenProvider.getAccessTokenValidTime()).willReturn(1800000L);
@@ -158,9 +150,10 @@ class AuthServiceTest {
     assertThat(response.profileName()).isEqualTo("침착맨");
 
     // Redis 검증
-    verify(redisService).setValues(
-        eq("RT:test@test.com"), eq("mockRefreshToken"), any(Duration.class));
-    verify(loginHistoryRepo).save(any());
+    verify(redisService).setValues(eq("RT:test@test.com"), eq("mockRefreshToken"),
+        any(Duration.class));
+    verify(authCommandService).saveLoginHistory(eq(auth), eq(LoginStatus.SUCCESS), anyString(),
+        anyString());
 
   }
 
@@ -173,7 +166,7 @@ class AuthServiceTest {
     AuthLocal authLocal = AuthLocal.builder()
         .email("test@test.com").passwordHash("encodedPassword").auth(auth).build();
 
-    given(authLocalRepo.findByEmail(anyString())).willReturn(Optional.of(authLocal));
+    given(authCommandService.getAuthLocalByEmail(anyString())).willReturn(authLocal);
     given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
 
     //when & then
@@ -181,7 +174,8 @@ class AuthServiceTest {
         .isInstanceOf(BusinessException.class)
         .hasMessageContaining(ErrorCode.AUTH_MISMATCH_PASSWORD.getMessage());
 
-    verify(loginHistoryRepo).save(any());
+    verify(authCommandService).saveLoginHistory(eq(auth), eq(LoginStatus.FAILURE), anyString(),
+        anyString());
   }
 
   @Test
@@ -210,20 +204,22 @@ class AuthServiceTest {
     String redisKey = "RT:" + email;
 
     Auth auth = Auth.builder().role(Role.USER).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
     AuthLocal authLocal = AuthLocal.builder().email(email).passwordHash("Qwer1234").auth(auth)
         .build();
     TokenDto newToken = TokenDto.of("newAccessToken", "newRefreshToken", 1000L, 9999L, auth,
         "프로필명");
-    User user = User.builder().nickname("프로필명").build();
 
     given(jwtTokenProvider.validateToken(oldRefreshToken)).willReturn(true);
     given(jwtTokenProvider.getEmailFromToken(oldRefreshToken)).willReturn(email);
     given(redisService.getValues(redisKey)).willReturn(oldRefreshToken);
-    given(authLocalRepo.findByEmail(email)).willReturn(Optional.of(authLocal));
-    given(userRepo.findByAuth(auth)).willReturn(Optional.of(user));
+    given(authCommandService.getAuthLocalByEmail(email)).willReturn(authLocal);
+    given(authCommandService.extractProfileNameByRole(auth)).willReturn("프로필명");
+    given(authCommandService.extractUserIdIfPresent(auth)).willReturn(1L);
+    given(authCommandService.extractSellerIdIfPresent(auth)).willReturn(null);
     given(jwtTokenProvider.createRefreshToken(email)).willReturn(newToken.refreshToken());
-    given(jwtTokenProvider.createAccessToken(email, null, null, null, auth.getRole().name()))
-        .willReturn(newToken.accessToken());
+    given(jwtTokenProvider.createAccessToken(anyString(), any(Long.class), nullable(Long.class),
+        nullable(Long.class), eq(auth.getRole().name()))).willReturn(newToken.accessToken());
     given(jwtTokenProvider.getRefreshTokenValidTime()).willReturn(9999L);
     given(jwtTokenProvider.getAccessTokenValidTime()).willReturn(1000L); // 만료 시간 모킹
 

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -14,6 +14,7 @@ import com.example.WonkaoTalk.common.config.security.jwt.JwtTokenProvider;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.redis.RedisService;
+import com.example.WonkaoTalk.domain.auth.dto.AuthUserInfoDto;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
 import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
@@ -22,7 +23,6 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
-import com.example.WonkaoTalk.domain.user.entity.User;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -126,15 +126,11 @@ class AuthServiceTest {
         .auth(auth)
         .build();
 
-    User user = User.builder().nickname("침착맨").build();
+    AuthUserInfoDto userInfo = AuthUserInfoDto.of("침착맨", 1L, null);
 
     given(authCommandService.getAuthLocalByEmail(anyString())).willReturn(authLocal);
     given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
-
-    given(authCommandService.extractProfileNameByRole(any(Auth.class))).willReturn("침착맨");
-    given(authCommandService.extractUserIdIfPresent(any(Auth.class))).willReturn(1L);
-    given(authCommandService.extractSellerIdIfPresent(any(Auth.class))).willReturn(null);
-
+    given(authCommandService.getAuthUserInfo(any(Auth.class))).willReturn(userInfo);
     given(jwtTokenProvider.createAccessToken(anyString(), any(Long.class), nullable(Long.class),
         nullable(Long.class), anyString())).willReturn("mockAccessToken");
     given(jwtTokenProvider.createRefreshToken(anyString())).willReturn("mockRefreshToken");
@@ -209,14 +205,13 @@ class AuthServiceTest {
         .build();
     TokenDto newToken = TokenDto.of("newAccessToken", "newRefreshToken", 1000L, 9999L, auth,
         "프로필명");
+    AuthUserInfoDto userInfo = AuthUserInfoDto.of("침착맨", 1L, null);
 
     given(jwtTokenProvider.validateToken(oldRefreshToken)).willReturn(true);
     given(jwtTokenProvider.getEmailFromToken(oldRefreshToken)).willReturn(email);
     given(redisService.getValues(redisKey)).willReturn(oldRefreshToken);
     given(authCommandService.getAuthLocalByEmail(email)).willReturn(authLocal);
-    given(authCommandService.extractProfileNameByRole(auth)).willReturn("프로필명");
-    given(authCommandService.extractUserIdIfPresent(auth)).willReturn(1L);
-    given(authCommandService.extractSellerIdIfPresent(auth)).willReturn(null);
+    given(authCommandService.getAuthUserInfo(auth)).willReturn(userInfo);
     given(jwtTokenProvider.createRefreshToken(email)).willReturn(newToken.refreshToken());
     given(jwtTokenProvider.createAccessToken(anyString(), any(Long.class), nullable(Long.class),
         nullable(Long.class), eq(auth.getRole().name()))).willReturn(newToken.accessToken());


### PR DESCRIPTION
## 📌 관련 이슈
- #64 

## 📝 작업 내용
- AuthService의 트랜잭션이 필요한 로직을 분리해 AuthCommandService로 작성하였습니다.
- AuthCommandService로 분리되어 기존의 AuthServiceTest의 테스트 코드를 수정하였습니다.

## ✅ 작업 결과 
<img width="617" height="291" alt="image" src="https://github.com/user-attachments/assets/df795a73-c4da-40b9-940b-81e9f705e844" />


## 🎸 기타
