### PR TITLE
feat: 주문 조회 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
 
   // 주문 도메인
   ORDER_NOT_FOUND(404, "ORDER-NOT-FOUND", "주문을 찾을 수 없습니다."),
+  ORDER_ITEM_NOT_FOUND(404, "ORDER-ITEM_NOT-FOUND", "주문 상품을 찾을 수 없습니다."),
 
   // 결제 도메인
   PAYMENT_NOT_FOUND(404, "PAYMENT-NOT-FOUND", "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/ErrorCode.java
@@ -77,7 +77,7 @@ public enum ErrorCode {
 
   // 주문 도메인
   ORDER_NOT_FOUND(404, "ORDER-NOT-FOUND", "주문을 찾을 수 없습니다."),
-  ORDER_ITEM_NOT_FOUND(404, "ORDER-ITEM_NOT-FOUND", "주문 상품을 찾을 수 없습니다."),
+  ORDER_ITEM_NOT_FOUND(404, "ORDER-ITEM-NOT-FOUND", "주문 상품을 찾을 수 없습니다."),
 
   // 결제 도메인
   PAYMENT_NOT_FOUND(404, "PAYMENT-NOT-FOUND", "결제 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/controller/OrderController.java
@@ -4,14 +4,22 @@ import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderDetailResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderListResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.service.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,5 +48,38 @@ public class OrderController {
   ) {
     OrderPreviewResponse responseDto = orderService.previewOrder(requestDto);
     return ResponseEntity.ok(ApiResponse.success("주문 미리보기가 생성되었습니다.", responseDto));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<OrderListResponse>> getOrderList(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+  ) {
+    OrderListResponse orderListResponse = orderService.getOrders(userDetails.getUserId(), pageable);
+
+    return ResponseEntity.ok(ApiResponse.success("주문 리스트 조회가 완료되었습니다.", orderListResponse));
+  }
+
+  @GetMapping("/{orderId}")
+  public ResponseEntity<ApiResponse<OrderDetailResponse>> getOrderDetail(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long orderId
+  ) {
+    OrderDetailResponse orderDetailResponse = orderService.getOrderDetail(
+        userDetails.getUserId(),
+        orderId
+    );
+
+    return ResponseEntity.ok(ApiResponse.success("주문 상세 조회가 완료되었습니다.", orderDetailResponse));
+  }
+
+  @DeleteMapping("/{orderId}")
+  public ResponseEntity<ApiResponse<Void>> deleteOrder(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long orderId
+  ) {
+    orderService.deleteOrder(userDetails.getUserId(), orderId);
+
+    return ResponseEntity.ok(ApiResponse.success("주문 삭제가 완료되었습니다.", null));
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderCreateResponse.java
@@ -1,21 +1,9 @@
 package com.example.WonkaoTalk.domain.order.dto;
 
 public record OrderCreateResponse(
-    OrderCreateInfoDto orderInfo,
+    OrderInfoDto orderInfo,
     PaymentCreateInfoDto paymentInfo
 ) {
-
-  public record OrderCreateInfoDto(
-      Long orderId,
-      String orderNumber,
-      String orderTitle,
-      Long originalAmount,
-      Long discountAmount,
-      Long pointUsedAmount,
-      Long finalAmount
-  ) {
-
-  }
 
   // Toss에 요청할때 사용할 정보 따로 뻄. (front에서 처리하기 쉽게하려고..)
   public record PaymentCreateInfoDto(

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderDetailResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderDetailResponse.java
@@ -1,0 +1,41 @@
+package com.example.WonkaoTalk.domain.order.dto;
+
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
+import com.example.WonkaoTalk.domain.payment.entity.PgProvider;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderDetailResponse(
+    // 주문정보
+    OrderInfoDto orderInfo,
+    // 상품정보
+    List<OrderItemInfoDto> orderItemInfoList,
+    // 결제정보
+    List<PaymentInfoDto> paymentInfo
+
+) {
+
+  public record PaymentInfoDto(
+      Long paymentId,
+      PaymentStatus status,
+      PgProvider pgProvider,
+      Long totalAmount,
+      LocalDateTime requestedAt,
+      LocalDateTime approvedAt
+  ) {
+
+    public static PaymentInfoDto from(Payment payment) {
+      return new PaymentInfoDto(
+          payment.getPaymentId(),
+          payment.getStatus(),
+          payment.getPgProvider(),
+          payment.getTotalAmount(),
+          payment.getRequestedAt(),
+          payment.getApprovedAt()
+      );
+    }
+
+  }
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderInfoDto.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderInfoDto.java
@@ -1,0 +1,26 @@
+package com.example.WonkaoTalk.domain.order.dto;
+
+import com.example.WonkaoTalk.domain.order.entity.Order;
+
+public record OrderInfoDto(
+    Long orderId,
+    String orderNumber,
+    String orderTitle,
+    Long originalAmount,
+    Long discountAmount,
+    Long pointUsedAmount,
+    Long finalAmount
+) {
+
+  public static OrderInfoDto from(Order order) {
+    return new OrderInfoDto(
+        order.getOrderId(),
+        order.getOrderNumber(),
+        order.getOrderTitle(),
+        order.getOriginalAmount(),
+        order.getDiscountAmount(),
+        order.getPointUsedAmount(),
+        order.getFinalAmount()
+    );
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderItemInfoDto.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderItemInfoDto.java
@@ -1,0 +1,22 @@
+package com.example.WonkaoTalk.domain.order.dto;
+
+import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+
+public record OrderItemInfoDto(
+    String productName,
+    String optionSummary,
+    Long productAmount,
+    int quantity
+    // TODO: 썸네일도 추가해야함. OrderItem에 썸네일 스냅샷 추가 후 변경 예정
+) {
+
+  public static OrderItemInfoDto from(OrderItem orderItem) {
+    return new OrderItemInfoDto(
+        orderItem.getProductName(),
+        orderItem.getOptionSummary(),
+        orderItem.getProductAmount(),
+        orderItem.getQuantity()
+    );
+  }
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderListResponse.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/OrderListResponse.java
@@ -1,0 +1,22 @@
+package com.example.WonkaoTalk.domain.order.dto;
+
+import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderListResponse(
+    List<OrderSummaryDto> orders,
+    PageInfoDto pageInfo
+) {
+
+  public record OrderSummaryDto(
+      Long orderId,
+      String orderNumber,
+      String orderTitle,
+      OrderStatus orderStatus,
+      Long finalAmount,
+      LocalDateTime createdAt
+  ) {
+
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/order/dto/PageInfoDto.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/dto/PageInfoDto.java
@@ -1,0 +1,23 @@
+package com.example.WonkaoTalk.domain.order.dto;
+
+import org.springframework.data.domain.Page;
+
+public record PageInfoDto(
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+
+  public static PageInfoDto from(Page<?> page) {
+    return new PageInfoDto(
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.hasNext()
+    );
+  }
+}
+

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
@@ -17,6 +17,8 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -24,6 +26,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "orders")
+@SQLDelete(sql = "UPDATE orders SET deleted_at = NOW() WHERE order_id = ?")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
@@ -67,6 +71,9 @@ public class Order {
   @Column(name = "title", nullable = false)
   // 주문 명 (xx외 2건)
   private String orderTitle;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
 
   private Order(String orderNumber, User user, OrderStatus orderStatus,
       Long originalAmount, Long discountAmount, Long pointUsedAmount, Long finalAmount,
@@ -116,5 +123,9 @@ public class Order {
 
   public void markPaymentCanceled() {
     this.orderStatus = OrderStatus.PAYMENT_CANCELED;
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/entity/Order.java
@@ -124,8 +124,4 @@ public class Order {
   public void markPaymentCanceled() {
     this.orderStatus = OrderStatus.PAYMENT_CANCELED;
   }
-
-  public void softDelete() {
-    this.deletedAt = LocalDateTime.now();
-  }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/repo/OrderRepo.java
@@ -1,9 +1,16 @@
 package com.example.WonkaoTalk.domain.order.repo;
 
 import com.example.WonkaoTalk.domain.order.entity.Order;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepo extends JpaRepository<Order, Long> {
 
   boolean existsByOrderNumber(String orderNumber);
+
+  Page<Order> findByUserId(Long userId, Pageable pageable);
+
+  Optional<Order> findByUserIdAndOrderId(Long userId, Long orderId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -215,9 +215,7 @@ public class OrderService {
 
     List<OrderItem> orderItems = orderItemRepo.findByOrder(order);
 
-    List<Payment> payments = paymentRepo.findByOrder_OrderIdAndOrder_User_IdOrderByCreatedAtDesc(
-        orderId,
-        userId);
+    List<Payment> payments = paymentRepo.findByOrder_OrderIdOrderByCreatedAtDesc(orderId);
 
     if (orderItems.isEmpty()) {
       throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -235,7 +235,7 @@ public class OrderService {
     Order order = orderRepo.findByUserIdAndOrderId(userId, orderId)
         .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-    order.softDelete();
+    orderRepo.delete(order);
   }
 
   // 옵션 중복 검증 메서드

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -191,8 +191,6 @@ public class OrderService {
   // 주문 목록 가지고 오는 메서드
   @Transactional(readOnly = true)
   public OrderListResponse getOrders(Long userId, Pageable pageable) {
-    User user = userRepo.findById(userId)
-        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
     Page<Order> orderPage = orderRepo.findByUserId(userId, pageable);
 
     // 조회 한 오더 정보를 pageInfo와 Summary로 만들어서 OrderListResponse로 만들어야함

--- a/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/order/service/OrderService.java
@@ -5,11 +5,18 @@ import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest.DeliveryRequestDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderDetailResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderDetailResponse.PaymentInfoDto;
+import com.example.WonkaoTalk.domain.order.dto.OrderInfoDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderItemDto;
+import com.example.WonkaoTalk.domain.order.dto.OrderItemInfoDto;
+import com.example.WonkaoTalk.domain.order.dto.OrderListResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderListResponse.OrderSummaryDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.OrderPreviewItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse.SummaryDto;
+import com.example.WonkaoTalk.domain.order.dto.PageInfoDto;
 import com.example.WonkaoTalk.domain.order.entity.Delivery;
 import com.example.WonkaoTalk.domain.order.entity.Order;
 import com.example.WonkaoTalk.domain.order.entity.OrderItem;
@@ -17,6 +24,7 @@ import com.example.WonkaoTalk.domain.order.repo.DeliveryRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
 import com.example.WonkaoTalk.domain.payment.service.PaymentService;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
@@ -34,6 +42,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +58,7 @@ public class OrderService {
   private final OrderRepo orderRepo;
   private final OrderItemRepo orderItemRepo;
   private final DeliveryRepo deliveryRepo;
+  private final PaymentRepo paymentRepo;
 
   private final PaymentService paymentService;
 
@@ -126,7 +137,7 @@ public class OrderService {
     // 13. 주문 생성 응답 반환
     // orderId, orderNumber, paymentId, tossOrderId, amount, orderName
     return new OrderCreateResponse(
-        new OrderCreateResponse.OrderCreateInfoDto(
+        new OrderInfoDto(
             savedOrder.getOrderId(),
             savedOrder.getOrderNumber(),
             savedOrder.getOrderTitle(),
@@ -175,6 +186,60 @@ public class OrderService {
 
     // 8. response dto 생성 및 return
     return new OrderPreviewResponse(orderPreviewItemDtos, summaryDto);
+  }
+
+  // 주문 목록 가지고 오는 메서드
+  @Transactional(readOnly = true)
+  public OrderListResponse getOrders(Long userId, Pageable pageable) {
+    User user = userRepo.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+    Page<Order> orderPage = orderRepo.findByUserId(userId, pageable);
+
+    // 조회 한 오더 정보를 pageInfo와 Summary로 만들어서 OrderListResponse로 만들어야함
+    // 먼저 summary 를 만들어야함
+    List<OrderSummaryDto> summaryDtos = orderPage.getContent().stream()
+        .map(order -> new OrderSummaryDto(order.getOrderId(), order.getOrderNumber(),
+            order.getOrderTitle(), order.getOrderStatus(), order.getFinalAmount(),
+            order.getCreatedAt()))
+        .toList();
+    // 그다음은 PageInfo인데 이건 어떻게만들지? from 만들어 놨잖아
+    return new OrderListResponse(
+        summaryDtos,
+        PageInfoDto.from(orderPage)
+    );
+  }
+
+  // 주문 상세정보 전달 메서드
+  @Transactional(readOnly = true)
+  public OrderDetailResponse getOrderDetail(Long userId, Long orderId) {
+    Order order = orderRepo.findByUserIdAndOrderId(userId, orderId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+    List<OrderItem> orderItems = orderItemRepo.findByOrder(order);
+
+    List<Payment> payments = paymentRepo.findByOrder_OrderIdAndOrder_User_IdOrderByCreatedAtDesc(
+        orderId,
+        userId);
+
+    if (orderItems.isEmpty()) {
+      throw new BusinessException(ErrorCode.ORDER_ITEM_NOT_FOUND);
+    }
+
+    return new OrderDetailResponse(
+        OrderInfoDto.from(order),
+        orderItems.stream().map(OrderItemInfoDto::from).toList(),
+        payments.stream().map(PaymentInfoDto::from).toList()
+    );
+
+  }
+
+  // 주문 정보 삭제 메서드
+  @Transactional
+  public void deleteOrder(Long userId, Long orderId) {
+    Order order = orderRepo.findByUserIdAndOrderId(userId, orderId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+    order.softDelete();
   }
 
   // 옵션 중복 검증 메서드

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
@@ -1,10 +1,13 @@
 package com.example.WonkaoTalk.domain.payment.repo;
 
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepo extends JpaRepository<Payment, Long> {
 
   Optional<Payment> findByTossOrderId(String tossOrderId);
+  
+  List<Payment> findByOrder_OrderIdAndOrder_User_IdOrderByCreatedAtDesc(Long orderId, Long userId);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/repo/PaymentRepo.java
@@ -9,5 +9,5 @@ public interface PaymentRepo extends JpaRepository<Payment, Long> {
 
   Optional<Payment> findByTossOrderId(String tossOrderId);
   
-  List<Payment> findByOrder_OrderIdAndOrder_User_IdOrderByCreatedAtDesc(Long orderId, Long userId);
+  List<Payment> findByOrder_OrderIdOrderByCreatedAtDesc(Long orderId);
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
@@ -222,4 +222,19 @@ public class OrderServiceTest {
     assertThat(savedDelivery.getOrder()).isNotNull();
   }
 
+  @Test
+  @DisplayName("주문 삭제 시 Repository delete를 호출한다.")
+  public void deleteOrder_CallsRepositoryDelete() {
+    // given
+    Order order = mock(Order.class);
+
+    when(orderRepo.findByUserIdAndOrderId(1L, 10L)).thenReturn(Optional.of(order));
+
+    // when
+    orderService.deleteOrder(1L, 10L);
+
+    // then
+    verify(orderRepo).delete(order);
+  }
+
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #94 

## 📝 작업 내용
- 주문 목록 조회 API에 Pageable 기반 페이지네이션을 적용
- 주문 상세 조회 API에서 주문 정보, 주문 상품 정보, 결제 이력을 함께 반환
- 주문 생성 응답의 주문 정보 DTO를 공통 OrderInfoDto로 분리
- Order deletedAt 기반 소프트 삭제를 적용하고 삭제된 주문을 기본 조회에서 제외
- DELETE /api/v1/orders/{orderId} API를 추가
- 주문 상세 조회를 위해 주문별 결제 이력 조회 메서드를 추가

## ✅ 작업 결과 
- 테스트는 이번에 시나리오 만들면서 다시 추가하겠습니다.

## 🎸 기타
- 