### PR TITLE
Feat/92 주문 시 배송 정보 저장 로직 추가

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateRequest.java
@@ -14,7 +14,7 @@ public record OrderCreateRequest(
 
     @Valid
     @NotNull
-    DeliveryRequest delivery,
+    DeliveryRequestDto delivery,
 
     // TODO: 포인트 도메인 구현 후 보유 포인트/사용 정책 검증 추가
     @Min(0)
@@ -23,7 +23,7 @@ public record OrderCreateRequest(
 ) {
 
   // 일단은 static으로 선언해서 사용. -> 아직은 해당 DTO에서만 사용하기때문..(요청의 일부)
-  public record DeliveryRequest(
+  public record DeliveryRequestDto(
       @NotBlank
       String recipientName,
 

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/Delivery.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/Delivery.java
@@ -13,13 +13,18 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "deliveries")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Delivery {
 
   @Id
@@ -52,6 +57,13 @@ public class Delivery {
   @Column
   private String memo;
 
+  @Column
+  private String deliveryCompany;
+
+  @Column
+  private String trackingNumber; // TODO: Long으로 할지 고민중.. 운송번호 보통 다 정수일것같은데 아닐수있어서..
+
+
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
@@ -59,5 +71,39 @@ public class Delivery {
   @LastModifiedDate
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
+
+  private Delivery(Order order, String recipientName, String recipientPhone, String zipcode,
+      String address, String addressDetail, String memo, DeliveryStatus deliveryStatus) {
+    this.order = order;
+    this.recipientName = recipientName;
+    this.recipientPhone = recipientPhone;
+    this.zipcode = zipcode;
+    this.address = address;
+    this.addressDetail = addressDetail;
+    this.memo = memo;
+    this.deliveryStatus = deliveryStatus;
+  }
+
+  public static Delivery createDelivery(Order order, String recipientName, String recipientPhone,
+      String zipcode,
+      String address, String addressDetail, String memo) {
+    return new Delivery(order, recipientName, recipientPhone, zipcode, address, addressDetail, memo,
+        DeliveryStatus.PREPARING);
+  }
+
+  public void markShipped(String deliveryCompany, String trackingNumber) {
+    this.deliveryCompany = deliveryCompany;
+    this.trackingNumber = trackingNumber;
+    this.deliveryStatus = DeliveryStatus.SHIPPED;
+  }
+
+  public void markInTransit() {
+    this.deliveryStatus = DeliveryStatus.IN_TRANSIT;
+  }
+
+  public void markDelivered() {
+    this.deliveryStatus = DeliveryStatus.DELIVERED;
+  }
+
 
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/DeliveryStatus.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/DeliveryStatus.java
@@ -1,6 +1,8 @@
 package com.example.WonkaoTalk.domain.order.entity;
 
 public enum DeliveryStatus {
-  SHIPPING,
+  PREPARING,
   SHIPPED,
+  IN_TRANSIT, // 배송 중
+  DELIVERED,  // 배송 완료
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -3,14 +3,17 @@ package com.example.WonkaoTalk.domain.order.service;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
+import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest.DeliveryRequestDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.OrderPreviewItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.SummaryDto;
+import com.example.WonkaoTalk.domain.order.entity.Delivery;
 import com.example.WonkaoTalk.domain.order.entity.Order;
 import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.repo.DeliveryRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
@@ -44,6 +47,7 @@ public class OrderService {
   private final ProductVariantRepo productVariantRepo;
   private final OrderRepo orderRepo;
   private final OrderItemRepo orderItemRepo;
+  private final DeliveryRepo deliveryRepo;
 
   private final PaymentService paymentService;
 
@@ -110,14 +114,21 @@ public class OrderService {
     Order savedOrder = orderRepo.save(order);
     orderItemRepo.saveAll(createOrderItems(savedOrder, orderItems, productVariants));
 
-    // TODO: Delivery 생성
-
     // 12. Payment 생성
     // status = READY
     // tossOrderId 생성
     // idempotencyKey 생성
     // totalAmount = order.finalAmount
     Payment payment = paymentService.createReadyPayment(savedOrder);
+
+    // TODO: 함수로 뺄지 고민
+    DeliveryRequestDto deliveryRequestDto = requestDto.delivery();
+
+    Delivery delivery = Delivery.createDelivery(savedOrder, deliveryRequestDto.recipientName(),
+        deliveryRequestDto.recipientPhone(), deliveryRequestDto.zipcode(),
+        deliveryRequestDto.address(), deliveryRequestDto.addressDetail(),
+        deliveryRequestDto.memo());
+    deliveryRepo.save(delivery);
 
     // 13. 주문 생성 응답 반환
     // orderId, orderNumber, paymentId, tossOrderId, amount, orderName

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -121,14 +121,7 @@ public class OrderService {
     // totalAmount = order.finalAmount
     Payment payment = paymentService.createReadyPayment(savedOrder);
 
-    // TODO: 함수로 뺄지 고민
-    DeliveryRequestDto deliveryRequestDto = requestDto.delivery();
-
-    Delivery delivery = Delivery.createDelivery(savedOrder, deliveryRequestDto.recipientName(),
-        deliveryRequestDto.recipientPhone(), deliveryRequestDto.zipcode(),
-        deliveryRequestDto.address(), deliveryRequestDto.addressDetail(),
-        deliveryRequestDto.memo());
-    deliveryRepo.save(delivery);
+    saveDelivery(savedOrder, requestDto.delivery());
 
     // 13. 주문 생성 응답 반환
     // orderId, orderNumber, paymentId, tossOrderId, amount, orderName
@@ -322,6 +315,20 @@ public class OrderService {
             item.quantity()
         ))
         .toList();
+  }
+
+  private void saveDelivery(Order order, DeliveryRequestDto deliveryRequestDto) {
+    Delivery delivery = Delivery.createDelivery(
+        order,
+        deliveryRequestDto.recipientName(),
+        deliveryRequestDto.recipientPhone(),
+        deliveryRequestDto.zipcode(),
+        deliveryRequestDto.address(),
+        deliveryRequestDto.addressDetail(),
+        deliveryRequestDto.memo()
+    );
+
+    deliveryRepo.save(delivery);
   }
 
   // 주문 번호 생성

--- a/src/test/java/com/example/WonkaoTalk/domain/order/entity/DeliveryTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/order/entity/DeliveryTest.java
@@ -1,0 +1,66 @@
+package com.example.WonkaoTalk.domain.order.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DeliveryTest {
+
+  @Test
+  @DisplayName("배송 정보 생성 시 PREPARING 상태로 초기화된다.")
+  void createDelivery_InitializesPreparingStatus() {
+    // given
+    Order order = Order.createOrder("ORD-1234", null, 10000L, 0L, 0L, 10000L, "테스트 상품");
+
+    // when
+    Delivery delivery = Delivery.createDelivery(order, "홍길동", "010-1234-5678", "06234",
+        "서울특별시 강남구 테헤란로", "101동 1001호", "문 앞에 놔주세요");
+
+    // then
+    assertThat(delivery.getOrder()).isEqualTo(order);
+    assertThat(delivery.getRecipientName()).isEqualTo("홍길동");
+    assertThat(delivery.getRecipientPhone()).isEqualTo("010-1234-5678");
+    assertThat(delivery.getZipcode()).isEqualTo("06234");
+    assertThat(delivery.getAddress()).isEqualTo("서울특별시 강남구 테헤란로");
+    assertThat(delivery.getAddressDetail()).isEqualTo("101동 1001호");
+    assertThat(delivery.getMemo()).isEqualTo("문 앞에 놔주세요");
+    assertThat(delivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.PREPARING);
+  }
+
+  @Test
+  @DisplayName("배송 시작 처리 시 택배사와 운송장 번호를 저장하고 SHIPPED 상태로 변경한다.")
+  void markShipped_UpdatesCarrierInfoAndStatus() {
+    // given
+    Delivery delivery = Delivery.createDelivery(null, "홍길동", "010-1234-5678", "06234",
+        "서울특별시 강남구 테헤란로", "101동 1001호", null);
+
+    // when
+    delivery.markShipped("CJ대한통운", "1234567890");
+
+    // then
+    assertThat(delivery.getDeliveryCompany()).isEqualTo("CJ대한통운");
+    assertThat(delivery.getTrackingNumber()).isEqualTo("1234567890");
+    assertThat(delivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.SHIPPED);
+  }
+
+  @Test
+  @DisplayName("배송 중과 배송 완료 상태로 변경할 수 있다.")
+  void markInTransitAndDelivered_UpdatesDeliveryStatus() {
+    // given
+    Delivery delivery = Delivery.createDelivery(null, "홍길동", "010-1234-5678", "06234",
+        "서울특별시 강남구 테헤란로", "101동 1001호", null);
+
+    // when
+    delivery.markInTransit();
+
+    // then
+    assertThat(delivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.IN_TRANSIT);
+
+    // when
+    delivery.markDelivered();
+
+    // then
+    assertThat(delivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.DELIVERED);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
@@ -2,19 +2,42 @@ package com.example.WonkaoTalk.domain.order.service;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
+import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest.DeliveryRequestDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderItemDto;
+import com.example.WonkaoTalk.domain.order.entity.Delivery;
+import com.example.WonkaoTalk.domain.order.entity.DeliveryStatus;
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.order.repo.DeliveryRepo;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
+import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.service.PaymentService;
+import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -22,6 +45,24 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class OrderServiceTest {
+
+  @Mock
+  private UserRepo userRepo;
+
+  @Mock
+  private ProductVariantRepo productVariantRepo;
+
+  @Mock
+  private OrderRepo orderRepo;
+
+  @Mock
+  private OrderItemRepo orderItemRepo;
+
+  @Mock
+  private DeliveryRepo deliveryRepo;
+
+  @Mock
+  private PaymentService paymentService;
 
   @InjectMocks
   private OrderService orderService;
@@ -121,5 +162,64 @@ public class OrderServiceTest {
         .hasMessage(ErrorCode.PROD_STOCK_INSUFFICIENT.getMessage());
   }
 
+  @Test
+  @DisplayName("주문 생성 시 요청 배송 정보를 Delivery로 저장한다.")
+  public void createOrder_SaveDeliveryInfo() {
+    // given
+    User user = mock(User.class);
+    Product product = mock(Product.class);
+    ProductVariant variant = mock(ProductVariant.class);
+
+    OrderCreateRequest request = new OrderCreateRequest(
+        List.of(new OrderItemDto(10L, 2)),
+        new DeliveryRequestDto(
+            "홍길동",
+            "010-1234-5678",
+            "06234",
+            "서울특별시 강남구 테헤란로",
+            "101동 1001호",
+            "문 앞에 놔주세요"
+        ),
+        0L
+    );
+
+    when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+    when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(variant));
+    when(orderRepo.existsByOrderNumber(any())).thenReturn(false);
+    when(orderRepo.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(orderItemRepo.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(paymentService.createReadyPayment(any(Order.class))).thenAnswer(invocation ->
+        Payment.createReadyPayment(invocation.getArgument(0), "ORD-TEST-PAY", "idem-key", 20000L,
+            LocalDateTime.now()));
+
+    when(variant.getId()).thenReturn(10L);
+    when(variant.getStock()).thenReturn(10);
+    when(variant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    when(variant.getProduct()).thenReturn(product);
+    when(variant.getName()).thenReturn("검정");
+
+    when(product.getId()).thenReturn(100L);
+    when(product.getName()).thenReturn("테스트 상품");
+    when(product.getThumbnail()).thenReturn("thumbnail.jpg");
+    when(product.getPrice()).thenReturn(12000);
+    when(product.getDiscountedPrice()).thenReturn(10000);
+
+    // when
+    orderService.createOrder(1L, request);
+
+    // then
+    ArgumentCaptor<Delivery> deliveryCaptor = ArgumentCaptor.forClass(Delivery.class);
+    verify(deliveryRepo).save(deliveryCaptor.capture());
+
+    Delivery savedDelivery = deliveryCaptor.getValue();
+    assertThat(savedDelivery.getRecipientName()).isEqualTo("홍길동");
+    assertThat(savedDelivery.getRecipientPhone()).isEqualTo("010-1234-5678");
+    assertThat(savedDelivery.getZipcode()).isEqualTo("06234");
+    assertThat(savedDelivery.getAddress()).isEqualTo("서울특별시 강남구 테헤란로");
+    assertThat(savedDelivery.getAddressDetail()).isEqualTo("101동 1001호");
+    assertThat(savedDelivery.getMemo()).isEqualTo("문 앞에 놔주세요");
+    assertThat(savedDelivery.getDeliveryStatus()).isEqualTo(DeliveryStatus.PREPARING);
+    assertThat(savedDelivery.getOrder()).isNotNull();
+  }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #92 

## 📝 작업 내용
- 배송 정보 저장 및 이후 배송 상태 변경에 대한 로직 추가

## ✅ 작업 결과 
- 
<img width="1283" height="325" alt="image" src="https://github.com/user-attachments/assets/f8c2b37a-09cd-4906-96c6-bfdad5fd0006" />


## 🎸 기타
