### PR TITLE
feat: 상품 정보/판매 상태 수정 API 제작

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
       "variant의 옵션 이름이 등록된 옵션 목록과 일치하지 않습니다."),
   PROD_INVALID_STOCK_OPTION(400, "PROD-INVALID-STOCK-OPTION", "옵션이 있는 상품은 stock을 직접 입력할 수 없습니다."),
   PROD_DUPLICATE_SORT_ORDER(400, "PROD-DUPLICATE-SORT-ORDER", "sortOrder 값이 중복되었습니다."),
+  PROD_INVALID_IMAGE_ID(400, "PROD-INVALID-IMAGE-ID", "해당 상품에 속하지 않는 이미지입니다."),
 
   // 이미지 도메인
   IMAGE_INVALID_TYPE(400, "IMAGE-INVALID-TYPE", "허용되지 않는 파일 형식입니다. (jpg, jpeg, png, webp)"),

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -7,11 +7,15 @@ import com.example.WonkaoTalk.domain.product.dto.CategoryResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductCreateRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductCreateResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductDetailResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateResponse;
 import com.example.WonkaoTalk.domain.product.service.CategoryService;
 import com.example.WonkaoTalk.domain.product.service.ProductCreateService;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
+import com.example.WonkaoTalk.domain.product.service.ProductUpdateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +27,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,6 +42,7 @@ public class ProductController {
 
   private final ProductService productService;
   private final ProductCreateService productCreateService;
+  private final ProductUpdateService productUpdateService;
   private final CategoryService categoryService;
 
   @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
@@ -64,6 +70,29 @@ public class ProductController {
       @PathVariable Long productId) {
     ProductDetailResponse response = productService.getProductDetail(productId);
     return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
+  }
+
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
+  @Operation(summary = "상품 수정 폼 조회", description = "판매자가 상품 수정 폼을 구성하는 데 필요한 기존 정보를 조회합니다.")
+  @GetMapping("/{productId}/edit")
+  public ResponseEntity<ApiResponse<ProductEditFormResponse>> getProductEditForm(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long productId) {
+    ProductEditFormResponse response = productUpdateService.getEditForm(
+        userDetails.getAuthId(), productId);
+    return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
+  }
+
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
+  @Operation(summary = "상품 정보 수정", description = "판매자가 자신의 상품 기본 정보, 상세 설명, 이미지를 수정합니다.")
+  @PatchMapping("/{productId}")
+  public ResponseEntity<ApiResponse<ProductUpdateResponse>> updateProduct(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long productId,
+      @Valid @RequestBody ProductUpdateRequest request) {
+    ProductUpdateResponse response = productUpdateService.update(
+        userDetails.getAuthId(), productId, request);
+    return ResponseEntity.ok(ApiResponse.success("상품 정보가 수정되었습니다", response));
   }
 
   @Operation(summary = "카테고리 조회", description = "상품 등록과 검색에 사용할 카테고리 트리를 조회합니다.")

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductEditFormResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductEditFormResponse.java
@@ -1,0 +1,56 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductEditFormResponse {
+
+  private Long productId;
+  private String name;
+  private Long categoryId;
+  private String thumbnail;
+  private Integer price;
+  private Integer discountRate;
+  private Integer discountedPrice;
+  private String status;
+  private String detail;
+  private List<ImageInfo> images;
+  private List<OptionGroupInfo> optionGroups;
+  private List<VariantInfo> variants;
+
+  @Getter
+  @Builder
+  public static class ImageInfo {
+    private Long imageId;
+    private String url;
+    private Integer sortOrder;
+  }
+
+  @Getter
+  @Builder
+  public static class OptionGroupInfo {
+    private Long optionGroupId;
+    private String name;
+    private Integer sortOrder;
+    private List<OptionInfo> options;
+  }
+
+  @Getter
+  @Builder
+  public static class OptionInfo {
+    private Long optionId;
+    private String name;
+  }
+
+  @Getter
+  @Builder
+  public static class VariantInfo {
+    private Long variantId;
+    private String variantName;
+    private Integer stock;
+    private String status;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ProductUpdateRequest(
+    @Size(max = 255) String name,
+    Long categoryId,
+    String thumbnailKey,
+    @Min(0) Integer price,
+    @Min(0) @Max(100) Integer discountRate,
+    String detail,
+    String status,
+    @Valid List<ImageRequest> images
+) {
+
+  public record ImageRequest(
+      Long imageId,
+      String objectKey,
+      @NotNull Integer sortOrder
+  ) {}
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductUpdateResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/ProductUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import java.time.LocalDateTime;
+
+public record ProductUpdateResponse(
+    Long productId,
+    String name,
+    Long categoryId,
+    String thumbnail,
+    Integer price,
+    Integer discountRate,
+    Integer discountedPrice,
+    String status,
+    LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/DeletedProductImage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/DeletedProductImage.java
@@ -1,0 +1,40 @@
+package com.example.WonkaoTalk.domain.product.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "deleted_product_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class DeletedProductImage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "url", nullable = false, columnDefinition = "TEXT")
+  private String url;
+
+  @CreatedDate
+  @Column(name = "deleted_at", nullable = false, updatable = false)
+  private LocalDateTime deletedAt;
+
+  @Builder
+  private DeletedProductImage(String url) {
+    this.url = url;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -80,6 +80,23 @@ public class Product {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  public void update(String name, Category category, String thumbnail,
+      Integer price, Integer discountRate, SaleStatus status) {
+    if (name != null) this.name = name;
+    if (category != null) this.category = category;
+    if (thumbnail != null) this.thumbnail = thumbnail;
+
+    boolean recalcPrice = price != null || discountRate != null;
+    if (price != null) this.price = price;
+    if (discountRate != null) this.discountRate = discountRate;
+    if (recalcPrice) {
+      int dr = this.discountRate != null ? this.discountRate : 0;
+      this.discountedPrice = (int) Math.round(this.price * (1 - dr / 100.0));
+    }
+
+    if (status != null) this.status = status;
+  }
+
   public boolean isOnSale() {
     return this.deletedAt == null && this.status == SaleStatus.ON_SALE;
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductDetail.java
@@ -48,4 +48,8 @@ public class ProductDetail {
   @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
+
+  public void updateContent(String content) {
+    this.content = content;
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductImage.java
@@ -51,4 +51,8 @@ public class ProductImage {
   @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
+
+  public void updateSortOrder(Integer sortOrder) {
+    this.sortOrder = sortOrder;
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/DeletedProductImageRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/DeletedProductImageRepo.java
@@ -1,0 +1,8 @@
+package com.example.WonkaoTalk.domain.product.repo;
+
+import com.example.WonkaoTalk.domain.product.entity.DeletedProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeletedProductImageRepo extends JpaRepository<DeletedProductImage, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductImageRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductImageRepo.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductImageRepo extends JpaRepository<ProductImage, Long> {
 
   List<ProductImage> findByProductIdOrderBySortOrderAsc(Long productId);
+
+  List<ProductImage> findByProductIdAndIdIn(Long productId, List<Long> ids);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -148,6 +148,10 @@ public class ProductUpdateService {
 
     String thumbnailUrl = null;
     if (request.thumbnailKey() != null) {
+      if (product.getThumbnail() != null) {
+        deletedProductImageRepo.save(
+            DeletedProductImage.builder().url(product.getThumbnail()).build());
+      }
       thumbnailUrl = imageService.validateAndGetProductUrl(request.thumbnailKey());
       objectKeysToMove.add(request.thumbnailKey());
     }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -231,18 +231,22 @@ public class ProductUpdateService {
     productImageRepo.deleteAllInBatch(toDelete);
 
     // 기존 이미지는 sortOrder만 업데이트, 새 이미지만 insert
+    List<ProductImage> newImages = new ArrayList<>();
     for (ImageRequest img : images) {
       if (img.imageId() != null) {
         existingImageMap.get(img.imageId()).updateSortOrder(img.sortOrder());
       } else {
         String url = imageService.validateAndGetProductUrl(img.objectKey());
         objectKeysToMove.add(img.objectKey());
-        productImageRepo.save(ProductImage.builder()
+        newImages.add(ProductImage.builder()
             .product(product)
             .url(url)
             .sortOrder(img.sortOrder())
             .build());
       }
+    }
+    if (!newImages.isEmpty()) {
+      productImageRepo.saveAll(newImages);
     }
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -251,8 +251,10 @@ public class ProductUpdateService {
   }
 
   private void recordDeletedUrls(List<ProductImage> images) {
-    images.forEach(img -> deletedProductImageRepo.save(
-        DeletedProductImage.builder().url(img.getUrl()).build()));
+    List<DeletedProductImage> deleted = images.stream()
+        .map(img -> DeletedProductImage.builder().url(img.getUrl()).build())
+        .toList();
+    deletedProductImageRepo.saveAll(deleted);
   }
 
   private void processDetail(Product product, String detail) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -1,0 +1,308 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.image.service.ImageService;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse.ImageInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse.OptionGroupInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse.OptionInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse.VariantInfo;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateRequest.ImageRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.DeletedProductImage;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductDetail;
+import com.example.WonkaoTalk.domain.product.entity.ProductImage;
+import com.example.WonkaoTalk.domain.product.entity.ProductOption;
+import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
+import com.example.WonkaoTalk.domain.product.repo.DeletedProductImageRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductImageRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductUpdateService {
+
+  private final SellerRepo sellerRepo;
+  private final StoreRepo storeRepo;
+  private final ProductRepo productRepo;
+  private final ProductDetailRepo productDetailRepo;
+  private final ProductImageRepo productImageRepo;
+  private final DeletedProductImageRepo deletedProductImageRepo;
+  private final ProductOptionGroupRepo productOptionGroupRepo;
+  private final ProductOptionRepo productOptionRepo;
+  private final ProductVariantRepo productVariantRepo;
+  private final CategoryRepo categoryRepo;
+  private final ImageService imageService;
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Transactional(readOnly = true)
+  public ProductEditFormResponse getEditForm(Long authId, Long productId) {
+    Store store = resolveStore(authId);
+    Product product = findOwnProduct(productId, store);
+
+    List<ImageInfo> images = productImageRepo.findByProductIdOrderBySortOrderAsc(productId)
+        .stream()
+        .map(img -> ImageInfo.builder()
+            .imageId(img.getId())
+            .url(img.getUrl())
+            .sortOrder(img.getSortOrder())
+            .build())
+        .toList();
+
+    String detail = productDetailRepo.findFirstByProductId(productId)
+        .map(ProductDetail::getContent)
+        .orElse(null);
+
+    List<ProductOptionGroup> groups = productOptionGroupRepo.findByProductId(productId);
+    List<Long> groupIds = groups.stream().map(ProductOptionGroup::getId).toList();
+    Map<Long, List<ProductOption>> optionsByGroup = productOptionRepo
+        .findByProductOptionGroupIdIn(groupIds)
+        .stream()
+        .collect(Collectors.groupingBy(opt -> opt.getProductOptionGroup().getId()));
+
+    List<OptionGroupInfo> optionGroups = groups.stream()
+        .map(group -> {
+          List<OptionInfo> options = optionsByGroup.getOrDefault(group.getId(), List.of())
+              .stream()
+              .map(opt -> OptionInfo.builder()
+                  .optionId(opt.getId())
+                  .name(opt.getName())
+                  .build())
+              .toList();
+          return OptionGroupInfo.builder()
+              .optionGroupId(group.getId())
+              .name(group.getName())
+              .sortOrder(group.getSortOrder())
+              .options(options)
+              .build();
+        })
+        .toList();
+
+    List<VariantInfo> variants = productVariantRepo.findByProductId(productId).stream()
+        .map(v -> VariantInfo.builder()
+            .variantId(v.getId())
+            .variantName(v.getName())
+            .stock(v.getStock())
+            .status(v.getStatus().name())
+            .build())
+        .toList();
+
+    return ProductEditFormResponse.builder()
+        .productId(product.getId())
+        .name(product.getName())
+        .categoryId(product.getCategory().getId())
+        .thumbnail(product.getThumbnail())
+        .price(product.getPrice())
+        .discountRate(product.getDiscountRate())
+        .discountedPrice(product.getDiscountedPrice())
+        .status(product.getStatus().name())
+        .detail(detail)
+        .images(images)
+        .optionGroups(optionGroups)
+        .variants(variants)
+        .build();
+  }
+
+  @Transactional
+  public ProductUpdateResponse update(Long authId, Long productId, ProductUpdateRequest request) {
+    Store store = resolveStore(authId);
+    Product product = findOwnProduct(productId, store);
+
+    validateRequest(request);
+
+    Category category = null;
+    if (request.categoryId() != null) {
+      category = categoryRepo.findById(request.categoryId())
+          .orElseThrow(() -> new BusinessException(ErrorCode.PROD_CATEGORY_NOT_FOUND));
+    }
+
+    List<String> objectKeysToMove = new ArrayList<>();
+
+    String thumbnailUrl = null;
+    if (request.thumbnailKey() != null) {
+      thumbnailUrl = imageService.validateAndGetProductUrl(request.thumbnailKey());
+      objectKeysToMove.add(request.thumbnailKey());
+    }
+
+    if (request.images() != null) {
+      processImages(product, request.images(), objectKeysToMove);
+    }
+
+    if (request.detail() != null) {
+      processDetail(product, request.detail());
+    }
+
+    SaleStatus newStatus = request.status() != null ? SaleStatus.valueOf(request.status()) : null;
+    product.update(request.name(), category, thumbnailUrl, request.price(), request.discountRate(), newStatus);
+
+    productRepo.save(product);
+
+    if (!objectKeysToMove.isEmpty()) {
+      eventPublisher.publishEvent(new ProductCreatedEvent(objectKeysToMove));
+    }
+
+    return new ProductUpdateResponse(
+        product.getId(),
+        product.getName(),
+        product.getCategory().getId(),
+        product.getThumbnail(),
+        product.getPrice(),
+        product.getDiscountRate(),
+        product.getDiscountedPrice(),
+        product.getStatus().name(),
+        product.getUpdatedAt()
+    );
+  }
+
+  private void processImages(Product product, List<ImageRequest> images,
+      List<String> objectKeysToMove) {
+    List<ProductImage> currentImages = productImageRepo.findByProductIdOrderBySortOrderAsc(
+        product.getId());
+
+    if (images.isEmpty()) {
+      recordDeletedUrls(currentImages);
+      productImageRepo.deleteAll(currentImages);
+      return;
+    }
+
+    List<Long> requestedImageIds = images.stream()
+        .filter(img -> img.imageId() != null)
+        .map(ImageRequest::imageId)
+        .toList();
+
+    Map<Long, String> existingUrlMap;
+    if (!requestedImageIds.isEmpty()) {
+      List<ProductImage> foundImages = productImageRepo.findByProductIdAndIdIn(
+          product.getId(), requestedImageIds);
+      if (foundImages.size() != requestedImageIds.size()) {
+        throw new BusinessException(ErrorCode.PROD_INVALID_IMAGE_ID);
+      }
+      existingUrlMap = foundImages.stream()
+          .collect(Collectors.toMap(ProductImage::getId, ProductImage::getUrl));
+    } else {
+      existingUrlMap = Map.of();
+    }
+
+    Set<Integer> sortOrders = new HashSet<>();
+    for (ImageRequest img : images) {
+      if (!sortOrders.add(img.sortOrder())) {
+        throw new BusinessException(ErrorCode.PROD_DUPLICATE_SORT_ORDER);
+      }
+    }
+
+    Set<Long> keptImageIds = new HashSet<>(requestedImageIds);
+    List<ProductImage> deletedImages = currentImages.stream()
+        .filter(img -> !keptImageIds.contains(img.getId()))
+        .toList();
+    recordDeletedUrls(deletedImages);
+    productImageRepo.deleteAll(currentImages);
+
+    for (ImageRequest img : images) {
+      String url;
+      if (img.imageId() != null) {
+        url = existingUrlMap.get(img.imageId());
+      } else {
+        url = imageService.validateAndGetProductUrl(img.objectKey());
+        objectKeysToMove.add(img.objectKey());
+      }
+      productImageRepo.save(ProductImage.builder()
+          .product(product)
+          .url(url)
+          .sortOrder(img.sortOrder())
+          .build());
+    }
+  }
+
+  private void recordDeletedUrls(List<ProductImage> images) {
+    images.forEach(img -> deletedProductImageRepo.save(
+        DeletedProductImage.builder().url(img.getUrl()).build()));
+  }
+
+  private void processDetail(Product product, String detail) {
+    Optional<ProductDetail> existing = productDetailRepo.findFirstByProductId(product.getId());
+    if (detail.isEmpty()) {
+      existing.ifPresent(productDetailRepo::delete);
+      return;
+    }
+    String sanitized = Jsoup.clean(detail, Safelist.relaxed());
+    if (existing.isPresent()) {
+      existing.get().updateContent(sanitized);
+    } else {
+      productDetailRepo.save(ProductDetail.builder()
+          .product(product)
+          .content(sanitized)
+          .build());
+    }
+  }
+
+  private void validateRequest(ProductUpdateRequest request) {
+    if (request.price() != null && request.price() < 0) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_PRICE);
+    }
+    if (request.discountRate() != null
+        && (request.discountRate() < 0 || request.discountRate() > 100)) {
+      throw new BusinessException(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
+    }
+    if (request.status() != null
+        && !request.status().equals(SaleStatus.ON_SALE.name())
+        && !request.status().equals(SaleStatus.STOP_SALE.name())) {
+      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    }
+    if (request.images() != null) {
+      for (ImageRequest img : request.images()) {
+        boolean hasImageId = img.imageId() != null;
+        boolean hasObjectKey = img.objectKey() != null && !img.objectKey().isBlank();
+        if (hasImageId == hasObjectKey) {
+          throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
+      }
+    }
+  }
+
+  private Store resolveStore(Long authId) {
+    Seller seller = sellerRepo.findByAuthId(authId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+    return storeRepo.findBySeller(seller)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_STORE_NOT_FOUND));
+  }
+
+  private Product findOwnProduct(Long productId, Store store) {
+    Product product = productRepo.findById(productId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_NOT_FOUND));
+    if (product.getDeletedAt() != null) {
+      throw new BusinessException(ErrorCode.PROD_DELETED);
+    }
+    if (!product.getStore().getId().equals(store.getId())) {
+      throw new BusinessException(ErrorCode.FORBIDDEN);
+    }
+    return product;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -193,7 +193,7 @@ public class ProductUpdateService {
 
     if (images.isEmpty()) {
       recordDeletedUrls(currentImages);
-      productImageRepo.deleteAll(currentImages);
+      productImageRepo.deleteAllInBatch(currentImages);
       return;
     }
 
@@ -228,7 +228,7 @@ public class ProductUpdateService {
         .filter(img -> !keptImageIds.contains(img.getId()))
         .toList();
     recordDeletedUrls(toDelete);
-    productImageRepo.deleteAll(toDelete);
+    productImageRepo.deleteAllInBatch(toDelete);
 
     // 기존 이미지는 sortOrder만 업데이트, 새 이미지만 insert
     for (ImageRequest img : images) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -33,6 +33,7 @@ import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
 import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -165,7 +166,8 @@ public class ProductUpdateService {
     }
 
     SaleStatus newStatus = request.status() != null ? SaleStatus.valueOf(request.status()) : null;
-    product.update(request.name(), category, thumbnailUrl, request.price(), request.discountRate(), newStatus);
+    product.update(request.name(), category, thumbnailUrl, request.price(), request.discountRate(),
+        newStatus);
 
     productRepo.save(product);
 
@@ -282,10 +284,12 @@ public class ProductUpdateService {
         && (request.discountRate() < 0 || request.discountRate() > 100)) {
       throw new BusinessException(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
     }
-    if (request.status() != null
-        && !request.status().equals(SaleStatus.ON_SALE.name())
-        && !request.status().equals(SaleStatus.STOP_SALE.name())) {
-      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    if (request.status() != null) {
+      boolean valid = Arrays.stream(SaleStatus.values())
+          .anyMatch(s -> s.name().equals(request.status()));
+      if (!valid) {
+        throw new BusinessException(ErrorCode.BAD_REQUEST);
+      }
     }
     if (request.images() != null) {
       for (ImageRequest img : request.images()) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -198,17 +198,17 @@ public class ProductUpdateService {
         .map(ImageRequest::imageId)
         .toList();
 
-    Map<Long, String> existingUrlMap;
+    Map<Long, ProductImage> existingImageMap;
     if (!requestedImageIds.isEmpty()) {
       List<ProductImage> foundImages = productImageRepo.findByProductIdAndIdIn(
           product.getId(), requestedImageIds);
       if (foundImages.size() != requestedImageIds.size()) {
         throw new BusinessException(ErrorCode.PROD_INVALID_IMAGE_ID);
       }
-      existingUrlMap = foundImages.stream()
-          .collect(Collectors.toMap(ProductImage::getId, ProductImage::getUrl));
+      existingImageMap = foundImages.stream()
+          .collect(Collectors.toMap(ProductImage::getId, img -> img));
     } else {
-      existingUrlMap = Map.of();
+      existingImageMap = Map.of();
     }
 
     Set<Integer> sortOrders = new HashSet<>();
@@ -218,26 +218,27 @@ public class ProductUpdateService {
       }
     }
 
+    // 요청에 없는 기존 이미지만 삭제
     Set<Long> keptImageIds = new HashSet<>(requestedImageIds);
-    List<ProductImage> deletedImages = currentImages.stream()
+    List<ProductImage> toDelete = currentImages.stream()
         .filter(img -> !keptImageIds.contains(img.getId()))
         .toList();
-    recordDeletedUrls(deletedImages);
-    productImageRepo.deleteAll(currentImages);
+    recordDeletedUrls(toDelete);
+    productImageRepo.deleteAll(toDelete);
 
+    // 기존 이미지는 sortOrder만 업데이트, 새 이미지만 insert
     for (ImageRequest img : images) {
-      String url;
       if (img.imageId() != null) {
-        url = existingUrlMap.get(img.imageId());
+        existingImageMap.get(img.imageId()).updateSortOrder(img.sortOrder());
       } else {
-        url = imageService.validateAndGetProductUrl(img.objectKey());
+        String url = imageService.validateAndGetProductUrl(img.objectKey());
         objectKeysToMove.add(img.objectKey());
+        productImageRepo.save(ProductImage.builder()
+            .product(product)
+            .url(url)
+            .sortOrder(img.sortOrder())
+            .build());
       }
-      productImageRepo.save(ProductImage.builder()
-          .product(product)
-          .url(url)
-          .sortOrder(img.sortOrder())
-          .build());
     }
   }
 

--- a/src/main/resources/db/migration/V3__create_deleted_product_images.sql
+++ b/src/main/resources/db/migration/V3__create_deleted_product_images.sql
@@ -1,0 +1,5 @@
+CREATE TABLE deleted_product_images (
+    id         BIGSERIAL    PRIMARY KEY,
+    url        TEXT         NOT NULL,
+    deleted_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
@@ -120,7 +120,7 @@ class ProductUpdateServiceTest {
 
     when(productRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
     when(deletedProductImageRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-    when(productImageRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productImageRepo.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
     when(productDetailRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
     when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID)).thenReturn(List.of());
@@ -478,7 +478,7 @@ class ProductUpdateServiceTest {
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
     verify(productImageRepo).deleteAllInBatch(List.of());
-    verify(productImageRepo, never()).save(any());
+    verify(productImageRepo, never()).saveAll(any());
   }
 
   @Test
@@ -510,7 +510,7 @@ class ProductUpdateServiceTest {
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
     verify(imageService).validateAndGetProductUrl("temp/new.jpg");
-    verify(productImageRepo).save(any(ProductImage.class));
+    verify(productImageRepo).saveAll(any());
   }
 
   @Test
@@ -556,7 +556,7 @@ class ProductUpdateServiceTest {
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
     verify(productImageRepo, never()).deleteAllInBatch(any());
-    verify(productImageRepo, never()).save(any());
+    verify(productImageRepo, never()).saveAll(any());
   }
 
   // ── update 상세 설명 처리 ────────────────────────────────────────────────────

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
@@ -119,7 +119,7 @@ class ProductUpdateServiceTest {
     when(product.getUpdatedAt()).thenReturn(LocalDateTime.of(2026, 5, 24, 10, 0));
 
     when(productRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-    when(deletedProductImageRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(deletedProductImageRepo.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
     when(productImageRepo.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
     when(productDetailRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -459,7 +459,7 @@ class ProductUpdateServiceTest {
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
     verify(productImageRepo).deleteAllInBatch(List.of(existingImg));
-    verify(deletedProductImageRepo).save(any(DeletedProductImage.class));
+    verify(deletedProductImageRepo).saveAll(any());
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
@@ -1,0 +1,707 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.image.service.ImageService;
+import com.example.WonkaoTalk.domain.product.dto.ProductEditFormResponse;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateRequest.ImageRequest;
+import com.example.WonkaoTalk.domain.product.dto.ProductUpdateResponse;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.DeletedProductImage;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductDetail;
+import com.example.WonkaoTalk.domain.product.entity.ProductImage;
+import com.example.WonkaoTalk.domain.product.entity.ProductOption;
+import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
+import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
+import com.example.WonkaoTalk.domain.product.repo.DeletedProductImageRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductImageRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionGroupRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductUpdateServiceTest {
+
+  private static final Long AUTH_ID = 1L;
+  private static final Long PRODUCT_ID = 101L;
+  private static final Long STORE_ID = 7L;
+
+  @Mock
+  private SellerRepo sellerRepo;
+  @Mock
+  private StoreRepo storeRepo;
+  @Mock
+  private ProductRepo productRepo;
+  @Mock
+  private ProductDetailRepo productDetailRepo;
+  @Mock
+  private ProductImageRepo productImageRepo;
+  @Mock
+  private DeletedProductImageRepo deletedProductImageRepo;
+  @Mock
+  private ProductOptionGroupRepo productOptionGroupRepo;
+  @Mock
+  private ProductOptionRepo productOptionRepo;
+  @Mock
+  private ProductVariantRepo productVariantRepo;
+  @Mock
+  private CategoryRepo categoryRepo;
+  @Mock
+  private ImageService imageService;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @InjectMocks
+  private ProductUpdateService productUpdateService;
+
+  private Store store;
+  private Product product;
+  private Category category;
+
+  @BeforeEach
+  void setUp() {
+    Seller seller = mock(Seller.class);
+    store = mock(Store.class);
+    product = mock(Product.class);
+    category = mock(Category.class);
+
+    when(store.getId()).thenReturn(STORE_ID);
+    when(category.getId()).thenReturn(5L);
+
+    when(sellerRepo.findByAuthId(AUTH_ID)).thenReturn(Optional.of(seller));
+    when(storeRepo.findBySeller(seller)).thenReturn(Optional.of(store));
+    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(product.getId()).thenReturn(PRODUCT_ID);
+    when(product.getStore()).thenReturn(store);
+    when(product.getDeletedAt()).thenReturn(null);
+    when(product.getName()).thenReturn("기존 상품명");
+    when(product.getThumbnail()).thenReturn(null);
+    when(product.getPrice()).thenReturn(10000);
+    when(product.getDiscountRate()).thenReturn(0);
+    when(product.getDiscountedPrice()).thenReturn(10000);
+    when(product.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    when(product.getCategory()).thenReturn(category);
+    when(product.getUpdatedAt()).thenReturn(LocalDateTime.of(2026, 5, 24, 10, 0));
+
+    when(productRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(deletedProductImageRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productImageRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(productDetailRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID)).thenReturn(List.of());
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID)).thenReturn(Optional.empty());
+    when(productOptionGroupRepo.findByProductId(PRODUCT_ID)).thenReturn(List.of());
+    when(productVariantRepo.findByProductId(PRODUCT_ID)).thenReturn(List.of());
+
+    when(imageService.validateAndGetProductUrl(anyString()))
+        .thenReturn("http://localhost:9000/wonkaotalk/products/test.jpg");
+  }
+
+  // ── getEditForm 조회 실패 ────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("판매자를 찾을 수 없으면 SELLER_NOT_FOUND를 던진다")
+  void getEditForm_throwsException_whenSellerNotFound() {
+    when(sellerRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("스토어를 찾을 수 없으면 PROD_STORE_NOT_FOUND를 던진다")
+  void getEditForm_throwsException_whenStoreNotFound() {
+    when(storeRepo.findBySeller(any())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STORE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("상품을 찾을 수 없으면 PROD_NOT_FOUND를 던진다")
+  void getEditForm_throwsException_whenProductNotFound() {
+    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("논리 삭제된 상품이면 PROD_DELETED를 던진다")
+  void getEditForm_throwsException_whenProductIsDeleted() {
+    when(product.getDeletedAt()).thenReturn(LocalDateTime.now());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DELETED);
+  }
+
+  @Test
+  @DisplayName("다른 스토어의 상품이면 FORBIDDEN을 던진다")
+  void getEditForm_throwsException_whenProductBelongsToOtherStore() {
+    Store otherStore = mock(Store.class);
+    when(otherStore.getId()).thenReturn(999L);
+    when(product.getStore()).thenReturn(otherStore);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
+  }
+
+  // ── getEditForm 성공 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("수정 폼 조회 시 이미지 목록이 포함된다")
+  void getEditForm_includesImages() {
+    ProductImage img = mockProductImage(10L, "http://example.com/img.jpg", 1);
+    when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID)).thenReturn(List.of(img));
+
+    ProductEditFormResponse response = productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID);
+
+    assertThat(response.getImages()).hasSize(1);
+    assertThat(response.getImages().get(0).getImageId()).isEqualTo(10L);
+    assertThat(response.getImages().get(0).getUrl()).isEqualTo("http://example.com/img.jpg");
+    assertThat(response.getImages().get(0).getSortOrder()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("수정 폼 조회 시 상세 설명이 포함된다")
+  void getEditForm_includesDetail() {
+    ProductDetail detail = mock(ProductDetail.class);
+    when(detail.getContent()).thenReturn("<p>상품 설명</p>");
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID)).thenReturn(Optional.of(detail));
+
+    ProductEditFormResponse response = productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID);
+
+    assertThat(response.getDetail()).isEqualTo("<p>상품 설명</p>");
+  }
+
+  @Test
+  @DisplayName("수정 폼 조회 시 옵션 그룹과 옵션 목록이 포함된다")
+  void getEditForm_includesOptionGroupsAndOptions() {
+    ProductOptionGroup group = mockOptionGroup(20L, "색상", 1);
+    ProductOption option = mockProductOption(30L, "화이트", group);
+    when(productOptionGroupRepo.findByProductId(PRODUCT_ID)).thenReturn(List.of(group));
+    when(productOptionRepo.findByProductOptionGroupIdIn(List.of(20L))).thenReturn(List.of(option));
+
+    ProductEditFormResponse response = productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID);
+
+    assertThat(response.getOptionGroups()).hasSize(1);
+    assertThat(response.getOptionGroups().get(0).getOptionGroupId()).isEqualTo(20L);
+    assertThat(response.getOptionGroups().get(0).getName()).isEqualTo("색상");
+    assertThat(response.getOptionGroups().get(0).getOptions()).hasSize(1);
+    assertThat(response.getOptionGroups().get(0).getOptions().get(0).getName()).isEqualTo("화이트");
+  }
+
+  @Test
+  @DisplayName("수정 폼 조회 시 variant 목록이 포함된다")
+  void getEditForm_includesVariants() {
+    ProductVariant variant = mockVariant(40L, "화이트", 50, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByProductId(PRODUCT_ID)).thenReturn(List.of(variant));
+
+    ProductEditFormResponse response = productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID);
+
+    assertThat(response.getVariants()).hasSize(1);
+    assertThat(response.getVariants().get(0).getVariantId()).isEqualTo(40L);
+    assertThat(response.getVariants().get(0).getVariantName()).isEqualTo("화이트");
+    assertThat(response.getVariants().get(0).getStock()).isEqualTo(50);
+    assertThat(response.getVariants().get(0).getStatus()).isEqualTo("ON_SALE");
+  }
+
+  @Test
+  @DisplayName("상세 설명이 없으면 detail은 null이다")
+  void getEditForm_detailIsNull_whenNoDetail() {
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID)).thenReturn(Optional.empty());
+
+    ProductEditFormResponse response = productUpdateService.getEditForm(AUTH_ID, PRODUCT_ID);
+
+    assertThat(response.getDetail()).isNull();
+  }
+
+  // ── update 조회 실패 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("update: 판매자를 찾을 수 없으면 SELLER_NOT_FOUND를 던진다")
+  void update_throwsException_whenSellerNotFound() {
+    when(sellerRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, emptyRequest()));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("update: 상품을 찾을 수 없으면 PROD_NOT_FOUND를 던진다")
+  void update_throwsException_whenProductNotFound() {
+    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, emptyRequest()));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("update: 다른 스토어의 상품이면 FORBIDDEN을 던진다")
+  void update_throwsException_whenProductBelongsToOtherStore() {
+    Store otherStore = mock(Store.class);
+    when(otherStore.getId()).thenReturn(999L);
+    when(product.getStore()).thenReturn(otherStore);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, emptyRequest()));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
+  }
+
+  // ── update 입력값 검증 ───────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("가격이 음수면 PROD_INVALID_PRICE를 던진다")
+  void update_throwsException_whenPriceIsNegative() {
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, -1, null, null, null, null);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_PRICE);
+  }
+
+  @Test
+  @DisplayName("할인율이 음수면 PROD_INVALID_DISCOUNT_RATE를 던진다")
+  void update_throwsException_whenDiscountRateIsNegative() {
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, -1, null, null, null);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
+  }
+
+  @Test
+  @DisplayName("할인율이 100을 초과하면 PROD_INVALID_DISCOUNT_RATE를 던진다")
+  void update_throwsException_whenDiscountRateExceeds100() {
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, 101, null, null, null);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_DISCOUNT_RATE);
+  }
+
+  @Test
+  @DisplayName("잘못된 상태값이면 BAD_REQUEST를 던진다")
+  void update_throwsException_whenStatusIsInvalid() {
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, "INVALID_STATUS", null);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("이미지 요청에 imageId와 objectKey가 모두 있으면 BAD_REQUEST를 던진다")
+  void update_throwsException_whenImageHasBothIdAndKey() {
+    List<ImageRequest> images = List.of(new ImageRequest(1L, "temp/key.jpg", 1));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("이미지 요청에 imageId와 objectKey가 모두 없으면 BAD_REQUEST를 던진다")
+  void update_throwsException_whenImageHasNeitherIdNorKey() {
+    List<ImageRequest> images = List.of(new ImageRequest(null, null, 1));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  // ── update 카테고리 ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("존재하지 않는 카테고리 ID면 PROD_CATEGORY_NOT_FOUND를 던진다")
+  void update_throwsException_whenCategoryNotFound() {
+    when(categoryRepo.findById(anyLong())).thenReturn(Optional.empty());
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, 99L, null, null, null, null, null, null);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_CATEGORY_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("categoryId가 null이면 카테고리를 조회하지 않는다")
+  void update_doesNotQueryCategory_whenCategoryIdIsNull() {
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, emptyRequest());
+
+    verify(categoryRepo, never()).findById(anyLong());
+  }
+
+  // ── update 썸네일 처리 ───────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("thumbnailKey가 있으면 이미지 URL로 변환된다")
+  void update_convertsThumbnailKey_toProductUrl() {
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, "temp/new-thumb.jpg", null, null, null, null, null);
+
+    ProductUpdateResponse response = productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(imageService).validateAndGetProductUrl("temp/new-thumb.jpg");
+  }
+
+  @Test
+  @DisplayName("썸네일 교체 시 기존 썸네일 URL을 deleted_product_images에 기록한다")
+  void update_recordsOldThumbnailUrl_whenReplacingThumbnail() {
+    when(product.getThumbnail()).thenReturn("http://example.com/old-thumb.jpg");
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, "temp/new-thumb.jpg", null, null, null, null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(deletedProductImageRepo).save(any(DeletedProductImage.class));
+  }
+
+  @Test
+  @DisplayName("기존 썸네일이 없으면 deleted_product_images에 기록하지 않는다")
+  void update_doesNotRecordDeletedUrl_whenNoExistingThumbnail() {
+    when(product.getThumbnail()).thenReturn(null);
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, "temp/new-thumb.jpg", null, null, null, null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(deletedProductImageRepo, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("thumbnailKey가 없으면 thumbnailUrl을 변경하지 않는다")
+  void update_doesNotChangeThumbnail_whenKeyIsNull() {
+    ProductUpdateRequest request = emptyRequest();
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(imageService, never()).validateAndGetProductUrl(any());
+  }
+
+  // ── update 이미지 처리 ───────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("images가 빈 리스트이면 기존 이미지를 전부 삭제한다")
+  void update_deletesAllImages_whenImagesIsEmpty() {
+    ProductImage existingImg = mockProductImage(10L, "http://example.com/img.jpg", 1);
+    when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID))
+        .thenReturn(List.of(existingImg));
+
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, List.of());
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productImageRepo).deleteAll(List.of(existingImg));
+    verify(deletedProductImageRepo).save(any(DeletedProductImage.class));
+  }
+
+  @Test
+  @DisplayName("기존 이미지 ID를 포함하면 해당 이미지는 삭제되지 않는다")
+  void update_keepsExistingImage_whenImageIdProvided() {
+    ProductImage existingImg = mockProductImage(10L, "http://example.com/img.jpg", 1);
+    when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID))
+        .thenReturn(List.of(existingImg));
+    when(productImageRepo.findByProductIdAndIdIn(PRODUCT_ID, List.of(10L)))
+        .thenReturn(List.of(existingImg));
+
+    List<ImageRequest> images = List.of(new ImageRequest(10L, null, 2));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productImageRepo).deleteAll(List.of());
+    verify(productImageRepo, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("기존 이미지 ID를 제외하면 해당 이미지는 삭제된다")
+  void update_deletesImage_whenImageIdNotInRequest() {
+    ProductImage img1 = mockProductImage(10L, "http://example.com/img1.jpg", 1);
+    ProductImage img2 = mockProductImage(11L, "http://example.com/img2.jpg", 2);
+    when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID))
+        .thenReturn(List.of(img1, img2));
+    when(productImageRepo.findByProductIdAndIdIn(PRODUCT_ID, List.of(10L)))
+        .thenReturn(List.of(img1));
+
+    List<ImageRequest> images = List.of(new ImageRequest(10L, null, 1));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productImageRepo).deleteAll(List.of(img2));
+  }
+
+  @Test
+  @DisplayName("새 이미지 objectKey를 전달하면 새 이미지가 저장된다")
+  void update_savesNewImage_whenObjectKeyProvided() {
+    List<ImageRequest> images = List.of(new ImageRequest(null, "temp/new.jpg", 1));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(imageService).validateAndGetProductUrl("temp/new.jpg");
+    verify(productImageRepo).save(any(ProductImage.class));
+  }
+
+  @Test
+  @DisplayName("이미지 sortOrder가 중복이면 PROD_DUPLICATE_SORT_ORDER를 던진다")
+  void update_throwsException_whenDuplicateImageSortOrder() {
+    List<ImageRequest> images = List.of(
+        new ImageRequest(null, "temp/a.jpg", 1),
+        new ImageRequest(null, "temp/b.jpg", 1)
+    );
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DUPLICATE_SORT_ORDER);
+  }
+
+  @Test
+  @DisplayName("요청한 이미지 ID가 해당 상품에 속하지 않으면 PROD_INVALID_IMAGE_ID를 던진다")
+  void update_throwsException_whenImageIdNotBelongToProduct() {
+    ProductImage existingImg = mockProductImage(10L, "http://example.com/img.jpg", 1);
+    when(productImageRepo.findByProductIdOrderBySortOrderAsc(PRODUCT_ID))
+        .thenReturn(List.of(existingImg));
+    when(productImageRepo.findByProductIdAndIdIn(PRODUCT_ID, List.of(999L)))
+        .thenReturn(List.of());
+
+    List<ImageRequest> images = List.of(new ImageRequest(999L, null, 1));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productUpdateService.update(AUTH_ID, PRODUCT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_INVALID_IMAGE_ID);
+  }
+
+  @Test
+  @DisplayName("images가 null이면 이미지를 처리하지 않는다")
+  void update_doesNotProcessImages_whenImagesIsNull() {
+    ProductUpdateRequest request = emptyRequest();
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productImageRepo, never()).deleteAll(any());
+    verify(productImageRepo, never()).save(any());
+  }
+
+  // ── update 상세 설명 처리 ────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("detail이 null이면 상세 설명을 처리하지 않는다")
+  void update_doesNotProcessDetail_whenDetailIsNull() {
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, emptyRequest());
+
+    verify(productDetailRepo, never()).save(any());
+    verify(productDetailRepo, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("detail이 빈 문자열이면 기존 상세 설명을 삭제한다")
+  void update_deletesDetail_whenDetailIsEmpty() {
+    ProductDetail existingDetail = mock(ProductDetail.class);
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID))
+        .thenReturn(Optional.of(existingDetail));
+
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, "", null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productDetailRepo).delete(existingDetail);
+  }
+
+  @Test
+  @DisplayName("detail이 빈 문자열이고 기존 상세가 없으면 삭제를 시도하지 않는다")
+  void update_doesNotDelete_whenDetailIsEmptyAndNoExistingDetail() {
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID)).thenReturn(Optional.empty());
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, "", null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productDetailRepo, never()).delete(any());
+  }
+
+  @Test
+  @DisplayName("detail이 있고 기존 상세가 없으면 새로 저장한다")
+  void update_savesNewDetail_whenDetailAndNoExistingDetail() {
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID)).thenReturn(Optional.empty());
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, "<p>새 설명</p>", null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(productDetailRepo).save(any(ProductDetail.class));
+  }
+
+  @Test
+  @DisplayName("detail이 있고 기존 상세가 있으면 내용을 업데이트한다")
+  void update_updatesExistingDetail_whenDetailAndExistingDetail() {
+    ProductDetail existingDetail = mock(ProductDetail.class);
+    when(productDetailRepo.findFirstByProductId(PRODUCT_ID))
+        .thenReturn(Optional.of(existingDetail));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, "<p>수정된 설명</p>", null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(existingDetail).updateContent(any());
+    verify(productDetailRepo, never()).save(any());
+  }
+
+  // ── update 성공 응답 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("수정 성공 시 응답에 상품 ID가 포함된다")
+  void update_returnsProductId_onSuccess() {
+    ProductUpdateResponse response = productUpdateService.update(AUTH_ID, PRODUCT_ID,
+        emptyRequest());
+
+    assertThat(response.productId()).isEqualTo(PRODUCT_ID);
+  }
+
+  @Test
+  @DisplayName("수정 성공 시 이벤트가 발행되지 않는다 - S3 이동 대상이 없을 때")
+  void update_doesNotPublishEvent_whenNoObjectKeysToMove() {
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, emptyRequest());
+
+    verify(eventPublisher, never()).publishEvent(any());
+  }
+
+  @Test
+  @DisplayName("thumbnailKey가 있으면 이벤트가 발행된다")
+  void update_publishesEvent_whenThumbnailKeyProvided() {
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, "temp/new-thumb.jpg", null, null, null, null, null);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(eventPublisher).publishEvent(any(ProductCreatedEvent.class));
+  }
+
+  @Test
+  @DisplayName("새 이미지 objectKey가 있으면 이벤트가 발행된다")
+  void update_publishesEvent_whenNewImageObjectKeyProvided() {
+    List<ImageRequest> images = List.of(new ImageRequest(null, "temp/new.jpg", 1));
+    ProductUpdateRequest request = new ProductUpdateRequest(
+        null, null, null, null, null, null, null, images);
+
+    productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
+
+    verify(eventPublisher).publishEvent(any(ProductCreatedEvent.class));
+  }
+
+  // ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+  private ProductUpdateRequest emptyRequest() {
+    return new ProductUpdateRequest(null, null, null, null, null, null, null, null);
+  }
+
+  private ProductImage mockProductImage(Long id, String url, Integer sortOrder) {
+    ProductImage img = mock(ProductImage.class);
+    when(img.getId()).thenReturn(id);
+    when(img.getUrl()).thenReturn(url);
+    when(img.getSortOrder()).thenReturn(sortOrder);
+    return img;
+  }
+
+  private ProductOptionGroup mockOptionGroup(Long id, String name, Integer sortOrder) {
+    ProductOptionGroup group = mock(ProductOptionGroup.class);
+    when(group.getId()).thenReturn(id);
+    when(group.getName()).thenReturn(name);
+    when(group.getSortOrder()).thenReturn(sortOrder);
+    return group;
+  }
+
+  private ProductOption mockProductOption(Long id, String name, ProductOptionGroup group) {
+    ProductOption option = mock(ProductOption.class);
+    when(option.getId()).thenReturn(id);
+    when(option.getName()).thenReturn(name);
+    when(option.getProductOptionGroup()).thenReturn(group);
+    return option;
+  }
+
+  private ProductVariant mockVariant(Long id, String name, int stock, SaleStatus status) {
+    ProductVariant variant = mock(ProductVariant.class);
+    when(variant.getId()).thenReturn(id);
+    when(variant.getName()).thenReturn(name);
+    when(variant.getStock()).thenReturn(stock);
+    when(variant.getStatus()).thenReturn(status);
+    return variant;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateServiceTest.java
@@ -458,7 +458,7 @@ class ProductUpdateServiceTest {
 
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
-    verify(productImageRepo).deleteAll(List.of(existingImg));
+    verify(productImageRepo).deleteAllInBatch(List.of(existingImg));
     verify(deletedProductImageRepo).save(any(DeletedProductImage.class));
   }
 
@@ -477,7 +477,7 @@ class ProductUpdateServiceTest {
 
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
-    verify(productImageRepo).deleteAll(List.of());
+    verify(productImageRepo).deleteAllInBatch(List.of());
     verify(productImageRepo, never()).save(any());
   }
 
@@ -497,7 +497,7 @@ class ProductUpdateServiceTest {
 
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
-    verify(productImageRepo).deleteAll(List.of(img2));
+    verify(productImageRepo).deleteAllInBatch(List.of(img2));
   }
 
   @Test
@@ -555,7 +555,7 @@ class ProductUpdateServiceTest {
 
     productUpdateService.update(AUTH_ID, PRODUCT_ID, request);
 
-    verify(productImageRepo, never()).deleteAll(any());
+    verify(productImageRepo, never()).deleteAllInBatch(any());
     verify(productImageRepo, never()).save(any());
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- #106 

## 📝 작업 내용
- 상품 정보 수정 API를 제작했습니다
- 판매자용 상품 정보 조회 API를 만들었습니다

## ✅ 작업 결과 
- 테스트 결과
<img width="682" height="281" alt="스크린샷 2026-05-24 오후 10 10 32" src="https://github.com/user-attachments/assets/9a1d40e5-e933-4bf7-84bb-3decfbacef76" />
