### PR TITLE
feat: Swagger API 문서 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
+    // --- API Docs ---
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
+
     // --- Security & Auth ---
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/example/WonkaoTalk/common/config/OpenApiConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/OpenApiConfig.java
@@ -3,7 +3,6 @@ package com.example.WonkaoTalk.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
-  private static final String BEARER_AUTH = "bearerAuth";
+  public static final String BEARER_AUTH = "bearerAuth";
 
   @Bean
   public OpenAPI openAPI() {
@@ -24,7 +23,6 @@ public class OpenApiConfig {
             .addSecuritySchemes(BEARER_AUTH, new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
-                .bearerFormat("JWT")))
-        .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH));
+                .bearerFormat("JWT")));
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/common/config/OpenApiConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/OpenApiConfig.java
@@ -1,0 +1,30 @@
+package com.example.WonkaoTalk.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  private static final String BEARER_AUTH = "bearerAuth";
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("WonkaoTalk API")
+            .description("WonkaoTalk 백엔드 API 문서")
+            .version("v1"))
+        .components(new Components()
+            .addSecuritySchemes(BEARER_AUTH, new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -44,7 +44,10 @@ public class SecurityConfig {
                 "/api/v1/users/signup",
                 "/api/v1/sellers/signup",
                 "/api/v1/search",
-                "/ws/**"
+                "/ws/**",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html"
             ).permitAll() // 인증 없이 접근 허용
             .requestMatchers(
                 "/api/v1/auth/logout",

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.example.WonkaoTalk.domain.auth.controller;
 
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
@@ -10,6 +11,7 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginResponse;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -70,6 +72,7 @@ public class AuthController {
         .body(ApiResponse.success("로그인에 성공하였습니다.", responseBody));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "로그아웃", description = "access token을 블랙리스트에 등록하고 refresh token 쿠키를 제거합니다.")
   @PostMapping("/logout")
   public ResponseEntity<ApiResponse<Void>> logout(

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -9,6 +9,8 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
 import com.example.WonkaoTalk.domain.auth.dto.LoginResponse;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,10 +28,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/v1/auth")
 @RequiredArgsConstructor
+@Tag(name = "인증", description = "이메일 중복 확인, 로그인, 로그아웃, 토큰 재발급 API")
 public class AuthController {
 
   private final AuthService authService;
 
+  @Operation(summary = "이메일 중복 확인", description = "회원가입 전 이메일 사용 가능 여부를 확인합니다.")
   @PostMapping("/check-email")
   public ResponseEntity<ApiResponse<EmailCheckResponse>> checkEmail(
       @Valid @RequestBody EmailCheckRequest request
@@ -42,6 +46,7 @@ public class AuthController {
     return ResponseEntity.ok(ApiResponse.success(message, data));
   }
 
+  @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 access token과 refresh token을 발급합니다.")
   @PostMapping("/login")
   public ResponseEntity<ApiResponse<LoginResponse>> login(
       @Valid @RequestBody LoginRequest request,
@@ -65,6 +70,7 @@ public class AuthController {
         .body(ApiResponse.success("로그인에 성공하였습니다.", responseBody));
   }
 
+  @Operation(summary = "로그아웃", description = "access token을 블랙리스트에 등록하고 refresh token 쿠키를 제거합니다.")
   @PostMapping("/logout")
   public ResponseEntity<ApiResponse<Void>> logout(
       @RequestHeader("Authorization") String authHeader,
@@ -91,6 +97,7 @@ public class AuthController {
         .body(ApiResponse.success("로그아웃에 성공하였습니다.", null));
   }
 
+  @Operation(summary = "토큰 재발급", description = "refresh token 쿠키를 검증해 새로운 access token과 refresh token을 발급합니다.")
   @PostMapping("/reissue")
   public ResponseEntity<ApiResponse<LoginResponse>> reissueToken(
       @CookieValue(value = "refresh-token", required = false) String refreshToken

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/EmailCheckRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/EmailCheckRequest.java
@@ -1,9 +1,11 @@
 package com.example.WonkaoTalk.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record EmailCheckRequest(
+    @Schema(example = "user@example.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     @Pattern(
         // OWASP 이메일 정규식

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/LoginRequest.java
@@ -1,11 +1,13 @@
 package com.example.WonkaoTalk.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 @Builder
 public record LoginRequest(
+    @Schema(example = "user@example.com")
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Pattern(
         // OWASP 이메일 정규식

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatMessageController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.chat.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.chat.dto.ChatMessageListResponse;
@@ -7,6 +8,7 @@ import com.example.WonkaoTalk.domain.chat.dto.ChatMessageRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatMessageResponse;
 import com.example.WonkaoTalk.domain.chat.service.ChatMessageService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chats")
 @Tag(name = "채팅 메시지", description = "채팅 메시지 전송과 메시지 내역 조회 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class ChatMessageController {
 
   private final ChatMessageService chatMessageService;

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatMessageController.java
@@ -6,6 +6,8 @@ import com.example.WonkaoTalk.domain.chat.dto.ChatMessageListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatMessageRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatMessageResponse;
 import com.example.WonkaoTalk.domain.chat.service.ChatMessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,11 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chats")
+@Tag(name = "채팅 메시지", description = "채팅 메시지 전송과 메시지 내역 조회 API")
 public class ChatMessageController {
 
   private final ChatMessageService chatMessageService;
   private final SimpMessagingTemplate messagingTemplate;
 
+  @Operation(summary = "채팅 메시지 전송", description = "채팅방에 메시지를 저장하고 WebSocket 구독자에게 전송합니다.")
   @PostMapping("/{chatRoomId}/messages")
   public ResponseEntity<ApiResponse<ChatMessageResponse>> sendMessage(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -40,6 +44,7 @@ public class ChatMessageController {
     return ResponseEntity.ok(ApiResponse.success("메시지를 전송했습니다.", data));
   }
 
+  @Operation(summary = "채팅 메시지 목록 조회", description = "채팅방 메시지 내역을 커서 기반으로 조회합니다.")
   @GetMapping("/{chatRoomId}/messages")
   public ResponseEntity<ApiResponse<ChatMessageListResponse>> getMessageList(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.chat.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
@@ -7,6 +8,7 @@ import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chats")
 @Tag(name = "채팅방", description = "채팅방 생성과 채팅방 목록 조회 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class ChatRoomController {
 
   private final ChatRoomService chatRoomService;

--- a/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/chat/controller/ChatRoomController.java
@@ -6,6 +6,8 @@ import com.example.WonkaoTalk.domain.chat.dto.ChatRoomCreateRequest;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomListResponse;
 import com.example.WonkaoTalk.domain.chat.dto.ChatRoomResponse;
 import com.example.WonkaoTalk.domain.chat.service.ChatRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chats")
+@Tag(name = "채팅방", description = "채팅방 생성과 채팅방 목록 조회 API")
 public class ChatRoomController {
 
   private final ChatRoomService chatRoomService;
 
+  @Operation(summary = "채팅방 생성", description = "상대 사용자와의 채팅방을 생성하거나 기존 채팅방 정보를 반환합니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -38,6 +42,7 @@ public class ChatRoomController {
     return ResponseEntity.ok(ApiResponse.success("채팅방이 생성되었습니다.", data));
   }
 
+  @Operation(summary = "채팅방 목록 조회", description = "로그인한 사용자의 채팅방 목록을 커서 기반으로 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<ChatRoomListResponse>> getChatRoomList(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/image/controller/ImageController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/controller/ImageController.java
@@ -4,6 +4,8 @@ import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.image.dto.PresignedUrlRequest;
 import com.example.WonkaoTalk.domain.image.dto.PresignedUrlResponse;
 import com.example.WonkaoTalk.domain.image.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/v1/images")
 @RequiredArgsConstructor
+@Tag(name = "이미지", description = "이미지 업로드용 Presigned URL 발급 API")
 public class ImageController {
 
   private final ImageService imageService;
 
+  @Operation(summary = "Presigned URL 발급", description = "이미지 업로드를 위한 S3/MinIO Presigned URL을 발급합니다.")
   @PostMapping("/presigned-url")
   public ResponseEntity<ApiResponse<PresignedUrlResponse>> getPresignedUrl(
       @Valid @RequestBody PresignedUrlRequest request

--- a/src/main/java/com/example/WonkaoTalk/domain/image/controller/ImageController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/image/controller/ImageController.java
@@ -1,10 +1,12 @@
 package com.example.WonkaoTalk.domain.image.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.image.dto.PresignedUrlRequest;
 import com.example.WonkaoTalk.domain.image.dto.PresignedUrlResponse;
 import com.example.WonkaoTalk.domain.image.service.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/v1/images")
 @RequiredArgsConstructor
 @Tag(name = "이미지", description = "이미지 업로드용 Presigned URL 발급 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class ImageController {
 
   private final ImageService imageService;

--- a/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.order.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
@@ -8,6 +9,7 @@ import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
 @Tag(name = "주문", description = "주문 생성과 주문 미리보기 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class OrderController {
 
   private final OrderService orderService;

--- a/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
@@ -7,6 +7,8 @@ import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,10 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/orders")
 @RequiredArgsConstructor
+@Tag(name = "주문", description = "주문 생성과 주문 미리보기 API")
 public class OrderController {
 
   private final OrderService orderService;
 
+  @Operation(summary = "주문 생성", description = "상품 옵션, 수량, 배송 정보를 기반으로 주문을 생성하고 결제 준비 정보를 반환합니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<OrderCreateResponse>> createOrder(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -34,6 +38,7 @@ public class OrderController {
         .body(ApiResponse.success("주문이 생성되었습니다.", responseDto));
   }
 
+  @Operation(summary = "주문 미리보기", description = "주문 생성 전 상품 금액, 할인 금액, 최종 결제 금액을 계산합니다.")
   @PostMapping("/preview")
   public ResponseEntity<ApiResponse<OrderPreviewResponse>> previewOrder(
       @Valid @RequestBody OrderPreviewRequest requestDto

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/controller/PaymentController.java
@@ -8,6 +8,8 @@ import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmResponse;
 import com.example.WonkaoTalk.domain.payment.dto.PaymentFailRequest;
 import com.example.WonkaoTalk.domain.payment.dto.PaymentFailResponse;
 import com.example.WonkaoTalk.domain.payment.service.PaymentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
+@Tag(name = "결제", description = "토스페이먼츠 결제창 호출, 결제 승인, 결제 실패/취소 처리 API")
 public class PaymentController {
 
   private final PaymentService paymentService;
 
+  @Operation(summary = "결제창 호출 정보 조회", description = "토스 결제창 호출에 필요한 clientKey, orderId, 금액, 성공/실패 URL을 조회합니다.")
   @GetMapping("/{paymentId}/checkout")
   public ResponseEntity<ApiResponse<PaymentCheckoutResponse>> getCheckout(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -36,6 +40,7 @@ public class PaymentController {
     return ResponseEntity.ok(ApiResponse.success("결제창 호출 정보가 조회되었습니다.", response));
   }
 
+  @Operation(summary = "결제 승인", description = "토스 결제 인증 후 전달받은 paymentKey, orderId, amount를 검증하고 최종 승인합니다.")
   @PostMapping("/confirm")
   public ResponseEntity<ApiResponse<PaymentConfirmResponse>> confirm(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -45,6 +50,7 @@ public class PaymentController {
     return ResponseEntity.ok(ApiResponse.success("결제가 승인되었습니다.", response));
   }
 
+  @Operation(summary = "결제 실패/취소 저장", description = "토스 결제창 실패 또는 사용자 취소 정보를 주문과 결제 상태에 반영합니다.")
   @PostMapping("/{paymentId}/fail")
   public ResponseEntity<ApiResponse<PaymentFailResponse>> fail(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/controller/PaymentController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.payment.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.payment.dto.PaymentCheckoutResponse;
@@ -9,6 +10,7 @@ import com.example.WonkaoTalk.domain.payment.dto.PaymentFailRequest;
 import com.example.WonkaoTalk.domain.payment.dto.PaymentFailResponse;
 import com.example.WonkaoTalk.domain.payment.service.PaymentService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 @Tag(name = "결제", description = "토스페이먼츠 결제창 호출, 결제 승인, 결제 실패/취소 처리 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class PaymentController {
 
   private final PaymentService paymentService;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/CartController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/CartController.java
@@ -11,6 +11,8 @@ import com.example.WonkaoTalk.domain.product.dto.CartQuantityUpdateRequest;
 import com.example.WonkaoTalk.domain.product.dto.CartQuantityUpdateResponse;
 import com.example.WonkaoTalk.domain.product.dto.CartResponse;
 import com.example.WonkaoTalk.domain.product.service.CartService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,10 +32,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/carts")
 @RequiredArgsConstructor
+@Tag(name = "장바구니", description = "장바구니 조회, 상품 추가, 수량/옵션 변경, 상품 삭제 API")
 public class CartController {
 
   private final CartService cartService;
 
+  @Operation(summary = "장바구니 조회", description = "로그인한 사용자의 장바구니 상품 목록과 금액 요약을 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<CartResponse>> getCart(
       @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -41,6 +45,7 @@ public class CartController {
     return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
   }
 
+  @Operation(summary = "장바구니 상품 추가", description = "선택한 상품 옵션과 수량을 장바구니에 추가합니다.")
   @PostMapping("/items")
   public ResponseEntity<ApiResponse<CartAddResponse>> addToCart(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -50,6 +55,7 @@ public class CartController {
         .body(ApiResponse.success("장바구니에 상품이 추가되었습니다.", response));
   }
 
+  @Operation(summary = "장바구니 상품 수량 변경", description = "장바구니 상품의 구매 수량을 변경합니다.")
   @PatchMapping("/items/{cartItemId}/quantity")
   public ResponseEntity<ApiResponse<CartQuantityUpdateResponse>> updateCartItemQuantity(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -60,6 +66,7 @@ public class CartController {
     return ResponseEntity.ok(ApiResponse.success("수정이 완료되었습니다", response));
   }
 
+  @Operation(summary = "장바구니 상품 옵션 변경", description = "장바구니 상품의 선택 옵션을 다른 옵션으로 변경합니다.")
   @PatchMapping("/items/{cartItemId}/option")
   public ResponseEntity<ApiResponse<CartOptionUpdateResponse>> updateCartItemOption(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -70,6 +77,7 @@ public class CartController {
     return ResponseEntity.ok(ApiResponse.success("수정이 완료되었습니다", response));
   }
 
+  @Operation(summary = "장바구니 상품 삭제", description = "선택한 장바구니 상품을 삭제하거나 장바구니 전체를 비웁니다.")
   @DeleteMapping("/items")
   public ResponseEntity<ApiResponse<CartDeleteResponse>> deleteFromCart(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/CartController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/CartController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.product.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.product.dto.CartAddRequest;
@@ -12,6 +13,7 @@ import com.example.WonkaoTalk.domain.product.dto.CartQuantityUpdateResponse;
 import com.example.WonkaoTalk.domain.product.dto.CartResponse;
 import com.example.WonkaoTalk.domain.product.service.CartService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/carts")
 @RequiredArgsConstructor
 @Tag(name = "장바구니", description = "장바구니 조회, 상품 추가, 수량/옵션 변경, 상품 삭제 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class CartController {
 
   private final CartService cartService;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -11,6 +11,8 @@ import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.service.CategoryService;
 import com.example.WonkaoTalk.domain.product.service.ProductCreateService;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,12 +30,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/products")
 @RequiredArgsConstructor
+@Tag(name = "상품", description = "상품 등록, 상품 목록/상세 조회, 카테고리 조회 API")
 public class ProductController {
 
   private final ProductService productService;
   private final ProductCreateService productCreateService;
   private final CategoryService categoryService;
 
+  @Operation(summary = "상품 등록", description = "판매자가 상품 기본 정보, 상세 정보, 옵션, 이미지를 등록합니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -43,6 +47,7 @@ public class ProductController {
         .body(ApiResponse.success("상품이 등록되었습니다", response));
   }
 
+  @Operation(summary = "상품 목록 조회", description = "카테고리, 정렬 조건 등을 기준으로 상품 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<ProductListResponse>> getProducts(
       @ModelAttribute ProductListRequest request) {
@@ -50,6 +55,7 @@ public class ProductController {
     return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
   }
 
+  @Operation(summary = "상품 상세 조회", description = "상품 ID로 상품 상세 정보와 옵션 정보를 조회합니다.")
   @GetMapping("/{productId}")
   public ResponseEntity<ApiResponse<ProductDetailResponse>> getProduct(
       @PathVariable Long productId) {
@@ -57,6 +63,7 @@ public class ProductController {
     return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
   }
 
+  @Operation(summary = "카테고리 조회", description = "상품 등록과 검색에 사용할 카테고리 트리를 조회합니다.")
   @GetMapping("/categories")
   public ResponseEntity<ApiResponse<List<CategoryResponse>>> getCategories() {
     List<CategoryResponse> response = categoryService.getCategoryTree();

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.product.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.product.dto.CategoryResponse;
@@ -12,6 +13,7 @@ import com.example.WonkaoTalk.domain.product.service.CategoryService;
 import com.example.WonkaoTalk.domain.product.service.ProductCreateService;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -37,6 +39,7 @@ public class ProductController {
   private final ProductCreateService productCreateService;
   private final CategoryService categoryService;
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "상품 등록", description = "판매자가 상품 기본 정보, 상세 정보, 옵션, 이미지를 등록합니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<ProductCreateResponse>> createProduct(

--- a/src/main/java/com/example/WonkaoTalk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/controller/SearchController.java
@@ -4,6 +4,8 @@ import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
 import com.example.WonkaoTalk.domain.search.service.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,10 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
+@Tag(name = "검색", description = "상품과 스토어 통합 검색 API")
 public class SearchController {
 
     private final SearchService searchService;
 
+    @Operation(summary = "통합 검색", description = "검색어와 필터 조건으로 상품과 스토어를 검색합니다.")
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<SearchResponse>> search(
         @ModelAttribute SearchRequest request) {

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
@@ -11,6 +11,8 @@ import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpRequest;
 import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpResponse;
 import com.example.WonkaoTalk.domain.seller.dto.SellerUpdateRequest;
 import com.example.WonkaoTalk.domain.seller.service.SellerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,11 +30,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/sellers")
+@Tag(name = "판매자", description = "판매자 회원가입, 판매자 등록, 판매자 정보 조회/수정/탈퇴 API")
 public class SellerController {
 
   private final SellerService sellerService;
   private final AccountWithdraw accountWithdraw;
 
+  @Operation(summary = "판매자 회원가입", description = "이메일, 비밀번호, 사업자 정보를 입력해 판매자 계정을 생성합니다.")
   @PostMapping("/signup")
   public ResponseEntity<ApiResponse<SellerSignUpResponse>> signUp(
       @Valid @RequestBody SellerSignUpRequest request
@@ -43,6 +47,7 @@ public class SellerController {
         .body(ApiResponse.success("판매자 회원가입이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "판매자 등록", description = "기존 계정에 판매자 정보를 추가 등록합니다.")
   @PostMapping("/register")
   public ResponseEntity<ApiResponse<SellerSignUpResponse>> register(
       @Valid @RequestBody SellerRegisterRequest request,
@@ -55,6 +60,7 @@ public class SellerController {
     return ResponseEntity.ok(ApiResponse.success("판매자 등록이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "판매자 정보 조회", description = "로그인한 판매자의 정보를 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<SellerResponse>> getMySellerInfo(
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -64,6 +70,7 @@ public class SellerController {
     return ResponseEntity.ok(ApiResponse.success("판매자 정보를 조회했습니다.", response));
   }
 
+  @Operation(summary = "판매자 정보 수정", description = "로그인한 판매자의 사업자 정보를 수정합니다.")
   @PatchMapping
   public ResponseEntity<ApiResponse<SellerResponse>> updateMyInfo(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -74,6 +81,7 @@ public class SellerController {
     return ResponseEntity.ok(ApiResponse.success("판매자 정보 수정이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "판매자 탈퇴", description = "로그인한 판매자 계정을 탈퇴 처리하고 access token을 만료 처리합니다.")
   @DeleteMapping("/withdraw")
   public ResponseEntity<ApiResponse<Void>> withdraw(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.seller.controller;
 
 import com.example.WonkaoTalk.application.facade.AccountWithdraw;
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.response.ApiResponse;
@@ -12,6 +13,7 @@ import com.example.WonkaoTalk.domain.seller.dto.SellerSignUpResponse;
 import com.example.WonkaoTalk.domain.seller.dto.SellerUpdateRequest;
 import com.example.WonkaoTalk.domain.seller.service.SellerService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +49,7 @@ public class SellerController {
         .body(ApiResponse.success("판매자 회원가입이 완료되었습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "판매자 등록", description = "기존 계정에 판매자 정보를 추가 등록합니다.")
   @PostMapping("/register")
   public ResponseEntity<ApiResponse<SellerSignUpResponse>> register(
@@ -60,6 +63,7 @@ public class SellerController {
     return ResponseEntity.ok(ApiResponse.success("판매자 등록이 완료되었습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "판매자 정보 조회", description = "로그인한 판매자의 정보를 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<SellerResponse>> getMySellerInfo(
@@ -70,6 +74,7 @@ public class SellerController {
     return ResponseEntity.ok(ApiResponse.success("판매자 정보를 조회했습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "판매자 정보 수정", description = "로그인한 판매자의 사업자 정보를 수정합니다.")
   @PatchMapping
   public ResponseEntity<ApiResponse<SellerResponse>> updateMyInfo(
@@ -81,6 +86,7 @@ public class SellerController {
     return ResponseEntity.ok(ApiResponse.success("판매자 정보 수정이 완료되었습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "판매자 탈퇴", description = "로그인한 판매자 계정을 탈퇴 처리하고 access token을 만료 처리합니다.")
   @DeleteMapping("/withdraw")
   public ResponseEntity<ApiResponse<Void>> withdraw(

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerSignUpRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/dto/SellerSignUpRequest.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.seller.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -7,6 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record SellerSignUpRequest(
+    @Schema(example = "seller@example.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     @Pattern(
         regexp = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$",

--- a/src/main/java/com/example/WonkaoTalk/domain/shipping/controller/ShippingAddressController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/shipping/controller/ShippingAddressController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.shipping.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.shipping.dto.ShippingAddressCreateRequest;
@@ -8,6 +9,7 @@ import com.example.WonkaoTalk.domain.shipping.dto.ShippingAddressResponse;
 import com.example.WonkaoTalk.domain.shipping.dto.ShippingAddressUpdateRequest;
 import com.example.WonkaoTalk.domain.shipping.service.ShippingAddressService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/shipping/addresses")
 @Tag(name = "배송지", description = "사용자 배송지 목록 조회, 등록, 수정, 삭제, 기본 배송지 설정 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class ShippingAddressController {
 
   private final ShippingAddressService shippingAddressService;

--- a/src/main/java/com/example/WonkaoTalk/domain/shipping/controller/ShippingAddressController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/shipping/controller/ShippingAddressController.java
@@ -7,6 +7,8 @@ import com.example.WonkaoTalk.domain.shipping.dto.ShippingAddressListResponse;
 import com.example.WonkaoTalk.domain.shipping.dto.ShippingAddressResponse;
 import com.example.WonkaoTalk.domain.shipping.dto.ShippingAddressUpdateRequest;
 import com.example.WonkaoTalk.domain.shipping.service.ShippingAddressService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,10 +26,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/shipping/addresses")
+@Tag(name = "배송지", description = "사용자 배송지 목록 조회, 등록, 수정, 삭제, 기본 배송지 설정 API")
 public class ShippingAddressController {
 
   private final ShippingAddressService shippingAddressService;
 
+  @Operation(summary = "배송지 목록 조회", description = "로그인한 사용자의 저장된 배송지 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<ShippingAddressListResponse>> getList(
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -36,6 +40,7 @@ public class ShippingAddressController {
     return ResponseEntity.ok(ApiResponse.success("배송지 목록을 조회했습니다.", response));
   }
 
+  @Operation(summary = "배송지 등록", description = "새 배송지를 등록합니다. 첫 배송지는 자동으로 기본 배송지로 설정됩니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<ShippingAddressResponse>> create(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -47,6 +52,7 @@ public class ShippingAddressController {
         .body(ApiResponse.success("배송지가 등록되었습니다.", response));
   }
 
+  @Operation(summary = "배송지 수정", description = "저장된 배송지의 수령인, 연락처, 주소, 메모, 기본 배송지 여부를 수정합니다.")
   @PatchMapping("/{shippingAddressId}")
   public ResponseEntity<ApiResponse<ShippingAddressResponse>> update(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -58,6 +64,7 @@ public class ShippingAddressController {
     return ResponseEntity.ok(ApiResponse.success("배송지가 수정되었습니다.", response));
   }
 
+  @Operation(summary = "배송지 삭제", description = "저장된 배송지를 삭제합니다.")
   @DeleteMapping("/{shippingAddressId}")
   public ResponseEntity<ApiResponse<Void>> delete(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -67,6 +74,7 @@ public class ShippingAddressController {
     return ResponseEntity.ok(ApiResponse.success("배송지가 삭제되었습니다.", null));
   }
 
+  @Operation(summary = "기본 배송지 설정", description = "선택한 배송지를 기본 배송지로 설정하고 기존 기본 배송지를 해제합니다.")
   @PatchMapping("/{shippingAddressId}/default")
   public ResponseEntity<ApiResponse<ShippingAddressResponse>> setDefault(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.store.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
@@ -9,6 +10,7 @@ import com.example.WonkaoTalk.domain.store.dto.StoreResponse;
 import com.example.WonkaoTalk.domain.store.dto.StoreUpdateRequest;
 import com.example.WonkaoTalk.domain.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/stores")
 @Tag(name = "스토어", description = "판매자 스토어 등록, 조회, 수정, 삭제 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class StoreController {
 
   private final StoreService storeService;

--- a/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/store/controller/StoreController.java
@@ -8,6 +8,8 @@ import com.example.WonkaoTalk.domain.store.dto.StoreCreateRequest;
 import com.example.WonkaoTalk.domain.store.dto.StoreResponse;
 import com.example.WonkaoTalk.domain.store.dto.StoreUpdateRequest;
 import com.example.WonkaoTalk.domain.store.service.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,11 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/stores")
+@Tag(name = "스토어", description = "판매자 스토어 등록, 조회, 수정, 삭제 API")
 public class StoreController {
 
   private final StoreService storeService;
   private final SellerService sellerService;
 
+  @Operation(summary = "스토어 등록", description = "로그인한 판매자의 스토어 정보를 등록합니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<StoreResponse>> createStore(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -42,6 +46,7 @@ public class StoreController {
         .body(ApiResponse.success("스토어 등록이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "스토어 조회", description = "로그인한 판매자의 스토어 정보를 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<StoreResponse>> getStore(
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -52,6 +57,7 @@ public class StoreController {
     return ResponseEntity.ok(ApiResponse.success("스토어 정보 조회가 완료되었습니다.", response));
   }
 
+  @Operation(summary = "스토어 수정", description = "로그인한 판매자의 스토어 정보를 수정합니다.")
   @PatchMapping
   public ResponseEntity<ApiResponse<StoreResponse>> updateStore(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -63,6 +69,7 @@ public class StoreController {
     return ResponseEntity.ok(ApiResponse.success("스토어 정보 수정이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "스토어 삭제", description = "로그인한 판매자의 스토어를 삭제 처리합니다.")
   @DeleteMapping
   public ResponseEntity<ApiResponse<StoreResponse>> deleteStore(
       @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.domain.user.controller;
 
 import com.example.WonkaoTalk.application.facade.AccountWithdraw;
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.response.ApiResponse;
@@ -13,6 +14,7 @@ import com.example.WonkaoTalk.domain.user.dto.UserSignUpResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserUpdateRequest;
 import com.example.WonkaoTalk.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +53,7 @@ public class UserController {
         .body(ApiResponse.success("일반 회원가입이 완료되었습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "내 정보 조회", description = "로그인한 일반 사용자의 프로필 정보를 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
@@ -61,6 +64,7 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.success("내 정보를 조회했습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "내 정보 수정", description = "로그인한 일반 사용자의 프로필 정보를 수정합니다.")
   @PatchMapping
   public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(
@@ -72,6 +76,7 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.success("내 정보 수정이 완료되었습니다.", response));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "일반 사용자 탈퇴", description = "로그인한 일반 사용자 계정을 탈퇴 처리하고 access token을 만료 처리합니다.")
   @DeleteMapping("/withdraw")
   public ResponseEntity<ApiResponse<Void>> withdraw(
@@ -88,6 +93,7 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", null));
   }
 
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
   @Operation(summary = "전화번호로 사용자 검색", description = "전화번호로 친구 추가 대상 사용자를 검색합니다.")
   @PostMapping("/search")
   public ResponseEntity<ApiResponse<UserSearchResponse>> searchUserByPhone(

--- a/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
@@ -12,6 +12,8 @@ import com.example.WonkaoTalk.domain.user.dto.UserSignUpRequest;
 import com.example.WonkaoTalk.domain.user.dto.UserSignUpResponse;
 import com.example.WonkaoTalk.domain.user.dto.UserUpdateRequest;
 import com.example.WonkaoTalk.domain.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -29,11 +31,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@Tag(name = "사용자", description = "일반 사용자 회원가입, 내 정보 조회/수정/탈퇴 API")
 public class UserController {
 
   private final UserService userService;
   private final AccountWithdraw accountWithdraw;
 
+  @Operation(
+      summary = "일반 사용자 회원가입",
+      description = "이메일, 비밀번호, 이름, 닉네임, 전화번호, 생년월일, 성별 정보를 입력해 일반 사용자 계정을 생성합니다."
+  )
   @PostMapping("/signup")
   public ResponseEntity<ApiResponse<UserSignUpResponse>> signUp(
       @Valid @RequestBody UserSignUpRequest request
@@ -44,6 +51,7 @@ public class UserController {
         .body(ApiResponse.success("일반 회원가입이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "내 정보 조회", description = "로그인한 일반 사용자의 프로필 정보를 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -53,6 +61,7 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.success("내 정보를 조회했습니다.", response));
   }
 
+  @Operation(summary = "내 정보 수정", description = "로그인한 일반 사용자의 프로필 정보를 수정합니다.")
   @PatchMapping
   public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -63,6 +72,7 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.success("내 정보 수정이 완료되었습니다.", response));
   }
 
+  @Operation(summary = "일반 사용자 탈퇴", description = "로그인한 일반 사용자 계정을 탈퇴 처리하고 access token을 만료 처리합니다.")
   @DeleteMapping("/withdraw")
   public ResponseEntity<ApiResponse<Void>> withdraw(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -78,6 +88,7 @@ public class UserController {
     return ResponseEntity.ok(ApiResponse.success("회원 탈퇴가 완료되었습니다.", null));
   }
 
+  @Operation(summary = "전화번호로 사용자 검색", description = "전화번호로 친구 추가 대상 사용자를 검색합니다.")
   @PostMapping("/search")
   public ResponseEntity<ApiResponse<UserSearchResponse>> searchUserByPhone(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSignUpRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/dto/UserSignUpRequest.java
@@ -1,12 +1,14 @@
 package com.example.WonkaoTalk.domain.user.dto;
 
 import com.example.WonkaoTalk.domain.user.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 
 public record UserSignUpRequest(
+    @Schema(example = "user@example.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     @Pattern(
         regexp = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$",

--- a/src/main/java/com/example/WonkaoTalk/domain/user/friend/controller/FriendController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/friend/controller/FriendController.java
@@ -10,6 +10,8 @@ import com.example.WonkaoTalk.domain.user.friend.dto.FriendStatusRequest;
 import com.example.WonkaoTalk.domain.user.friend.dto.FriendUpdateRequest;
 import com.example.WonkaoTalk.domain.user.friend.dto.FriendUpdateResponse;
 import com.example.WonkaoTalk.domain.user.friend.service.FriendService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,10 +30,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/friends")
+@Tag(name = "친구", description = "친구 추가, 조회, 수정, 상태 변경, 삭제 API")
 public class FriendController {
 
   private final FriendService friendService;
 
+  @Operation(summary = "친구 추가", description = "사용자를 친구 목록에 추가합니다.")
   @PostMapping
   public ResponseEntity<ApiResponse<FriendAddResponse>> addFriend(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -42,6 +46,7 @@ public class FriendController {
         .body(ApiResponse.success("친구 추가가 완료되었습니다.", response));
   }
 
+  @Operation(summary = "친구 목록 조회", description = "로그인한 사용자의 친구 목록을 조회합니다.")
   @GetMapping
   public ResponseEntity<ApiResponse<FriendListResponse>> getFriends(
       @AuthenticationPrincipal CustomUserDetails userDetails
@@ -55,6 +60,7 @@ public class FriendController {
     return ResponseEntity.ok(ApiResponse.success("친구 조회를 완료했습니다.", response));
   }
 
+  @Operation(summary = "친구 정보 수정", description = "친구의 별칭 등 친구 정보를 수정합니다.")
   @PatchMapping("/{friendId}")
   public ResponseEntity<ApiResponse<FriendUpdateResponse>> updateFriendInfo(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -66,6 +72,7 @@ public class FriendController {
     return ResponseEntity.ok(ApiResponse.success("친구 정보가 수정되었습니다.", response));
   }
 
+  @Operation(summary = "친구 상태 변경", description = "친구 요청 수락, 거절 등 친구 상태를 변경합니다.")
   @PatchMapping("/{friendId}/status")
   public ResponseEntity<ApiResponse<Void>> changeFriendStatus(
       @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -76,6 +83,7 @@ public class FriendController {
     return ResponseEntity.ok(ApiResponse.success("친구 상태가 변경 되었습니다.", null));
   }
 
+  @Operation(summary = "친구 삭제", description = "친구 목록에서 선택한 친구를 삭제합니다.")
   @DeleteMapping("/{friendId}")
   public ResponseEntity<ApiResponse<Void>> deleteFriend(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/example/WonkaoTalk/domain/user/friend/controller/FriendController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/friend/controller/FriendController.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.domain.user.friend.controller;
 
+import com.example.WonkaoTalk.common.config.OpenApiConfig;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.user.friend.dto.FriendAddRequest;
@@ -11,6 +12,7 @@ import com.example.WonkaoTalk.domain.user.friend.dto.FriendUpdateRequest;
 import com.example.WonkaoTalk.domain.user.friend.dto.FriendUpdateResponse;
 import com.example.WonkaoTalk.domain.user.friend.service.FriendService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/friends")
 @Tag(name = "친구", description = "친구 추가, 조회, 수정, 상태 변경, 삭제 API")
+@SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
 public class FriendController {
 
   private final FriendService friendService;


### PR DESCRIPTION
## 📌 관련 이슈
- #97 

## 📝 작업 내용
- springdoc-openapi 의존성과 OpenAPI 기본 설정 추가
- Swagger UI와 API docs 경로를 Security 허용 목록에 추가
- 전체 컨트롤러에 API 그룹과 메서드 설명 추가
- 이메일 요청 필드에 Swagger 예시값 추가

## ✅ 작업 결과 
<img width="1482" height="1539" alt="image" src="https://github.com/user-attachments/assets/55031562-accd-4dc3-bb37-5c4e5107b693" />

## 🎸 기타

close #97 