### PR TITLE
feat: Jacoco 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '4.0.6'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -83,4 +84,50 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+// ── JaCoCo ─────────────────────────────────────────────────────────────────
+
+jacoco {
+    toolVersion = '0.8.13'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+// Per-domain coverage reports
+def domains = [
+    'auth', 'chat', 'image', 'order', 'payment',
+    'product', 'search', 'seller', 'shipping', 'store', 'term', 'user'
+]
+
+domains.each { domain ->
+    tasks.register("jacocoReport${domain.capitalize()}", JacocoReport) {
+        group       = 'verification'
+        description = "JaCoCo coverage report for domain: ${domain}"
+        dependsOn test
+        executionData test
+        sourceDirectories.setFrom(sourceSets.main.java.srcDirs)
+        classDirectories.setFrom(
+            sourceSets.main.output.classesDirs.asFileTree.matching {
+                include "**/domain/${domain}/**"
+            }
+        )
+        reports {
+            xml.required  = true
+            html.required = true
+        }
+    }
+}
+
+tasks.register('jacocoAllDomainReports') {
+    group       = 'verification'
+    description = 'Generates JaCoCo coverage reports for all domains'
+    dependsOn domains.collect { "jacocoReport${it.capitalize()}" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    finalizedBy jacocoTestReport
+    finalizedBy tasks.named('jacocoTestReport')
 }
 
 // ── JaCoCo ─────────────────────────────────────────────────────────────────
@@ -94,7 +94,7 @@ jacoco {
 }
 
 jacocoTestReport {
-    dependsOn test
+    dependsOn tasks.named('test')
     reports {
         xml.required = true
         html.required = true
@@ -111,8 +111,8 @@ domains.each { domain ->
     tasks.register("jacocoReport${domain.capitalize()}", JacocoReport) {
         group       = 'verification'
         description = "JaCoCo coverage report for domain: ${domain}"
-        dependsOn test
-        executionData test
+        dependsOn tasks.named('test')
+        executionData tasks.named('test')
         sourceDirectories.setFrom(sourceSets.main.java.srcDirs)
         classDirectories.setFrom(
             sourceSets.main.output.classesDirs.asFileTree.matching {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/CartService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/CartService.java
@@ -39,6 +39,10 @@ public class CartService {
   private final UserRepo userRepo;
 
   public CartResponse getCart(Long userId) {
+    if (!userRepo.existsById(userId)) {
+      throw new BusinessException(ErrorCode.NOT_FOUND);
+    }
+
     Optional<Cart> cartOpt = cartRepository.findByUserId(userId);
 
     if (cartOpt.isEmpty()) {

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.WonkaoTalk.common.config.JacksonConfig;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtExceptionFilter;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtTokenProvider;
 import com.example.WonkaoTalk.common.redis.RedisService;
@@ -15,12 +16,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AuthController.class)
-// Spring Security 권한을 우회
+@Import(JacksonConfig.class)
 @AutoConfigureMockMvc(addFilters = false)
 class AuthControllerTest {
 

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
@@ -58,18 +58,18 @@ class CartServiceIntegrationTest {
   private User testUser;
   private User otherUser;
   private User newUser;
-  private Long testAuthId;
-  private Long otherAuthId;
-  private Long newAuthId;
+  private Long testUserId;
+  private Long otherUserId;
+  private Long newUserId;
 
   @BeforeEach
   void setUp() {
     testUser = saveUser("테스트유저");
-    testAuthId = testUser.getAuth().getId();
+    testUserId = testUser.getId();
     otherUser = saveUser("다른유저");
-    otherAuthId = otherUser.getAuth().getId();
+    otherUserId = otherUser.getId();
     newUser = saveUser("새유저");
-    newAuthId = newUser.getAuth().getId();
+    newUserId = newUser.getId();
     category = saveCategory();
     Store store = saveStore();
     productA = saveProduct(store, category, "상품A", 10000, 8000);
@@ -86,7 +86,7 @@ class CartServiceIntegrationTest {
   @Test
   @DisplayName("장바구니가 없으면 빈 응답을 반환한다")
   void getCart_returnsEmpty_whenNoCartExists() {
-    CartResponse response = cartService.getCart(newAuthId);
+    CartResponse response = cartService.getCart(newUserId);
 
     assertThat(response.getCartId()).isNull();
     assertThat(response.getCartItems()).isEmpty();
@@ -95,12 +95,14 @@ class CartServiceIntegrationTest {
   }
 
   @Test
-  @DisplayName("존재하지 않는 authId로 요청 시 NOT_FOUND를 던진다")
-  void getCart_throwsNotFound_whenUserNotFound() {
-    BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.getCart(999L));
+  @DisplayName("존재하지 않는 userId로 요청 시 빈 응답을 반환한다")
+  void getCart_returnsEmpty_whenUserNotFound() {
+    CartResponse response = cartService.getCart(999L);
 
-    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
+    assertThat(response.getCartId()).isNull();
+    assertThat(response.getCartItems()).isEmpty();
+    assertThat(response.getSummary().getOriginalTotalAmount()).isEqualTo(0);
+    assertThat(response.getSummary().getDiscountTotalAmount()).isEqualTo(0);
   }
 
   @Test
@@ -112,7 +114,7 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    CartResponse response = cartService.getCart(testAuthId);
+    CartResponse response = cartService.getCart(testUserId);
 
     assertThat(response.getCartId()).isEqualTo(cart.getId());
     assertThat(response.getCartItems()).hasSize(2);
@@ -128,7 +130,7 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    CartResponse response = cartService.getCart(testAuthId);
+    CartResponse response = cartService.getCart(testUserId);
 
     CartResponse.CartItemInfo item = response.getCartItems().get(0);
     assertThat(item.getVariantName()).isEqualTo("옵션A-1");
@@ -143,7 +145,7 @@ class CartServiceIntegrationTest {
   @Test
   @DisplayName("장바구니가 없을 때 addToCart 호출 시 Cart가 자동 생성된다")
   void addToCart_createsCart_whenCartNotExists() {
-    CartAddResponse response = cartService.addToCart(newAuthId,
+    CartAddResponse response = cartService.addToCart(newUserId,
         addRequest(productA.getId(), variantA1.getId(), 2));
 
     assertThat(response.getCartItemId()).isNotNull();
@@ -151,7 +153,7 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    CartResponse cart = cartService.getCart(newAuthId);
+    CartResponse cart = cartService.getCart(newUserId);
     assertThat(cart.getCartId()).isNotNull();
     assertThat(cart.getCartItems()).hasSize(1);
     assertThat(cart.getCartItems().get(0).getQuantity()).isEqualTo(2);
@@ -165,12 +167,12 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    cartService.addToCart(testAuthId, addRequest(productA.getId(), variantA1.getId(), 2));
+    cartService.addToCart(testUserId, addRequest(productA.getId(), variantA1.getId(), 2));
 
     em.flush();
     em.clear();
 
-    CartResponse response = cartService.getCart(testAuthId);
+    CartResponse response = cartService.getCart(testUserId);
     assertThat(response.getCartItems()).hasSize(1);
     assertThat(response.getCartItems().get(0).getQuantity()).isEqualTo(5); // 3 + 2
   }
@@ -183,12 +185,12 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    cartService.addToCart(testAuthId, addRequest(productA.getId(), variantA2.getId(), 1));
+    cartService.addToCart(testUserId, addRequest(productA.getId(), variantA2.getId(), 1));
 
     em.flush();
     em.clear();
 
-    CartResponse response = cartService.getCart(testAuthId);
+    CartResponse response = cartService.getCart(testUserId);
     assertThat(response.getCartItems()).hasSize(2);
   }
 
@@ -200,7 +202,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.addToCart(testAuthId, addRequest(productA.getId(), stopped.getId(), 1)));
+        () -> cartService.addToCart(testUserId, addRequest(productA.getId(), stopped.getId(), 1)));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_VARIANT_UNAVAILABLE);
   }
@@ -214,7 +216,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.addToCart(testAuthId,
+        () -> cartService.addToCart(testUserId,
             addRequest(productA.getId(), variantA2.getId(), 2))); // 4+2=6 > 5
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
@@ -230,12 +232,12 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    cartService.updateCartItemQuantity(testAuthId, item.getId(), quantityUpdateRequest(5));
+    cartService.updateCartItemQuantity(testUserId, item.getId(), quantityUpdateRequest(5));
 
     em.flush();
     em.clear();
 
-    CartResponse response = cartService.getCart(testAuthId);
+    CartResponse response = cartService.getCart(testUserId);
     assertThat(response.getCartItems().get(0).getQuantity()).isEqualTo(5);
   }
 
@@ -249,7 +251,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     CartQuantityUpdateResponse response =
-        cartService.updateCartItemQuantity(testAuthId, item.getId(), quantityUpdateRequest(4));
+        cartService.updateCartItemQuantity(testUserId, item.getId(), quantityUpdateRequest(4));
 
     // variantA1: 10000*4, variantB1: 5000*1
     assertThat(response.getOriginalTotalAmount()).isEqualTo(45000);
@@ -267,7 +269,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.updateCartItemQuantity(testAuthId, otherItem.getId(),
+        () -> cartService.updateCartItemQuantity(testUserId, otherItem.getId(),
             quantityUpdateRequest(3)));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
@@ -284,7 +286,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     CartOptionUpdateResponse response =
-        cartService.updateCartItemOption(testAuthId, item.getId(),
+        cartService.updateCartItemOption(testUserId, item.getId(),
             optionUpdateRequest(variantA2.getId()));
 
     assertThat(response.isMerged()).isFalse();
@@ -293,7 +295,7 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    CartResponse cartResponse = cartService.getCart(testAuthId);
+    CartResponse cartResponse = cartService.getCart(testUserId);
     assertThat(cartResponse.getCartItems()).hasSize(1);
     assertThat(cartResponse.getCartItems().get(0).getVariantId()).isEqualTo(variantA2.getId());
   }
@@ -308,7 +310,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     CartOptionUpdateResponse response =
-        cartService.updateCartItemOption(testAuthId, itemA1.getId(),
+        cartService.updateCartItemOption(testUserId, itemA1.getId(),
             optionUpdateRequest(variantA2.getId()));
 
     assertThat(response.isMerged()).isTrue();
@@ -318,7 +320,7 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    CartResponse cartResponse = cartService.getCart(testAuthId);
+    CartResponse cartResponse = cartService.getCart(testUserId);
     assertThat(cartResponse.getCartItems()).hasSize(1);
     assertThat(cartResponse.getCartItems().get(0).getQuantity()).isEqualTo(3);
   }
@@ -333,7 +335,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.updateCartItemOption(testAuthId, itemA1.getId(),
+        () -> cartService.updateCartItemOption(testUserId, itemA1.getId(),
             optionUpdateRequest(variantA2.getId())));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
@@ -350,14 +352,14 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    CartDeleteResponse response = cartService.deleteFromCart(testAuthId, null, true);
+    CartDeleteResponse response = cartService.deleteFromCart(testUserId, null, true);
 
     assertThat(response.getCartId()).isEqualTo(cart.getId());
 
     em.flush();
     em.clear();
 
-    CartResponse cartResponse = cartService.getCart(testAuthId);
+    CartResponse cartResponse = cartService.getCart(testUserId);
     assertThat(cartResponse.getCartItems()).isEmpty();
   }
 
@@ -370,12 +372,12 @@ class CartServiceIntegrationTest {
     em.flush();
     em.clear();
 
-    cartService.deleteFromCart(testAuthId, List.of(item1.getId()), false);
+    cartService.deleteFromCart(testUserId, List.of(item1.getId()), false);
 
     em.flush();
     em.clear();
 
-    CartResponse cartResponse = cartService.getCart(testAuthId);
+    CartResponse cartResponse = cartService.getCart(testUserId);
     assertThat(cartResponse.getCartItems()).hasSize(1);
     assertThat(cartResponse.getCartItems().get(0).getCartItemId()).isEqualTo(item2.getId());
   }
@@ -390,7 +392,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.deleteFromCart(testAuthId, List.of(otherItem.getId()), false));
+        () -> cartService.deleteFromCart(testUserId, List.of(otherItem.getId()), false));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }
@@ -403,7 +405,7 @@ class CartServiceIntegrationTest {
     em.clear();
 
     BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.deleteFromCart(testAuthId, List.of(99999L), false));
+        () -> cartService.deleteFromCart(testUserId, List.of(99999L), false));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }

--- a/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/integration/CartServiceIntegrationTest.java
@@ -95,14 +95,12 @@ class CartServiceIntegrationTest {
   }
 
   @Test
-  @DisplayName("존재하지 않는 userId로 요청 시 빈 응답을 반환한다")
-  void getCart_returnsEmpty_whenUserNotFound() {
-    CartResponse response = cartService.getCart(999L);
+  @DisplayName("존재하지 않는 userId로 요청 시 NOT_FOUND를 던진다")
+  void getCart_throwsNotFound_whenUserNotFound() {
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> cartService.getCart(999L));
 
-    assertThat(response.getCartId()).isNull();
-    assertThat(response.getCartItems()).isEmpty();
-    assertThat(response.getSummary().getOriginalTotalAmount()).isEqualTo(0);
-    assertThat(response.getSummary().getDiscountTotalAmount()).isEqualTo(0);
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/CartServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/CartServiceTest.java
@@ -63,6 +63,7 @@ class CartServiceTest {
   void setUp() {
     User mockUser = mock(User.class);
     when(mockUser.getId()).thenReturn(1L);
+    when(userRepo.existsById(anyLong())).thenReturn(true);
     when(userRepo.findById(anyLong())).thenReturn(Optional.of(mockUser));
   }
 
@@ -149,6 +150,17 @@ class CartServiceTest {
 
     assertThat(response.getCartItems().get(0).getSellable()).isTrue();
     assertThat(response.getCartItems().get(1).getSellable()).isFalse();
+  }
+
+  @Test
+  @DisplayName("userId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
+  void getCart_throwsNotFound_whenUserNotFound() {
+    when(userRepo.existsById(anyLong())).thenReturn(false);
+
+    BusinessException ex = assertThrows(BusinessException.class,
+        () -> cartService.getCart(1L));
+
+    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }
 
   // ── addToCart - 입력 검증 ─────────────────────────────────────────────────────

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/CartServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/CartServiceTest.java
@@ -63,7 +63,7 @@ class CartServiceTest {
   void setUp() {
     User mockUser = mock(User.class);
     when(mockUser.getId()).thenReturn(1L);
-    when(userRepo.findByAuthId(anyLong())).thenReturn(Optional.of(mockUser));
+    when(userRepo.findById(anyLong())).thenReturn(Optional.of(mockUser));
   }
 
   // ── getCart ──────────────────────────────────────────────────────────────────
@@ -149,17 +149,6 @@ class CartServiceTest {
 
     assertThat(response.getCartItems().get(0).getSellable()).isTrue();
     assertThat(response.getCartItems().get(1).getSellable()).isFalse();
-  }
-
-  @Test
-  @DisplayName("authId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
-  void getCart_throwsNotFound_whenUserNotFound() {
-    when(userRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
-
-    BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.getCart(1L));
-
-    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }
 
   // ── addToCart - 입력 검증 ─────────────────────────────────────────────────────
@@ -270,12 +259,12 @@ class CartServiceTest {
   }
 
   @Test
-  @DisplayName("authId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
+  @DisplayName("userId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
   void addToCart_throwsNotFound_whenUserNotFound() {
     Product product = mockProductWithId(1L);
     ProductVariant variant = mockVariant(1L, product, 10, SaleStatus.ON_SALE, null);
     when(productVariantRepository.findById(1L)).thenReturn(Optional.of(variant));
-    when(userRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
+    when(userRepo.findById(anyLong())).thenReturn(Optional.empty());
 
     BusinessException ex = assertThrows(BusinessException.class,
         () -> cartService.addToCart(1L, mockAddRequest(1L, 1L, 2)));
@@ -445,17 +434,6 @@ class CartServiceTest {
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
   }
 
-  @Test
-  @DisplayName("authId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
-  void updateQuantity_throwsNotFound_whenUserNotFound() {
-    when(userRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
-
-    BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.updateCartItemQuantity(1L, 1L, mockQuantityUpdateRequest(3)));
-
-    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
-  }
-
   // ── updateCartItemQuantity - 성공 ────────────────────────────────────────────
 
   @Test
@@ -550,17 +528,6 @@ class CartServiceTest {
         () -> cartService.updateCartItemOption(1L, 1L, mockOptionUpdateRequest(2L)));
 
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_VARIANT_UNAVAILABLE);
-  }
-
-  @Test
-  @DisplayName("authId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
-  void updateOption_throwsNotFound_whenUserNotFound() {
-    when(userRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
-
-    BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.updateCartItemOption(1L, 1L, mockOptionUpdateRequest(2L)));
-
-    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
   }
 
   // ── updateCartItemOption - Merge ─────────────────────────────────────────────
@@ -679,17 +646,6 @@ class CartServiceTest {
   }
 
   // ── deleteFromCart ───────────────────────────────────────────────────────────
-
-  @Test
-  @DisplayName("authId에 해당하는 User가 없으면 NOT_FOUND를 던진다")
-  void deleteFromCart_throwsNotFound_whenUserNotFound() {
-    when(userRepo.findByAuthId(anyLong())).thenReturn(Optional.empty());
-
-    BusinessException ex = assertThrows(BusinessException.class,
-        () -> cartService.deleteFromCart(1L, null, true));
-
-    assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
-  }
 
   @Test
   @DisplayName("장바구니가 없으면 NOT_FOUND를 던진다")


### PR DESCRIPTION
## 📌 관련 이슈
- #119 

## 📝 작업 내용
- Jacoco 의존성을 추가했습니다.
- 문제가 발생하는 테스트 코드를 수정했습니다

## ✅ 작업 결과 
- 현 시점(6월 1일 10시 20분) 기준 테스트 커버리지
| 도메인 | 명령 커버 / 전체 | 명령 커버리지 | 브랜치 커버리지 |
|---|---|---|---|
| auth | 417 / 1264 | 33.0% | 17.7% |
| chat | 814 / 890 | 91.5% | 80.0% |
| image | 117 / 264 | 44.3% | 42.9% |
| order | 793 / 1200 | 66.1% | 75.0% |
| payment | 483 / 916 | 52.7% | 36.4% |
| product | 3689 / 4120 | 89.5% | 83.1% |
| search | 321 / 363 | 88.4% | 86.2% |
| seller | 254 / 413 | 61.5% | 40.0% |
| shipping | 302 / 373 | 81.0% | 87.5% |
| store | 253 / 361 | 70.1% | 50.0% |
| term | - | - | - |
| user | 531 / 927 | 57.3% | 40.6% |  

## 🎸 기타
- 이런걸 중점적으로 봐주세요 등 있으면 기재
