### PR TITLE
feat: 상품 재고 수정/상품 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -65,6 +65,8 @@ public enum ErrorCode {
   PROD_INVALID_STOCK_OPTION(400, "PROD-INVALID-STOCK-OPTION", "옵션이 있는 상품은 stock을 직접 입력할 수 없습니다."),
   PROD_DUPLICATE_SORT_ORDER(400, "PROD-DUPLICATE-SORT-ORDER", "sortOrder 값이 중복되었습니다."),
   PROD_INVALID_IMAGE_ID(400, "PROD-INVALID-IMAGE-ID", "해당 상품에 속하지 않는 이미지입니다."),
+  PROD_HAS_ACTIVE_ORDER(409, "PROD-HAS-ACTIVE-ORDER", "진행 중인 주문이 있어 상품을 삭제할 수 없습니다."),
+  PROD_VARIANT_NOT_FOUND(404, "PROD-NOT-FOUND-VARIANT", "해당 상품 옵션을 찾을 수 없습니다."),
 
   // 이미지 도메인
   IMAGE_INVALID_TYPE(400, "IMAGE-INVALID-TYPE", "허용되지 않는 파일 형식입니다. (jpg, jpeg, png, webp)"),

--- a/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderItemRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderItemRepo.java
@@ -2,10 +2,22 @@ package com.example.WonkaoTalk.domain.order.repo;
 
 import com.example.WonkaoTalk.domain.order.entity.Order;
 import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderItemRepo extends JpaRepository<OrderItem, Long> {
 
   List<OrderItem> findByOrder(Order order);
+
+  @Query("SELECT COUNT(oi) > 0 FROM OrderItem oi " +
+      "JOIN oi.order o " +
+      "WHERE oi.productVariant.product.id = :productId " +
+      "AND o.orderStatus IN :statuses")
+  boolean existsActiveOrderByProductId(
+      @Param("productId") Long productId,
+      @Param("statuses") List<OrderStatus> statuses
+  );
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderItemRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderItemRepo.java
@@ -5,19 +5,13 @@ import com.example.WonkaoTalk.domain.order.entity.OrderItem;
 import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface OrderItemRepo extends JpaRepository<OrderItem, Long> {
 
   List<OrderItem> findByOrder(Order order);
 
-  @Query("SELECT COUNT(oi) > 0 FROM OrderItem oi " +
-      "JOIN oi.order o " +
-      "WHERE oi.productVariant.product.id = :productId " +
-      "AND o.orderStatus IN :statuses")
-  boolean existsActiveOrderByProductId(
-      @Param("productId") Long productId,
-      @Param("statuses") List<OrderStatus> statuses
+  boolean existsByProductVariant_Product_IdAndOrder_OrderStatusIn(
+      Long productId,
+      List<OrderStatus> statuses
   );
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/controller/ProductController.java
@@ -12,10 +12,14 @@ import com.example.WonkaoTalk.domain.product.dto.ProductListRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductListResponse;
 import com.example.WonkaoTalk.domain.product.dto.ProductUpdateRequest;
 import com.example.WonkaoTalk.domain.product.dto.ProductUpdateResponse;
+import com.example.WonkaoTalk.domain.product.dto.StockAdjustRequest;
+import com.example.WonkaoTalk.domain.product.dto.StockAdjustResponse;
 import com.example.WonkaoTalk.domain.product.service.CategoryService;
 import com.example.WonkaoTalk.domain.product.service.ProductCreateService;
+import com.example.WonkaoTalk.domain.product.service.ProductDeleteService;
 import com.example.WonkaoTalk.domain.product.service.ProductService;
 import com.example.WonkaoTalk.domain.product.service.ProductUpdateService;
+import com.example.WonkaoTalk.domain.product.service.StockAdjustService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -43,6 +48,8 @@ public class ProductController {
   private final ProductService productService;
   private final ProductCreateService productCreateService;
   private final ProductUpdateService productUpdateService;
+  private final ProductDeleteService productDeleteService;
+  private final StockAdjustService stockAdjustService;
   private final CategoryService categoryService;
 
   @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
@@ -93,6 +100,29 @@ public class ProductController {
     ProductUpdateResponse response = productUpdateService.update(
         userDetails.getAuthId(), productId, request);
     return ResponseEntity.ok(ApiResponse.success("상품 정보가 수정되었습니다", response));
+  }
+
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
+  @Operation(summary = "상품 삭제", description = "판매자가 자신의 상품을 소프트 삭제합니다. 진행 중인 주문이 있으면 삭제할 수 없습니다.")
+  @DeleteMapping("/{productId}")
+  public ResponseEntity<ApiResponse<Void>> deleteProduct(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long productId) {
+    productDeleteService.delete(userDetails.getAuthId(), productId);
+    return ResponseEntity.ok(ApiResponse.success("상품이 삭제되었습니다", null));
+  }
+
+  @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)
+  @Operation(summary = "재고 조정", description = "판매자가 특정 상품 옵션(variant)의 재고를 조정합니다.")
+  @PatchMapping("/{productId}/variants/{variantId}/stock")
+  public ResponseEntity<ApiResponse<StockAdjustResponse>> adjustStock(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long productId,
+      @PathVariable Long variantId,
+      @Valid @RequestBody StockAdjustRequest request) {
+    StockAdjustResponse response = stockAdjustService.adjust(
+        userDetails.getAuthId(), productId, variantId, request);
+    return ResponseEntity.ok(ApiResponse.success("재고가 조정되었습니다", response));
   }
 
   @Operation(summary = "카테고리 조회", description = "상품 등록과 검색에 사용할 카테고리 트리를 조회합니다.")

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/StockAdjustRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/StockAdjustRequest.java
@@ -1,0 +1,15 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
+import jakarta.validation.constraints.NotNull;
+
+public record StockAdjustRequest(
+
+    @NotNull
+    Integer changeAmount,
+
+    @NotNull
+    StockChangeReason reason
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/dto/StockAdjustResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/dto/StockAdjustResponse.java
@@ -1,0 +1,16 @@
+package com.example.WonkaoTalk.domain.product.dto;
+
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
+import lombok.Builder;
+
+@Builder
+public record StockAdjustResponse(
+    Long variantId,
+    String variantName,
+    int stockBefore,
+    int changeAmount,
+    int stockAfter,
+    StockChangeReason reason
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/Product.java
@@ -97,6 +97,11 @@ public class Product {
     if (status != null) this.status = status;
   }
 
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+    this.status = SaleStatus.STOP_SALE;
+  }
+
   public boolean isOnSale() {
     return this.deletedAt == null && this.status == SaleStatus.ON_SALE;
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -62,6 +62,16 @@ public class ProductVariant {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  public void adjustStock(int changeAmount) {
+    this.stock += changeAmount;
+    if (this.stock == 0 && this.status == SaleStatus.ON_SALE) {
+      this.status = SaleStatus.OUT_OF_STOCK;
+    } else if (this.stock > 0 && this.status == SaleStatus.OUT_OF_STOCK
+        && this.product.getStatus() != SaleStatus.STOP_SALE) {
+      this.status = SaleStatus.ON_SALE;
+    }
+  }
+
   public boolean isSellable() {
     return this.deletedAt == null && this.product.isOnSale() && this.status == SaleStatus.ON_SALE;
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/entity/ProductVariant.java
@@ -63,6 +63,9 @@ public class ProductVariant {
   private LocalDateTime deletedAt;
 
   public void adjustStock(int changeAmount) {
+    if (this.stock + changeAmount < 0) {
+      throw new IllegalArgumentException("재고는 0 미만이 될 수 없습니다.");
+    }
     this.stock += changeAmount;
     if (this.stock == 0 && this.status == SaleStatus.ON_SALE) {
       this.status = SaleStatus.OUT_OF_STOCK;

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepo.java
@@ -1,8 +1,16 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.Product;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepo extends JpaRepository<Product, Long>, ProductRepoCustom {
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT p FROM Product p WHERE p.id = :id")
+  Optional<Product> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductVariantRepo.java
@@ -2,8 +2,11 @@ package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,10 +15,20 @@ public interface ProductVariantRepo extends JpaRepository<ProductVariant, Long> 
 
   List<ProductVariant> findByProductId(Long productId);
 
+  Optional<ProductVariant> findByIdAndProductId(Long id, Long productId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT pv FROM ProductVariant pv WHERE pv.id = :id AND pv.product.id = :productId")
+  Optional<ProductVariant> findByIdAndProductIdWithLock(
+      @Param("id") Long id,
+      @Param("productId") Long productId
+  );
+
   @Modifying(clearAutomatically = true)
   @Query("UPDATE ProductVariant pv " +
       "SET pv.stock = pv.stock - :quantity, " +
-      "pv.status = CASE WHEN (pv.stock - :quantity) = 0 AND pv.status = :onSale THEN :outOfStock ELSE pv.status END " +
+      "pv.status = CASE WHEN (pv.stock - :quantity) = 0 AND pv.status = :onSale THEN :outOfStock ELSE pv.status END "
+      +
       "WHERE pv.id = :id AND pv.stock >= :quantity")
   int decreaseStock(
       @Param("id") Long id,

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteService.java
@@ -1,0 +1,60 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDeleteService {
+
+  private static final List<OrderStatus> ACTIVE_STATUSES =
+      List.of(OrderStatus.CREATED, OrderStatus.PAYMENT_PENDING, OrderStatus.PAID);
+
+  private final SellerRepo sellerRepo;
+  private final StoreRepo storeRepo;
+  private final ProductRepo productRepo;
+  private final OrderItemRepo orderItemRepo;
+
+  @Transactional
+  public void delete(Long authId, Long productId) {
+    Store store = resolveStore(authId);
+    Product product = findOwnProduct(productId, store);
+
+    if (orderItemRepo.existsActiveOrderByProductId(productId, ACTIVE_STATUSES)) {
+      throw new BusinessException(ErrorCode.PROD_HAS_ACTIVE_ORDER);
+    }
+
+    product.softDelete();
+  }
+
+  private Store resolveStore(Long authId) {
+    Seller seller = sellerRepo.findByAuthId(authId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+    return storeRepo.findBySeller(seller)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_STORE_NOT_FOUND));
+  }
+
+  private Product findOwnProduct(Long productId, Store store) {
+    Product product = productRepo.findByIdWithLock(productId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_NOT_FOUND));
+    if (product.getDeletedAt() != null) {
+      throw new BusinessException(ErrorCode.PROD_DELETED);
+    }
+    if (!product.getStore().getId().equals(store.getId())) {
+      throw new BusinessException(ErrorCode.FORBIDDEN);
+    }
+    return product;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteService.java
@@ -32,7 +32,7 @@ public class ProductDeleteService {
     Store store = resolveStore(authId);
     Product product = findOwnProduct(productId, store);
 
-    if (orderItemRepo.existsActiveOrderByProductId(productId, ACTIVE_STATUSES)) {
+    if (orderItemRepo.existsByProductVariant_Product_IdAndOrder_OrderStatusIn(productId, ACTIVE_STATUSES)) {
       throw new BusinessException(ErrorCode.PROD_HAS_ACTIVE_ORDER);
     }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/StockAdjustService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/StockAdjustService.java
@@ -79,7 +79,7 @@ public class StockAdjustService {
   }
 
   private Product findOwnProduct(Long productId, Store store) {
-    Product product = productRepo.findById(productId)
+    Product product = productRepo.findByIdWithLock(productId)
         .orElseThrow(() -> new BusinessException(ErrorCode.PROD_NOT_FOUND));
     if (product.getDeletedAt() != null) {
       throw new BusinessException(ErrorCode.PROD_DELETED);

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/StockAdjustService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/StockAdjustService.java
@@ -1,0 +1,92 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.product.dto.StockAdjustRequest;
+import com.example.WonkaoTalk.domain.product.dto.StockAdjustResponse;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.StockHistory;
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.product.repo.StockHistoryRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StockAdjustService {
+
+  private static final Set<StockChangeReason> ALLOWED_REASONS =
+      Set.of(StockChangeReason.RESTOCK, StockChangeReason.ADJUSTMENT);
+
+  private final SellerRepo sellerRepo;
+  private final StoreRepo storeRepo;
+  private final ProductRepo productRepo;
+  private final ProductVariantRepo productVariantRepo;
+  private final StockHistoryRepo stockHistoryRepo;
+
+  @Transactional
+  public StockAdjustResponse adjust(Long authId, Long productId, Long variantId,
+      StockAdjustRequest request) {
+    validateRequest(request);
+
+    Store store = resolveStore(authId);
+    Product product = findOwnProduct(productId, store);
+    ProductVariant variant = productVariantRepo.findByIdAndProductIdWithLock(variantId, productId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_VARIANT_NOT_FOUND));
+
+    int stockBefore = variant.getStock();
+    int newStock = stockBefore + request.changeAmount();
+    if (newStock < 0) {
+      throw new BusinessException(ErrorCode.PROD_STOCK_INSUFFICIENT);
+    }
+
+    variant.adjustStock(request.changeAmount());
+    stockHistoryRepo.save(StockHistory.of(variant, null, request.changeAmount(), stockBefore, request.reason()));
+
+    return StockAdjustResponse.builder()
+        .variantId(variant.getId())
+        .variantName(variant.getName())
+        .stockBefore(stockBefore)
+        .changeAmount(request.changeAmount())
+        .stockAfter(variant.getStock())
+        .reason(request.reason())
+        .build();
+  }
+
+  private void validateRequest(StockAdjustRequest request) {
+    if (request.changeAmount() == 0) {
+      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    }
+    if (!ALLOWED_REASONS.contains(request.reason())) {
+      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    }
+  }
+
+  private Store resolveStore(Long authId) {
+    Seller seller = sellerRepo.findByAuthId(authId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SELLER_NOT_FOUND));
+    return storeRepo.findBySeller(seller)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_STORE_NOT_FOUND));
+  }
+
+  private Product findOwnProduct(Long productId, Store store) {
+    Product product = productRepo.findById(productId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.PROD_NOT_FOUND));
+    if (product.getDeletedAt() != null) {
+      throw new BusinessException(ErrorCode.PROD_DELETED);
+    }
+    if (!product.getStore().getId().equals(store.getId())) {
+      throw new BusinessException(ErrorCode.FORBIDDEN);
+    }
+    return product;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteServiceTest.java
@@ -1,0 +1,178 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductDeleteServiceTest {
+
+  private static final Long AUTH_ID = 1L;
+  private static final Long PRODUCT_ID = 101L;
+  private static final Long STORE_ID = 7L;
+
+  @Mock private SellerRepo sellerRepo;
+  @Mock private StoreRepo storeRepo;
+  @Mock private ProductRepo productRepo;
+  @Mock private OrderItemRepo orderItemRepo;
+
+  @InjectMocks private ProductDeleteService productDeleteService;
+
+  private Store store;
+  private Product product;
+
+  @BeforeEach
+  void setUp() {
+    Seller seller = mock(Seller.class);
+    store = mock(Store.class);
+    product = mock(Product.class);
+
+    when(store.getId()).thenReturn(STORE_ID);
+    when(sellerRepo.findByAuthId(AUTH_ID)).thenReturn(Optional.of(seller));
+    when(storeRepo.findBySeller(seller)).thenReturn(Optional.of(store));
+    when(productRepo.findByIdWithLock(PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(product.getStore()).thenReturn(store);
+    when(product.getDeletedAt()).thenReturn(null);
+    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(false);
+  }
+
+  // ── 인증/권한 실패 ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("판매자를 찾을 수 없으면 SELLER_NOT_FOUND를 던진다")
+  void delete_throwsException_whenSellerNotFound() {
+    when(sellerRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("스토어를 찾을 수 없으면 PROD_STORE_NOT_FOUND를 던진다")
+  void delete_throwsException_whenStoreNotFound() {
+    when(storeRepo.findBySeller(any())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STORE_NOT_FOUND);
+  }
+
+  // ── 상품 조회 실패 ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("상품을 찾을 수 없으면 PROD_NOT_FOUND를 던진다")
+  void delete_throwsException_whenProductNotFound() {
+    when(productRepo.findByIdWithLock(PRODUCT_ID)).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("이미 삭제된 상품이면 PROD_DELETED를 던진다")
+  void delete_throwsException_whenProductAlreadyDeleted() {
+    when(product.getDeletedAt()).thenReturn(LocalDateTime.now());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DELETED);
+  }
+
+  @Test
+  @DisplayName("다른 판매자의 상품이면 FORBIDDEN을 던진다")
+  void delete_throwsException_whenProductBelongsToOtherStore() {
+    Store otherStore = mock(Store.class);
+    when(otherStore.getId()).thenReturn(999L);
+    when(product.getStore()).thenReturn(otherStore);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
+  }
+
+  // ── 주문 검증 실패 ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("진행 중인 주문이 있으면 PROD_HAS_ACTIVE_ORDER를 던진다")
+  void delete_throwsException_whenActiveOrderExists() {
+    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(true);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_HAS_ACTIVE_ORDER);
+  }
+
+  // ── 성공 ──────────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("정상 삭제 시 상품의 softDelete가 호출된다")
+  void delete_callsSoftDelete_onSuccess() {
+    productDeleteService.delete(AUTH_ID, PRODUCT_ID);
+
+    verify(product).softDelete();
+  }
+
+  @Test
+  @DisplayName("진행 중 주문 상태 3개(CREATED, PAYMENT_PENDING, PAID)를 검증 대상으로 사용한다")
+  void delete_checksThreeActiveOrderStatuses() {
+    productDeleteService.delete(AUTH_ID, PRODUCT_ID);
+
+    verify(orderItemRepo).existsActiveOrderByProductId(eq(PRODUCT_ID), any());
+  }
+
+  @Test
+  @DisplayName("진행 중인 주문이 없으면 softDelete를 호출한다")
+  void delete_proceedsToSoftDelete_whenNoActiveOrders() {
+    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(false);
+
+    productDeleteService.delete(AUTH_ID, PRODUCT_ID);
+
+    verify(product).softDelete();
+  }
+
+  @Test
+  @DisplayName("진행 중인 주문이 있으면 softDelete를 호출하지 않는다")
+  void delete_doesNotCallSoftDelete_whenActiveOrderExists() {
+    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(true);
+
+    assertThrows(BusinessException.class, () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
+
+    verify(product, never()).softDelete();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteServiceTest.java
@@ -61,7 +61,7 @@ class ProductDeleteServiceTest {
     when(productRepo.findByIdWithLock(PRODUCT_ID)).thenReturn(Optional.of(product));
     when(product.getStore()).thenReturn(store);
     when(product.getDeletedAt()).thenReturn(null);
-    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(false);
+    when(orderItemRepo.existsByProductVariant_Product_IdAndOrder_OrderStatusIn(eq(PRODUCT_ID), any())).thenReturn(false);
   }
 
   // ── 인증/권한 실패 ────────────────────────────────────────────────────────────
@@ -130,7 +130,7 @@ class ProductDeleteServiceTest {
   @Test
   @DisplayName("진행 중인 주문이 있으면 PROD_HAS_ACTIVE_ORDER를 던진다")
   void delete_throwsException_whenActiveOrderExists() {
-    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(true);
+    when(orderItemRepo.existsByProductVariant_Product_IdAndOrder_OrderStatusIn(eq(PRODUCT_ID), any())).thenReturn(true);
 
     BusinessException ex = assertThrows(BusinessException.class,
         () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
@@ -153,13 +153,13 @@ class ProductDeleteServiceTest {
   void delete_checksThreeActiveOrderStatuses() {
     productDeleteService.delete(AUTH_ID, PRODUCT_ID);
 
-    verify(orderItemRepo).existsActiveOrderByProductId(eq(PRODUCT_ID), any());
+    verify(orderItemRepo).existsByProductVariant_Product_IdAndOrder_OrderStatusIn(eq(PRODUCT_ID), any());
   }
 
   @Test
   @DisplayName("진행 중인 주문이 없으면 softDelete를 호출한다")
   void delete_proceedsToSoftDelete_whenNoActiveOrders() {
-    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(false);
+    when(orderItemRepo.existsByProductVariant_Product_IdAndOrder_OrderStatusIn(eq(PRODUCT_ID), any())).thenReturn(false);
 
     productDeleteService.delete(AUTH_ID, PRODUCT_ID);
 
@@ -169,7 +169,7 @@ class ProductDeleteServiceTest {
   @Test
   @DisplayName("진행 중인 주문이 있으면 softDelete를 호출하지 않는다")
   void delete_doesNotCallSoftDelete_whenActiveOrderExists() {
-    when(orderItemRepo.existsActiveOrderByProductId(eq(PRODUCT_ID), any())).thenReturn(true);
+    when(orderItemRepo.existsByProductVariant_Product_IdAndOrder_OrderStatusIn(eq(PRODUCT_ID), any())).thenReturn(true);
 
     assertThrows(BusinessException.class, () -> productDeleteService.delete(AUTH_ID, PRODUCT_ID));
 

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/StockAdjustServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/StockAdjustServiceTest.java
@@ -1,0 +1,377 @@
+package com.example.WonkaoTalk.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.product.dto.StockAdjustRequest;
+import com.example.WonkaoTalk.domain.product.dto.StockAdjustResponse;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.entity.StockHistory;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
+import com.example.WonkaoTalk.domain.product.repo.StockHistoryRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StockAdjustServiceTest {
+
+  private static final Long AUTH_ID = 1L;
+  private static final Long PRODUCT_ID = 101L;
+  private static final Long VARIANT_ID = 12L;
+  private static final Long STORE_ID = 7L;
+
+  @Mock private SellerRepo sellerRepo;
+  @Mock private StoreRepo storeRepo;
+  @Mock private ProductRepo productRepo;
+  @Mock private ProductVariantRepo productVariantRepo;
+  @Mock private StockHistoryRepo stockHistoryRepo;
+
+  @InjectMocks private StockAdjustService stockAdjustService;
+
+  private Store store;
+  private Product product;
+
+  @BeforeEach
+  void setUp() {
+    Seller seller = mock(Seller.class);
+    store = mock(Store.class);
+    product = mock(Product.class);
+
+    when(store.getId()).thenReturn(STORE_ID);
+    when(sellerRepo.findByAuthId(AUTH_ID)).thenReturn(Optional.of(seller));
+    when(storeRepo.findBySeller(seller)).thenReturn(Optional.of(store));
+    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(product.getStore()).thenReturn(store);
+    when(product.getDeletedAt()).thenReturn(null);
+    when(stockHistoryRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+  }
+
+  // ── 입력값 검증 실패 ──────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("changeAmount가 0이면 BAD_REQUEST를 던진다")
+  void adjust_throwsException_whenChangeAmountIsZero() {
+    StockAdjustRequest request = new StockAdjustRequest(0, StockChangeReason.RESTOCK);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 reason(SALE)이면 BAD_REQUEST를 던진다")
+  void adjust_throwsException_whenReasonIsSale() {
+    StockAdjustRequest request = new StockAdjustRequest(10, StockChangeReason.SALE);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 reason(CANCEL)이면 BAD_REQUEST를 던진다")
+  void adjust_throwsException_whenReasonIsCancel() {
+    StockAdjustRequest request = new StockAdjustRequest(10, StockChangeReason.CANCEL);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 reason(INITIAL_STOCK)이면 BAD_REQUEST를 던진다")
+  void adjust_throwsException_whenReasonIsInitialStock() {
+    StockAdjustRequest request = new StockAdjustRequest(10, StockChangeReason.INITIAL_STOCK);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, request));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+  }
+
+  // ── 인증/권한 실패 ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("판매자를 찾을 수 없으면 SELLER_NOT_FOUND를 던진다")
+  void adjust_throwsException_whenSellerNotFound() {
+    when(sellerRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("스토어를 찾을 수 없으면 PROD_STORE_NOT_FOUND를 던진다")
+  void adjust_throwsException_whenStoreNotFound() {
+    when(storeRepo.findBySeller(any())).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STORE_NOT_FOUND);
+  }
+
+  // ── 상품 조회 실패 ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("상품을 찾을 수 없으면 PROD_NOT_FOUND를 던진다")
+  void adjust_throwsException_whenProductNotFound() {
+    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("삭제된 상품이면 PROD_DELETED를 던진다")
+  void adjust_throwsException_whenProductIsDeleted() {
+    when(product.getDeletedAt()).thenReturn(LocalDateTime.now());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_DELETED);
+  }
+
+  @Test
+  @DisplayName("다른 판매자의 상품이면 FORBIDDEN을 던진다")
+  void adjust_throwsException_whenProductBelongsToOtherStore() {
+    Store otherStore = mock(Store.class);
+    when(otherStore.getId()).thenReturn(999L);
+    when(product.getStore()).thenReturn(otherStore);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
+  }
+
+  // ── variant 조회 실패 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("variant를 찾을 수 없으면 PROD_VARIANT_NOT_FOUND를 던진다")
+  void adjust_throwsException_whenVariantNotFound() {
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.empty());
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_VARIANT_NOT_FOUND);
+  }
+
+  // ── 재고 검증 실패 ─────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("차감 결과 재고가 0 미만이 되면 PROD_STOCK_INSUFFICIENT를 던진다")
+  void adjust_throwsException_whenStockBecomesNegative() {
+    ProductVariant variant = buildVariant(5, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID,
+            new StockAdjustRequest(-6, StockChangeReason.ADJUSTMENT)));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
+  }
+
+  // ── 성공 — 응답 값 ────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("입고 성공 시 응답에 stockBefore, changeAmount, stockAfter가 올바르게 담긴다")
+  void adjust_returnsCorrectStockValues_onRestock() {
+    ProductVariant variant = buildVariant(30, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    StockAdjustResponse response = stockAdjustService.adjust(
+        AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(50));
+
+    assertThat(response.stockBefore()).isEqualTo(30);
+    assertThat(response.changeAmount()).isEqualTo(50);
+    assertThat(response.stockAfter()).isEqualTo(80);
+    assertThat(response.reason()).isEqualTo(StockChangeReason.RESTOCK);
+  }
+
+  @Test
+  @DisplayName("차감 성공 시 응답에 stockBefore, changeAmount, stockAfter가 올바르게 담긴다")
+  void adjust_returnsCorrectStockValues_onAdjustment() {
+    ProductVariant variant = buildVariant(30, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    StockAdjustResponse response = stockAdjustService.adjust(
+        AUTH_ID, PRODUCT_ID, VARIANT_ID,
+        new StockAdjustRequest(-5, StockChangeReason.ADJUSTMENT));
+
+    assertThat(response.stockBefore()).isEqualTo(30);
+    assertThat(response.changeAmount()).isEqualTo(-5);
+    assertThat(response.stockAfter()).isEqualTo(25);
+  }
+
+  @Test
+  @DisplayName("차감 결과 재고가 정확히 0이 되면 성공한다")
+  void adjust_succeedsWhenStockBecomesExactlyZero() {
+    ProductVariant variant = buildVariant(5, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    StockAdjustResponse response = stockAdjustService.adjust(
+        AUTH_ID, PRODUCT_ID, VARIANT_ID,
+        new StockAdjustRequest(-5, StockChangeReason.ADJUSTMENT));
+
+    assertThat(response.stockAfter()).isEqualTo(0);
+  }
+
+  // ── 성공 — variant 상태 변경 ─────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("차감 결과 재고가 0이 되면 variant status가 OUT_OF_STOCK으로 변경된다")
+  void adjust_changesVariantStatusToOutOfStock_whenStockBecomesZero() {
+    ProductVariant variant = buildVariant(5, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID,
+        new StockAdjustRequest(-5, StockChangeReason.ADJUSTMENT));
+
+    assertThat(variant.getStatus()).isEqualTo(SaleStatus.OUT_OF_STOCK);
+  }
+
+  @Test
+  @DisplayName("입고 결과 OUT_OF_STOCK이던 variant의 재고가 1 이상이 되면 ON_SALE로 복구된다")
+  void adjust_restoresVariantStatusToOnSale_whenStockIncreasesFromZero() {
+    ProductVariant variant = buildVariant(0, SaleStatus.OUT_OF_STOCK, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10));
+
+    assertThat(variant.getStatus()).isEqualTo(SaleStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("상품이 STOP_SALE이면 입고 후에도 variant status가 OUT_OF_STOCK으로 유지된다")
+  void adjust_doesNotRestoreVariantStatus_whenProductIsStopSale() {
+    ProductVariant variant = buildVariant(0, SaleStatus.OUT_OF_STOCK, SaleStatus.STOP_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10));
+
+    assertThat(variant.getStatus()).isEqualTo(SaleStatus.OUT_OF_STOCK);
+  }
+
+  // ── 성공 — 재고 이력 ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("재고 조정 성공 시 stock_histories에 이력이 저장된다")
+  void adjust_savesStockHistory_onSuccess() {
+    ProductVariant variant = buildVariant(30, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(50));
+
+    verify(stockHistoryRepo).save(any(StockHistory.class));
+  }
+
+  @Test
+  @DisplayName("저장되는 이력에 변경 전 재고, 변경량, 사유가 올바르게 기록된다")
+  void adjust_savesStockHistoryWithCorrectValues() {
+    ProductVariant variant = buildVariant(30, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(50));
+
+    ArgumentCaptor<StockHistory> captor = ArgumentCaptor.forClass(StockHistory.class);
+    verify(stockHistoryRepo).save(captor.capture());
+    StockHistory saved = captor.getValue();
+    assertThat(saved.getStockBefore()).isEqualTo(30);
+    assertThat(saved.getChangeAmount()).isEqualTo(50);
+    assertThat(saved.getStockAfter()).isEqualTo(80);
+    assertThat(saved.getReason()).isEqualTo(StockChangeReason.RESTOCK);
+  }
+
+  @Test
+  @DisplayName("판매자가 직접 조정한 이력의 order_id는 null이다")
+  void adjust_savesStockHistoryWithNullOrder() {
+    ProductVariant variant = buildVariant(30, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(50));
+
+    ArgumentCaptor<StockHistory> captor = ArgumentCaptor.forClass(StockHistory.class);
+    verify(stockHistoryRepo).save(captor.capture());
+    assertThat(captor.getValue().getOrder()).isNull();
+  }
+
+  @Test
+  @DisplayName("재고 부족이면 이력을 저장하지 않는다")
+  void adjust_doesNotSaveHistory_whenStockIsInsufficient() {
+    ProductVariant variant = buildVariant(3, SaleStatus.ON_SALE, SaleStatus.ON_SALE);
+    when(productVariantRepo.findByIdAndProductIdWithLock(VARIANT_ID, PRODUCT_ID))
+        .thenReturn(Optional.of(variant));
+
+    assertThrows(BusinessException.class, () -> stockAdjustService.adjust(
+        AUTH_ID, PRODUCT_ID, VARIANT_ID,
+        new StockAdjustRequest(-10, StockChangeReason.ADJUSTMENT)));
+
+    verify(stockHistoryRepo, never()).save(any());
+  }
+
+  // ── 헬퍼 ──────────────────────────────────────────────────────────────────────
+
+  private StockAdjustRequest restockRequest(int amount) {
+    return new StockAdjustRequest(amount, StockChangeReason.RESTOCK);
+  }
+
+  private ProductVariant buildVariant(int stock, SaleStatus variantStatus,
+      SaleStatus productStatus) {
+    Product variantProduct = mock(Product.class);
+    when(variantProduct.getStatus()).thenReturn(productStatus);
+    return ProductVariant.builder()
+        .product(variantProduct)
+        .stock(stock)
+        .name("화이트 / M")
+        .status(variantStatus)
+        .build();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/StockAdjustServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/StockAdjustServiceTest.java
@@ -67,7 +67,7 @@ class StockAdjustServiceTest {
     when(store.getId()).thenReturn(STORE_ID);
     when(sellerRepo.findByAuthId(AUTH_ID)).thenReturn(Optional.of(seller));
     when(storeRepo.findBySeller(seller)).thenReturn(Optional.of(store));
-    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(productRepo.findByIdWithLock(PRODUCT_ID)).thenReturn(Optional.of(product));
     when(product.getStore()).thenReturn(store);
     when(product.getDeletedAt()).thenReturn(null);
     when(stockHistoryRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -148,7 +148,7 @@ class StockAdjustServiceTest {
   @Test
   @DisplayName("상품을 찾을 수 없으면 PROD_NOT_FOUND를 던진다")
   void adjust_throwsException_whenProductNotFound() {
-    when(productRepo.findById(PRODUCT_ID)).thenReturn(Optional.empty());
+    when(productRepo.findByIdWithLock(PRODUCT_ID)).thenReturn(Optional.empty());
 
     BusinessException ex = assertThrows(BusinessException.class,
         () -> stockAdjustService.adjust(AUTH_ID, PRODUCT_ID, VARIANT_ID, restockRequest(10)));


### PR DESCRIPTION
## 📌 관련 이슈
- #107 

## 📝 작업 내용
- 상품 재고 수정 API를 만들었습니다.
- 상품 삭제 API를 만들었습니다.

## ✅ 작업 결과 
- 테스트 결과
<img width="835" height="281" alt="스크린샷 2026-05-26 오전 10 22 27" src="https://github.com/user-attachments/assets/15876631-4e36-4351-add4-caaef965b98e" />
<img width="835" height="281" alt="스크린샷 2026-05-26 오전 10 22 18" src="https://github.com/user-attachments/assets/e4e81ccc-bfdd-4d96-8956-67f6a78d7bba" />


## 🎸 기타
- 상품 삭제는 'Product의 deletedAt'에 시간을 기록합니다. Variant에도 deletedAt이 존재하긴 하는데, 현재는 어디에도 쓰이지 않고 있긴 합니다.
- 기존에 원자적 방식을 사용하는 메소드를 만들어 놨는데, 이력을 기록하려면 '기존 재고'정보가 필요해서 비관적 락을 거는 방식으로 처리했습니다. 애써 만들었는데 쓸 수가 없었네요
- 진행중인 주문이 있는 경우에는 상품을 삭제할 수 없습니다.
