### PR TITLE
fix: 로컬 버킷 설정을 public으로 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
   minio-init:
     image: minio/mc
     container_name: wonkao-talk-minio-init
+    restart: "no"
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,24 @@ services:
     command: server /data --console-address ":9001"
     volumes:
       - ./minio/data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  minio-init:
+    image: minio/mc
+    container_name: wonkao-talk-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb --ignore-existing local/wonkao-talk;
+      mc anonymous set download local/wonkao-talk;
+      "
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0


### PR DESCRIPTION
## 📌 관련 이슈
- #89 

## 📝 작업 내용
- minio의 버킷 설정을 private에서 public으로 변경했습니다.

## ✅ 작업 결과 
- 버킷의 설정만 변경했습니다

## 🎸 기타
- docker compose up을 다시 해야 적용이 될 수도 있습니다.
- S3랑은 별개입니다.
