### PR TITLE
Feature/103 재고 이력 관리 테이블 추가

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/StockHistory.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/StockHistory.java
@@ -46,13 +46,13 @@ public class StockHistory {
   private Order order;
 
   @Column(name = "change_amount", nullable = false)
-  private Integer changeAmount;
+  private int changeAmount;
 
   @Column(name = "stock_before", nullable = false)
-  private Integer stockBefore;
+  private int stockBefore;
 
   @Column(name = "stock_after", nullable = false)
-  private Integer stockAfter;
+  private int stockAfter;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "reason", nullable = false, length = 20)

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/StockHistory.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/StockHistory.java
@@ -1,0 +1,81 @@
+package com.example.WonkaoTalk.domain.product.entity;
+
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "stock_histories")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class StockHistory {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_variant_id", nullable = false)
+  private ProductVariant productVariant;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id")
+  private Order order;
+
+  @Column(name = "change_amount", nullable = false)
+  private Integer changeAmount;
+
+  @Column(name = "stock_before", nullable = false)
+  private Integer stockBefore;
+
+  @Column(name = "stock_after", nullable = false)
+  private Integer stockAfter;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "reason", nullable = false, length = 20)
+  private StockChangeReason reason;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  public static StockHistory of(
+      ProductVariant productVariant,
+      Order order,
+      int changeAmount,
+      int stockBefore,
+      StockChangeReason reason
+  ) {
+    return StockHistory.builder()
+        .productVariant(productVariant)
+        .order(order)
+        .changeAmount(changeAmount)
+        .stockBefore(stockBefore)
+        .stockAfter(stockBefore + changeAmount)
+        .reason(reason)
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/enums/StockChangeReason.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/enums/StockChangeReason.java
@@ -1,8 +1,9 @@
 package com.example.WonkaoTalk.domain.product.enums;
 
 public enum StockChangeReason {
-  SALE,        // 결제 완료로 인한 차감
-  CANCEL,      // 주문 취소로 인한 복구
-  RESTOCK,     // 판매자 입고
-  ADJUSTMENT   // 판매자 수동 조정
+  SALE,          // 결제 완료로 인한 차감
+  CANCEL,        // 주문 취소로 인한 복구
+  INITIAL_STOCK, // 상품 최초 등록 시 초기 재고
+  RESTOCK,       // 판매자 입고
+  ADJUSTMENT     // 판매자 수동 조정
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/enums/StockChangeReason.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/enums/StockChangeReason.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.product.enums;
+
+public enum StockChangeReason {
+  SALE,        // 결제 완료로 인한 차감
+  CANCEL,      // 주문 취소로 인한 복구
+  RESTOCK,     // 판매자 입고
+  ADJUSTMENT   // 판매자 수동 조정
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/StockHistoryRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/StockHistoryRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.product.repo;
+
+import com.example.WonkaoTalk.domain.product.entity.StockHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockHistoryRepo extends JpaRepository<StockHistory, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
@@ -15,8 +15,10 @@ import com.example.WonkaoTalk.domain.product.entity.ProductImage;
 import com.example.WonkaoTalk.domain.product.entity.ProductOption;
 import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.StockHistory;
 import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
 import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
@@ -25,6 +27,7 @@ import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.product.repo.StockHistoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepo;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
@@ -58,6 +61,7 @@ public class ProductCreateService {
   private final ProductOptionRepo productOptionRepo;
   private final ProductVariantRepo productVariantRepo;
   private final VariantOptionMapRepo variantOptionMapRepo;
+  private final StockHistoryRepo stockHistoryRepo;
   private final ImageService imageService;
   private final ApplicationEventPublisher eventPublisher;
 
@@ -127,12 +131,13 @@ public class ProductCreateService {
     }
 
     if (!hasOptions) {
-      productVariantRepo.save(ProductVariant.builder()
+      ProductVariant variant = productVariantRepo.save(ProductVariant.builder()
           .product(product)
           .name("기본")
           .stock(request.stock())
           .status(SaleStatus.ON_SALE)
           .build());
+      stockHistoryRepo.save(StockHistory.of(variant, null, request.stock(), 0, StockChangeReason.RESTOCK));
     } else {
       saveOptionsAndVariants(product, request);
     }
@@ -197,6 +202,7 @@ public class ProductCreateService {
           .stock(variantReq.stock())
           .status(SaleStatus.ON_SALE)
           .build());
+      stockHistoryRepo.save(StockHistory.of(variant, null, variantReq.stock(), 0, StockChangeReason.RESTOCK));
 
       for (int i = 0; i < combo.size(); i++) {
         ProductOption option = groupOptionMaps.get(i).get(combo.get(i));

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
@@ -239,6 +239,13 @@ public class ProductCreateService {
     if (!hasOptionGroups && (request.stock() == null || request.stock() < 1)) {
       throw new BusinessException(ErrorCode.PROD_INVALID_QUANTITY);
     }
+    if (hasVariants) {
+      for (VariantRequest variant : request.variants()) {
+        if (variant.stock() == null || variant.stock() < 1) {
+          throw new BusinessException(ErrorCode.PROD_INVALID_QUANTITY);
+        }
+      }
+    }
   }
 
   private void validateSortOrders(ProductCreateRequest request) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
@@ -137,7 +137,8 @@ public class ProductCreateService {
           .stock(request.stock())
           .status(SaleStatus.ON_SALE)
           .build());
-      stockHistoryRepo.save(StockHistory.of(variant, null, request.stock(), 0, StockChangeReason.RESTOCK));
+      stockHistoryRepo.save(
+          StockHistory.of(variant, null, request.stock(), 0, StockChangeReason.INITIAL_STOCK));
     } else {
       saveOptionsAndVariants(product, request);
     }
@@ -202,7 +203,8 @@ public class ProductCreateService {
           .stock(variantReq.stock())
           .status(SaleStatus.ON_SALE)
           .build());
-      stockHistoryRepo.save(StockHistory.of(variant, null, variantReq.stock(), 0, StockChangeReason.RESTOCK));
+      stockHistoryRepo.save(
+          StockHistory.of(variant, null, variantReq.stock(), 0, StockChangeReason.INITIAL_STOCK));
 
       for (int i = 0; i < combo.size(); i++) {
         ProductOption option = groupOptionMaps.get(i).get(combo.get(i));
@@ -218,7 +220,8 @@ public class ProductCreateService {
     if (request.price() < 0) {
       throw new BusinessException(ErrorCode.PROD_INVALID_PRICE);
     }
-    if (request.discountRate() != null && (request.discountRate() < 0 || request.discountRate() > 100)) {
+    if (request.discountRate() != null && (request.discountRate() < 0
+        || request.discountRate() > 100)) {
       throw new BusinessException(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
     }
   }

--- a/src/main/resources/db/migration/V2__create_stock_histories.sql
+++ b/src/main/resources/db/migration/V2__create_stock_histories.sql
@@ -6,5 +6,5 @@ CREATE TABLE stock_histories (
     stock_before        INT             NOT NULL,
     stock_after         INT             NOT NULL,
     reason              VARCHAR(20)     NOT NULL,
-    created_at          TIMESTAMP       NOT NULL
+    created_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/src/main/resources/db/migration/V2__create_stock_histories.sql
+++ b/src/main/resources/db/migration/V2__create_stock_histories.sql
@@ -1,0 +1,10 @@
+CREATE TABLE stock_histories (
+    id                  BIGSERIAL       PRIMARY KEY,
+    product_variant_id  BIGINT          NOT NULL REFERENCES product_variants(id),
+    order_id            BIGINT          REFERENCES orders(id),
+    change_amount       INT             NOT NULL,
+    stock_before        INT             NOT NULL,
+    stock_after         INT             NOT NULL,
+    reason              VARCHAR(20)     NOT NULL,
+    created_at          TIMESTAMP       NOT NULL
+);

--- a/src/test/java/com/example/WonkaoTalk/domain/product/entity/StockHistoryTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/entity/StockHistoryTest.java
@@ -27,11 +27,11 @@ class StockHistoryTest {
   void of_increase_stockAfterCalculatedCorrectly() {
     ProductVariant variant = mock(ProductVariant.class);
 
-    StockHistory history = StockHistory.of(variant, null, 10, 0, StockChangeReason.RESTOCK);
+    StockHistory history = StockHistory.of(variant, null, 10, 0, StockChangeReason.INITIAL_STOCK);
 
     assertThat(history.getChangeAmount()).isEqualTo(10);
     assertThat(history.getStockBefore()).isEqualTo(0);
     assertThat(history.getStockAfter()).isEqualTo(10);
-    assertThat(history.getReason()).isEqualTo(StockChangeReason.RESTOCK);
+    assertThat(history.getReason()).isEqualTo(StockChangeReason.INITIAL_STOCK);
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/product/entity/StockHistoryTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/entity/StockHistoryTest.java
@@ -1,0 +1,37 @@
+package com.example.WonkaoTalk.domain.product.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StockHistoryTest {
+
+  @Test
+  @DisplayName("차감 시 stockAfter는 stockBefore + changeAmount(음수)이다")
+  void of_decrease_stockAfterCalculatedCorrectly() {
+    ProductVariant variant = mock(ProductVariant.class);
+
+    StockHistory history = StockHistory.of(variant, null, -3, 10, StockChangeReason.SALE);
+
+    assertThat(history.getChangeAmount()).isEqualTo(-3);
+    assertThat(history.getStockBefore()).isEqualTo(10);
+    assertThat(history.getStockAfter()).isEqualTo(7);
+    assertThat(history.getReason()).isEqualTo(StockChangeReason.SALE);
+  }
+
+  @Test
+  @DisplayName("입고 시 stockAfter는 stockBefore + changeAmount(양수)이다")
+  void of_increase_stockAfterCalculatedCorrectly() {
+    ProductVariant variant = mock(ProductVariant.class);
+
+    StockHistory history = StockHistory.of(variant, null, 10, 0, StockChangeReason.RESTOCK);
+
+    assertThat(history.getChangeAmount()).isEqualTo(10);
+    assertThat(history.getStockBefore()).isEqualTo(0);
+    assertThat(history.getStockAfter()).isEqualTo(10);
+    assertThat(history.getReason()).isEqualTo(StockChangeReason.RESTOCK);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductCreateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductCreateServiceTest.java
@@ -339,6 +339,36 @@ class ProductCreateServiceTest {
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_QUANTITY);
   }
 
+  @Test
+  @DisplayName("옵션 있는 상품에서 variant의 stock이 null이면 PROD_INVALID_QUANTITY를 던진다")
+  void throwsException_whenVariantStockIsNull() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        colorGroups(),
+        List.of(new VariantRequest(List.of("화이트"), null))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_QUANTITY);
+  }
+
+  @Test
+  @DisplayName("옵션 있는 상품에서 variant의 stock이 0이면 PROD_INVALID_QUANTITY를 던진다")
+  void throwsException_whenVariantStockIsZero() {
+    ProductCreateRequest request = new ProductCreateRequest(
+        "상품", 5L, null, 15000, null, null, null, null,
+        colorGroups(),
+        List.of(new VariantRequest(List.of("화이트"), 0))
+    );
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productCreateService.create(AUTH_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_QUANTITY);
+  }
+
   // ── 옵션/variant 일관성 검증 ───────────────────────────────────────────────────
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductCreateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductCreateServiceTest.java
@@ -29,6 +29,7 @@ import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.product.repo.StockHistoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.VariantOptionMapRepo;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
@@ -77,6 +78,8 @@ class ProductCreateServiceTest {
   @Mock
   private VariantOptionMapRepo variantOptionMapRepo;
   @Mock
+  private StockHistoryRepo stockHistoryRepo;
+  @Mock
   private ImageService imageService;
   @Mock
   private ApplicationEventPublisher eventPublisher;
@@ -108,6 +111,7 @@ class ProductCreateServiceTest {
     when(productOptionRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
     when(productVariantRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
     when(variantOptionMapRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(stockHistoryRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
     when(imageService.validateAndGetProductUrl(anyString()))
         .thenReturn("http://localhost:9000/wonkaotalk/products/test.jpg");
@@ -287,6 +291,24 @@ class ProductCreateServiceTest {
         () -> productCreateService.create(AUTH_ID, request));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
+  }
+
+  // ── 재고 이력 ─────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("옵션 없는 상품 등록 시 재고 이력이 1건 저장된다")
+  void createProduct_noOption_stockHistorySaved() {
+    productCreateService.create(AUTH_ID, noOptionRequest());
+
+    verify(stockHistoryRepo).save(any());
+  }
+
+  @Test
+  @DisplayName("옵션 있는 상품 등록 시 variant 수만큼 재고 이력이 저장된다")
+  void createProduct_withOption_stockHistorySavedPerVariant() {
+    productCreateService.create(AUTH_ID, withOptionRequest());
+
+    verify(stockHistoryRepo, atLeastOnce()).save(any());
   }
 
   // ── 재고 검증 ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 📌 관련 이슈
- #103 

## 📝 작업 내용
- 재고 이력 관리 테이블을 추가했습니다.
- 상품 등록 시 이력이 추가되도록 했습니다.

## ✅ 작업 결과 
- 테스트 결과
<img width="880" height="273" alt="스크린샷 2026-05-22 오전 11 41 02" src="https://github.com/user-attachments/assets/100fe88f-30e5-4153-bb98-b5581b1d7cdc" />
<img width="880" height="273" alt="스크린샷 2026-05-22 오전 11 40 54" src="https://github.com/user-attachments/assets/ed7f2a34-f04c-4f1d-9a45-ce0d1be02e80" />

## 🎸 기타
- Payments쪽에서도 decreaseStock()부분에 이력을 남기도록 추가하는 것이 맞긴 한데, 제 권한 밖이라 이걸 써야 하나 말아야 하나 고민이 되어서 건드리지 않았습니다. 나중에 시간날 때 추가해 주시면 될 것 같습니다.
