### PR TITLE
refactor: 웹소켓을 위한 메시지 전송 데이터 구조 변경 및 테스트코드 작성

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatMessageController.java
@@ -9,6 +9,7 @@ import com.example.WonkaoTalk.domain.chat.service.ChatMessageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatMessageController {
 
   private final ChatMessageService chatMessageService;
+  private final SimpMessagingTemplate messagingTemplate;
 
   @PostMapping("/{chatRoomId}/messages")
   public ResponseEntity<ApiResponse<ChatMessageResponse>> sendMessage(
@@ -34,7 +36,7 @@ public class ChatMessageController {
     Long userId = userDetails.getUserId();
 
     ChatMessageResponse data = chatMessageService.sendMessage(userId, chatRoomId, request);
-
+    messagingTemplate.convertAndSend("/sub/chat/room/" + chatRoomId, data);
     return ResponseEntity.ok(ApiResponse.success("메시지를 전송했습니다.", data));
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/dto/ChatMessageResponse.java
@@ -1,16 +1,31 @@
 package com.example.WonkaoTalk.domain.chat.dto;
 
 import com.example.WonkaoTalk.domain.chat.entity.ChatMessage;
+import com.example.WonkaoTalk.domain.chat.enums.MessageType;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
 public record ChatMessageResponse(
-    Long messageId
+    Long messageId,
+    Long senderId,
+    String nickname,
+    String content,
+    MessageType messageType,
+    LocalDateTime createdAt,
+    Integer unreadCount
 ) {
 
-  public static ChatMessageResponse from(ChatMessage chatMessage) {
+  public static ChatMessageResponse of(ChatMessage chatMessage, String senderNickname,
+      Integer unreadCount) {
     return ChatMessageResponse.builder()
         .messageId(chatMessage.getId())
+        .senderId(chatMessage.getSenderId())
+        .nickname(senderNickname)
+        .content(chatMessage.getContent())
+        .messageType(chatMessage.getMessageType())
+        .createdAt(chatMessage.getCreatedAt())
+        .unreadCount(unreadCount)
         .build();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
@@ -22,11 +22,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +33,6 @@ public class ChatMessageService {
   private final ChatMessageRepo chatMessageRepo;
   private final ChatRoomRepo chatRoomRepo;
   private final ChatParticipantRepo chatParticipantRepo;
-  private final SimpMessagingTemplate messagingTemplate;
   private final UserRepo userRepo;
 
   @Transactional
@@ -73,17 +69,7 @@ public class ChatMessageService {
         chatRoomId);
     int unreadCount = calculateUnreadCount(chatMessage.getId(), allReadMessageIds);
 
-    ChatMessageResponse response = ChatMessageResponse.of(chatMessage, me.getNickname(),
-        unreadCount);
-
-    TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-      @Override
-      public void afterCommit() {
-        messagingTemplate.convertAndSend("/sub/chat/room/" + chatRoomId, response);
-      }
-    });
-
-    return response;
+    return ChatMessageResponse.of(chatMessage, me.getNickname(), unreadCount);
   }
 
   @Transactional

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageService.java
@@ -48,6 +48,9 @@ public class ChatMessageService {
             userId)
         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHAT_PARTICIPANT));
 
+    User me = userRepo.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
     ChatMessage answerMessage = null;
     if (request.answerMessageId() != null) {
       answerMessage = chatMessageRepo.findById(request.answerMessageId())
@@ -66,7 +69,12 @@ public class ChatMessageService {
     chatRoom.updateLastMessage(chatMessage.getContent(), chatMessage.getCreatedAt());
     participant.updateLastReadMessage(chatMessage);
 
-    ChatMessageResponse response = ChatMessageResponse.from(chatMessage);
+    List<Long> allReadMessageIds = chatParticipantRepo.findAllParticipantsLastReadMessageIds(
+        chatRoomId);
+    int unreadCount = calculateUnreadCount(chatMessage.getId(), allReadMessageIds);
+
+    ChatMessageResponse response = ChatMessageResponse.of(chatMessage, me.getNickname(),
+        unreadCount);
 
     TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
       @Override

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageServiceTest.java
@@ -1,188 +1,337 @@
-//package com.example.WonkaoTalk.domain.chat.service;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//import com.example.WonkaoTalk.common.exception.BusinessException;
-//import com.example.WonkaoTalk.common.exception.ErrorCode;
-//import com.example.WonkaoTalk.domain.chat.dto.ChatMessageListResponse;
-//import com.example.WonkaoTalk.domain.chat.dto.ChatMessageRequest;
-//import com.example.WonkaoTalk.domain.chat.dto.ChatMessageResponse;
-//import com.example.WonkaoTalk.domain.chat.entity.ChatMessage;
-//import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
-//import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
-//import com.example.WonkaoTalk.domain.chat.enums.MessageType;
-//import com.example.WonkaoTalk.domain.chat.enums.RoomType;
-//import com.example.WonkaoTalk.domain.chat.repo.ChatMessageRepo;
-//import com.example.WonkaoTalk.domain.chat.repo.ChatParticipantRepo;
-//import com.example.WonkaoTalk.domain.chat.repo.ChatRoomRepo;
-//import java.time.LocalDateTime;
-//import java.util.List;
-//import java.util.Optional;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.data.domain.SliceImpl;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//@ExtendWith(MockitoExtension.class)
-//class ChatMessageServiceTest {
-//
-//  @InjectMocks
-//  private ChatMessageService chatMessageService;
-//
-//  @Mock
-//  private ChatMessageRepo chatMessageRepo;
-//  @Mock
-//  private ChatRoomRepo chatRoomRepo;
-//  @Mock
-//  private ChatParticipantRepo chatParticipantRepo;
-//
-//  @Test
-//  @DisplayName("✅ 메시지 전송 성공")
-//  void sendMessageSuccessTest() {
-//    // given
-//    Long userId = 1L;
-//    Long chatRoomId = 10L;
-//    ChatMessageRequest request = ChatMessageRequest.builder()
-//        .content("테스트")
-//        .messageType(MessageType.TEXT)
-//        .build();
-//
-//    ChatRoom room = ChatRoom.builder().build();
-//    ChatParticipant participant = ChatParticipant.builder().build();
-//
-//    when(chatRoomRepo.findById(chatRoomId)).thenReturn(Optional.of(room));
-//    when(chatParticipantRepo.findByChatRoomIdAndUserId(chatRoomId, userId))
-//        .thenReturn(Optional.of(participant));
-//
-//    when(chatMessageRepo.saveAndFlush(any(ChatMessage.class))).thenAnswer(invocation -> {
-//      ChatMessage message = invocation.getArgument(0);
-//      ReflectionTestUtils.setField(message, "id", 100L);
-//      return message;
-//    });
-//
-//    // when
-//    ChatMessageResponse response = chatMessageService.sendMessage(userId, chatRoomId, request);
-//
-//    // then
-//    assertThat(response.messageId()).isEqualTo(100L);
-//
-//    assertThat(room.getLastMessageContent()).isEqualTo("테스트");
-//    assertThat(participant.getLastReadMessage()).isNotNull();
-//
-//    verify(chatMessageRepo, times(1)).saveAndFlush(any(ChatMessage.class));
-//  }
-//
-//  @Test
-//  @DisplayName("❌ 실패 - 존재하지 않는 채팅방")
-//  void sendMessageFailRoomNotFound() {
-//    // given
-//    Long userId = 1L;
-//    Long chatRoomId = 999L;
-//    ChatMessageRequest request = ChatMessageRequest.builder().content("테스트").build();
-//
-//    when(chatRoomRepo.findById(chatRoomId)).thenReturn(Optional.empty());
-//
-//    // when & then
-//    assertThatThrownBy(() -> chatMessageService.sendMessage(userId, chatRoomId, request))
-//        .isInstanceOf(BusinessException.class)
-//        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
-//  }
-//
-//  @Test
-//  @DisplayName("❌ 실패 - 채팅방 참여 권한 없음")
-//  void sendMessageFailNotParticipant() {
-//    // given
-//    Long userId = 1L;
-//    Long chatRoomId = 10L;
-//    ChatMessageRequest request = ChatMessageRequest.builder().content("테스트").build();
-//
-//    ChatRoom room = ChatRoom.builder().build();
-//    when(chatRoomRepo.findById(chatRoomId)).thenReturn(Optional.of(room));
-//
-//    when(chatParticipantRepo.findByChatRoomIdAndUserId(chatRoomId, userId))
-//        .thenReturn(Optional.empty());
-//
-//    // when & then
-//    assertThatThrownBy(() -> chatMessageService.sendMessage(userId, chatRoomId, request))
-//        .isInstanceOf(BusinessException.class)
-//        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_CHAT_PARTICIPANT);
-//  }
-//
-//  @Test
-//  @DisplayName("✅ 메시지 내역 조회 성공")
-//  void getMessageListSuccessNoCursorTest() {
-//    // given
-//    Long myId = 1L;
-//    Long chatRoomId = 10L;
-//    int size = 20;
-//
-//    ChatRoom chatRoom = createChatRoom(chatRoomId);
-//    ChatParticipant myParticipant = createParticipant(chatRoom, myId);
-//
-//    ChatMessage msg1 = createMessage(200L, chatRoom, 2L, "상대방이 보낸 최신 메시지");
-//    ChatMessage msg2 = createMessage(199L, chatRoom, myId, "내가 보낸 과거 메시지");
-//    List<ChatMessage> mockMessages = List.of(msg1, msg2);
-//
-//    when(chatParticipantRepo.findByChatRoomIdAndUserId(chatRoomId, myId))
-//        .thenReturn(Optional.of(myParticipant));
-//
-//    when(chatMessageRepo.findMessagesByCursor(eq(chatRoomId), eq(null),
-//        any(PageRequest.class)))
-//        .thenReturn(new SliceImpl<>(mockMessages, PageRequest.of(0, size), true));
-//
-//    when(chatParticipantRepo.findAllParticipantsLastReadMessageIds(chatRoomId))
-//        .thenReturn(List.of(200L));
-//
-//    // when
-//    ChatMessageListResponse response = chatMessageService.getMessageList(myId, chatRoomId, null,
-//        size);
-//
-//    // then
-//    assertThat(response).isNotNull();
-//    assertThat(response.messageList()).hasSize(2);
-//    assertThat(response.nextCursorId()).isEqualTo(199L);
-//
-//    assertThat(response.messageList().get(0).isMe()).isFalse();
-//    assertThat(response.messageList().get(0).unreadCount()).isEqualTo(0);
-//
-//    assertThat(response.messageList().get(1).isMe()).isTrue();
-//    assertThat(response.messageList().get(1).unreadCount()).isEqualTo(0);
-//
-//    assertThat(myParticipant.getLastReadMessage().getId()).isEqualTo(200L);
-//  }
-//
-//  private ChatRoom createChatRoom(Long id) {
-//    ChatRoom room = ChatRoom.builder().roomType(RoomType.SINGLE).build();
-//    ReflectionTestUtils.setField(room, "id", id);
-//    return room;
-//  }
-//
-//  private ChatParticipant createParticipant(ChatRoom room, Long userId) {
-//    ChatParticipant participant = ChatParticipant.builder().chatRoom(room).userId(userId).build();
-//    ReflectionTestUtils.setField(participant, "id", 1L);
-//    return participant;
-//  }
-//
-//  private ChatMessage createMessage(Long id, ChatRoom room, Long senderId, String content) {
-//    ChatMessage message = ChatMessage.builder()
-//        .chatRoom(room)
-//        .senderId(senderId)
-//        .content(content)
-//        .messageType(MessageType.TEXT)
-//        .build();
-//    ReflectionTestUtils.setField(message, "id", id);
-//    ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
-//    return message;
-//  }
-//}
+package com.example.WonkaoTalk.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.chat.dto.ChatMessageListResponse;
+import com.example.WonkaoTalk.domain.chat.dto.ChatMessageRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatMessageResponse;
+import com.example.WonkaoTalk.domain.chat.entity.ChatMessage;
+import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import com.example.WonkaoTalk.domain.chat.enums.MessageType;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import com.example.WonkaoTalk.domain.chat.repo.ChatMessageRepo;
+import com.example.WonkaoTalk.domain.chat.repo.ChatParticipantRepo;
+import com.example.WonkaoTalk.domain.chat.repo.ChatRoomRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+  private static final Long USER_ID = 1L;
+  private static final Long ROOM_ID = 100L;
+
+  @InjectMocks
+  private ChatMessageService chatMessageService;
+
+  @Mock
+  private ChatMessageRepo chatMessageRepo;
+
+  @Mock
+  private ChatRoomRepo chatRoomRepo;
+
+  @Mock
+  private ChatParticipantRepo chatParticipantRepo;
+
+  @Mock
+  private UserRepo userRepo;
+
+  @Test
+  @DisplayName("메시지 전송 성공")
+  void sendMessageSuccess() {
+    // given
+    User user = createUser(USER_ID, "나");
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+
+    givenUnreadIds(2L, null);
+    givenSaveMessage();
+
+    // when
+    ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
+
+    // then
+    assertThat(result.content()).isEqualTo("안녕");
+    assertThat(result.nickname()).isEqualTo("나");
+    assertThat(result.unreadCount()).isEqualTo(1);
+    assertThat(room.getLastMessageContent()).isEqualTo("안녕");
+    assertThat(participant.getLastReadMessage()).isNotNull();
+
+    verify(chatMessageRepo).saveAndFlush(any(ChatMessage.class));
+  }
+
+  @Test
+  @DisplayName("답장 메시지 전송 성공")
+  void sendMessageAnswerSuccess() {
+    // given
+    User user = createUser(USER_ID, "나");
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+    ChatMessage answer = createMessage(room, 10L, USER_ID, "원본");
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+    given(chatMessageRepo.findById(10L)).willReturn(Optional.of(answer));
+
+    givenUnreadIds(1L);
+    givenSaveMessage();
+
+    // when
+    ChatMessageResponse result = chatMessageService.sendMessage(
+        USER_ID,
+        ROOM_ID,
+        new ChatMessageRequest("답장", MessageType.TEXT, 10L)
+    );
+
+    // then
+    assertThat(result.content()).isEqualTo("답장");
+  }
+
+  @Test
+  @DisplayName("채팅방이 없으면 예외 발생")
+  void sendMessageRoomNotFoundFail() {
+    // given
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("채팅 참여자가 아니면 예외 발생")
+  void sendMessageNotParticipantFail() {
+    // given
+    ChatRoom room = createRoom();
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.NOT_CHAT_PARTICIPANT);
+  }
+
+  @Test
+  @DisplayName("유저가 없으면 예외 발생")
+  void sendMessageUserNotFoundFail() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    given(userRepo.findById(USER_ID)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("답장 메시지가 없으면 예외 발생")
+  void sendMessageAnswerMessageNotFoundFail() {
+    // given
+    User user = createUser(USER_ID, "나");
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+    given(chatMessageRepo.findById(99L)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID,
+        new ChatMessageRequest("답장", MessageType.TEXT, 99L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("메시지 목록 조회 성공")
+  void getMessageListSuccess() {
+    // given
+    User user = createUser(USER_ID, "나");
+    User otherUser = createUser(2L, "너");
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    ChatMessage message1 = createMessage(room, 10L, USER_ID, "안녕");
+    ChatMessage message2 = createMessage(room, 9L, 2L, "반가워");
+
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    givenMessageSlice(true, message1, message2);
+    givenUnreadIds(9L);
+    given(userRepo.findAllById(any())).willReturn(List.of(user, otherUser));
+
+    // when
+    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
+
+    // then
+    assertThat(result.messageList()).hasSize(2);
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.nextCursorId()).isEqualTo(9L);
+    assertThat(participant.getLastReadMessage().getId()).isEqualTo(10L);
+  }
+
+  @Test
+  @DisplayName("닉네임이 없으면 알 수 없음 처리")
+  void getMessageListUnknownNicknameSuccess() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+    ChatMessage message = createMessage(room, 10L, 999L, "hello");
+
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    givenMessageSlice(false, message);
+    givenUnreadIds();
+    given(userRepo.findAllById(any())).willReturn(List.of());
+
+    // when
+    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
+
+    // then
+    assertThat(result.messageList().getFirst().nickname()).isEqualTo("(알 수 없음)");
+  }
+
+  @Test
+  @DisplayName("메시지가 없으면 빈 목록 반환")
+  void getMessageListEmptySuccess() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    givenMessageSlice(false);
+    givenUnreadIds();
+    given(userRepo.findAllById(any())).willReturn(List.of());
+
+    // when
+    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
+
+    // then
+    assertThat(result.messageList()).isEmpty();
+    assertThat(result.nextCursorId()).isNull();
+  }
+
+  @Test
+  @DisplayName("참여자가 아니면 메시지 조회 실패")
+  void getMessageListNotParticipantFail() {
+    // given
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.NOT_CHAT_PARTICIPANT);
+  }
+
+  // -- 헬퍼 메서드 --
+  private void givenUnreadIds(Long... ids) {
+    given(chatParticipantRepo.findAllParticipantsLastReadMessageIds(ROOM_ID))
+        .willReturn(Arrays.asList(ids));
+  }
+
+  private void givenSaveMessage() {
+    given(chatMessageRepo.saveAndFlush(any(ChatMessage.class))).willAnswer(invocation -> {
+      ChatMessage message = invocation.getArgument(0);
+      ReflectionTestUtils.setField(message, "id", 2L);
+      ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
+      return message;
+    });
+  }
+
+  private void givenMessageSlice(boolean hasNext, ChatMessage... messages) {
+    Slice<ChatMessage> slice = new SliceImpl<>(List.of(messages), PageRequest.of(0, 20), hasNext);
+    given(chatMessageRepo.findMessagesByCursor(ROOM_ID, null, PageRequest.of(0, 20)))
+        .willReturn(slice);
+  }
+
+  private User createUser(Long id, String nickname) {
+    User user = User.builder()
+        .nickname(nickname)
+        .name(nickname)
+        .phone("01012341234")
+        .build();
+    ReflectionTestUtils.setField(user, "id", id);
+    return user;
+  }
+
+  private ChatRoom createRoom() {
+    ChatRoom room = ChatRoom.builder()
+        .roomType(RoomType.SINGLE)
+        .participantCount(2)
+        .build();
+    ReflectionTestUtils.setField(room, "id", ROOM_ID);
+    return room;
+  }
+
+  private ChatParticipant createParticipant(ChatRoom room) {
+    ChatParticipant participant = ChatParticipant.builder()
+        .chatRoom(room)
+        .userId(USER_ID)
+        .build();
+    ReflectionTestUtils.setField(participant, "id", 10L);
+    return participant;
+  }
+
+  private ChatMessage createMessage(ChatRoom room, Long id, Long senderId, String content) {
+    ChatMessage message = ChatMessage.builder()
+        .chatRoom(room)
+        .senderId(senderId)
+        .content(content)
+        .messageType(MessageType.TEXT)
+        .build();
+    ReflectionTestUtils.setField(message, "id", id);
+    ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
+    return message;
+  }
+
+  private ChatMessageRequest request() {
+    return new ChatMessageRequest("안녕", MessageType.TEXT, null);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
@@ -1,0 +1,261 @@
+package com.example.WonkaoTalk.domain.chat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
+import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
+import com.example.WonkaoTalk.domain.chat.entity.ChatMessage;
+import com.example.WonkaoTalk.domain.chat.entity.ChatParticipant;
+import com.example.WonkaoTalk.domain.chat.entity.ChatRoom;
+import com.example.WonkaoTalk.domain.chat.enums.MessageType;
+import com.example.WonkaoTalk.domain.chat.enums.RoomType;
+import com.example.WonkaoTalk.domain.chat.repo.ChatMessageRepo;
+import com.example.WonkaoTalk.domain.chat.repo.ChatParticipantRepo;
+import com.example.WonkaoTalk.domain.chat.repo.ChatRoomRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+  private static final Long USER_ID = 1L;
+  private static final Long RECEIVER_ID = 2L;
+  private static final Long ROOM_ID = 100L;
+
+  @InjectMocks
+  private ChatRoomService chatRoomService;
+
+  @Mock
+  private ChatRoomRepo chatRoomRepo;
+
+  @Mock
+  private ChatParticipantRepo chatParticipantRepo;
+
+  @Mock
+  private UserRepo userRepo;
+
+  @Mock
+  private ChatMessageRepo chatMessageRepo;
+
+  @Test
+  @DisplayName("채팅방 생성 성공 - 기존 방 존재 시 조회")
+  void createChatRoomWhenRoomExists_ReturnsExistingRoom() {
+    // given
+    User me = createUser(USER_ID, "나");
+    User receiver = createUser(RECEIVER_ID, "상대방");
+    ChatRoom room = createRoom();
+
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
+    given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.of(receiver));
+    given(chatParticipantRepo.findChatRoomByUsers(USER_ID, RECEIVER_ID)).willReturn(
+        Optional.of(room));
+
+    // when
+    ChatRoomResponse result = chatRoomService.createChatRoom(USER_ID,
+        new ChatRoomCreateRequest(RECEIVER_ID));
+
+    // then
+    assertThat(result.chatRoomId()).isEqualTo(ROOM_ID);
+    assertThat(result.participants()).hasSize(2);
+    verify(chatRoomRepo, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("채팅방 생성 성공 - 새 방 생성")
+  void createChatRoomWhenNewRoomReturnsCreatedRoom() {
+    // given
+    User me = createUser(USER_ID, "나");
+    User receiver = createUser(RECEIVER_ID, "상대방");
+    ChatRoom room = createRoom();
+
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
+    given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.of(receiver));
+    given(chatParticipantRepo.findChatRoomByUsers(USER_ID, RECEIVER_ID)).willReturn(
+        Optional.empty());
+    given(chatRoomRepo.save(any(ChatRoom.class))).willReturn(room);
+
+    // when
+    ChatRoomResponse result = chatRoomService.createChatRoom(USER_ID,
+        new ChatRoomCreateRequest(RECEIVER_ID));
+
+    // then
+    assertThat(result.chatRoomId()).isEqualTo(ROOM_ID);
+    assertThat(result.roomType()).isEqualTo(RoomType.SINGLE);
+    verify(chatRoomRepo, times(1)).save(any(ChatRoom.class));
+    verify(chatParticipantRepo, times(2)).save(any(ChatParticipant.class));
+  }
+
+  @Test
+  @DisplayName("자기 자신과 채팅방 생성 시 예외 발생")
+  void createChatRoomWhenSelfThrowsException() {
+    // when & then
+    assertThatThrownBy(
+        () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(USER_ID)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.CANNOT_CHAT_SELF);
+  }
+
+  @Test
+  @DisplayName("내 유저 정보가 없으면 예외 발생")
+  void createChatRoomWhenMyUserNotFoundThrowsException() {
+    // given
+    given(userRepo.findById(USER_ID)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+        () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(RECEIVER_ID)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("상대 유저 정보가 없으면 예외 발생")
+  void createChatRoomWhenReceiverNotFoundThrowsException() {
+    // given
+    User me = createUser(USER_ID, "나");
+
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
+    given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+        () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(RECEIVER_ID)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("채팅방 목록 조회 성공")
+  void getChatRoomListWhenRoomsExistReturnsList() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+        .willReturn(createSlice(true, participant));
+    given(chatMessageRepo.countUnreadMessages(ROOM_ID, null))
+        .willReturn(3);
+
+    // when
+    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    assertThat(result.rooms()).hasSize(1);
+    assertThat(result.hasNext()).isTrue();
+    assertThat(result.nextCursorId()).isEqualTo(ROOM_ID);
+    assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("읽은 메시지 정보가 있을 때 읽지 않은 메시지 개수 계산 성공")
+  void getChatRoomListWithLastReadMessageReturnsUnreadCount() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+    ChatMessage lastRead = createMessage(room);
+    participant.updateLastReadMessage(lastRead);
+
+    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+        .willReturn(createSlice(false, participant));
+    given(chatMessageRepo.countUnreadMessages(ROOM_ID, 10L))
+        .willReturn(1);
+
+    // when
+    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("채팅방이 없으면 빈 목록 반환")
+  void getChatRoomListWhenEmptyReturnsEmptyList() {
+    // given
+    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+        .willReturn(createSlice(false));
+
+    // when
+    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    assertThat(result.rooms()).isEmpty();
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.nextCursorId()).isNull();
+  }
+
+  // -- 헬퍼 메서드 --
+  private User createUser(Long id, String nickname) {
+    User user = User.builder()
+        .nickname(nickname)
+        .name(nickname)
+        .phone("01012341234")
+        .image("profile.png")
+        .build();
+    ReflectionTestUtils.setField(user, "id", id);
+    return user;
+  }
+
+  private ChatRoom createRoom() {
+    ChatRoom room = ChatRoom.builder()
+        .roomType(RoomType.SINGLE)
+        .participantCount(2)
+        .lastMessageContent("안녕")
+        .build();
+    ReflectionTestUtils.setField(room, "id", ROOM_ID);
+    ReflectionTestUtils.setField(room, "createdAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(room, "lastMessageAt", LocalDateTime.now());
+    return room;
+  }
+
+  private ChatParticipant createParticipant(ChatRoom room) {
+    ChatParticipant participant = ChatParticipant.builder()
+        .chatRoom(room)
+        .userId(USER_ID)
+        .roomTitle("상대방")
+        .roomImage("profile.png")
+        .build();
+    ReflectionTestUtils.setField(participant, "id", 10L);
+    return participant;
+  }
+
+  private ChatMessage createMessage(ChatRoom room) {
+    ChatMessage message = ChatMessage.builder()
+        .chatRoom(room)
+        .senderId(USER_ID)
+        .content("안녕")
+        .messageType(MessageType.TEXT)
+        .build();
+    ReflectionTestUtils.setField(message, "id", 10L);
+    ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
+    return message;
+  }
+
+  private Slice<ChatParticipant> createSlice(boolean hasNext, ChatParticipant... participants) {
+    return new SliceImpl<>(List.of(participants), PageRequest.of(0, 20), hasNext);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #82 

## 📝 작업 내용
- DTO 변경
- DTO에 맞게 서비스 변경 
- 강사님 피드백대로 웹소켓 전송 controller로 옮겨서 강결합 문제 해결
- 서비스 테스트 코드 작성 

## ✅ 작업 결과 
<img width="726" height="276" alt="image" src="https://github.com/user-attachments/assets/6755a33b-29dc-421d-a547-3bb4847c3320" />