### PR TITLE
fix: 결제 승인 실패 기록을 별도 트랜잭션으로 저장

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/domain/payment/event/PaymentFailedEvent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/event/PaymentFailedEvent.java
@@ -1,0 +1,5 @@
+package com.example.WonkaoTalk.domain.payment.event;
+
+public record PaymentFailedEvent(Long paymentId, String failCode, String failMessage) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentFailRecorder.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentFailRecorder.java
@@ -3,11 +3,14 @@ package com.example.WonkaoTalk.domain.payment.service;
 import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.event.PaymentFailedEvent;
 import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Service
 @RequiredArgsConstructor
@@ -15,13 +18,13 @@ public class PaymentFailRecorder {
 
   private final PaymentRepo paymentRepo;
 
-  // 결제 실패 시 실패 기록 표시용
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void recordFail(Long paymentId, String failCode, String failMessage) {
-    Payment payment = paymentRepo.findById(paymentId).orElseThrow(() -> new BusinessException(
-        ErrorCode.PAYMENT_NOT_FOUND));
+  public void recordFail(PaymentFailedEvent event) {
+    Payment payment = paymentRepo.findById(event.paymentId())
+        .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
-    payment.markFailed(failCode, failMessage);
+    payment.markFailed(event.failCode(), event.failMessage());
     payment.getOrder().markPaymentFailed();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentFailRecorder.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentFailRecorder.java
@@ -1,0 +1,27 @@
+package com.example.WonkaoTalk.domain.payment.service;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFailRecorder {
+
+  private final PaymentRepo paymentRepo;
+
+  // 결제 실패 시 실패 기록 표시용
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void recordFail(Long paymentId, String failCode, String failMessage) {
+    Payment payment = paymentRepo.findById(paymentId).orElseThrow(() -> new BusinessException(
+        ErrorCode.PAYMENT_NOT_FOUND));
+
+    payment.markFailed(failCode, failMessage);
+    payment.getOrder().markPaymentFailed();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
@@ -16,6 +16,7 @@ import com.example.WonkaoTalk.domain.payment.dto.PaymentFailRequest;
 import com.example.WonkaoTalk.domain.payment.dto.PaymentFailResponse;
 import com.example.WonkaoTalk.domain.payment.entity.Payment;
 import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
+import com.example.WonkaoTalk.domain.payment.event.PaymentFailedEvent;
 import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,7 +39,7 @@ public class PaymentService {
   private final ProductVariantRepo productVariantRepo;
   private final TossPaymentsProperties tossPaymentsProperties;
   private final TossPaymentsClient tossPaymentsClient;
-  private final PaymentFailRecorder paymentFailRecorder;
+  private final ApplicationEventPublisher eventPublisher;
 
   // 주문 생성
   @Transactional
@@ -135,7 +137,8 @@ public class PaymentService {
       log.warn(
           "TossPayments confirm failed. paymentId={}, tossOrderId={}, tossCode={}, tossMessage={}",
           payment.getPaymentId(), payment.getTossOrderId(), e.getCode(), e.getMessage());
-      paymentFailRecorder.recordFail(payment.getPaymentId(), e.getCode(), e.getMessage());
+      eventPublisher.publishEvent(
+          new PaymentFailedEvent(payment.getPaymentId(), e.getCode(), e.getMessage()));
 
       throw new BusinessException(ErrorCode.PAYMENT_APPROVAL_FAILED);
     }

--- a/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/payment/service/PaymentService.java
@@ -37,6 +37,7 @@ public class PaymentService {
   private final ProductVariantRepo productVariantRepo;
   private final TossPaymentsProperties tossPaymentsProperties;
   private final TossPaymentsClient tossPaymentsClient;
+  private final PaymentFailRecorder paymentFailRecorder;
 
   // 주문 생성
   @Transactional
@@ -134,8 +135,8 @@ public class PaymentService {
       log.warn(
           "TossPayments confirm failed. paymentId={}, tossOrderId={}, tossCode={}, tossMessage={}",
           payment.getPaymentId(), payment.getTossOrderId(), e.getCode(), e.getMessage());
-      payment.markFailed(e.getCode(), e.getMessage());
-      payment.getOrder().markPaymentFailed();
+      paymentFailRecorder.recordFail(payment.getPaymentId(), e.getCode(), e.getMessage());
+
       throw new BusinessException(ErrorCode.PAYMENT_APPROVAL_FAILED);
     }
   }

--- a/src/test/java/com/example/WonkaoTalk/domain/payment/integration/PaymentIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/payment/integration/PaymentIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.example.WonkaoTalk.domain.payment.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.order.entity.Order;
+import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
+import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
+import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentsClient;
+import com.example.WonkaoTalk.domain.payment.client.TossPaymentsException;
+import com.example.WonkaoTalk.domain.payment.dto.PaymentConfirmRequest;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
+import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
+import com.example.WonkaoTalk.domain.payment.service.PaymentService;
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.store.entity.Store;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.enums.Gender;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// flyway 로 db erd 마무리 되면 그때 제거할것
+@SpringBootTest(properties = "spring.flyway.enabled=false")
+@Import(TestContainerConfig.class)
+class PaymentIntegrationTest {
+
+  @Autowired
+  private EntityManager em;
+
+  @Autowired
+  private OrderRepo orderRepo;
+
+  @Autowired
+  private OrderItemRepo orderItemRepo;
+
+  @Autowired
+  private TransactionTemplate transactionTemplate;
+
+  @Autowired
+  private PaymentService paymentService;
+
+  @Autowired
+  private PaymentRepo paymentRepo;
+
+  @MockitoBean
+  private TossPaymentsClient tossPaymentsClient;
+
+  @Test
+  @DisplayName("토스 승인 실패 시 Payment와 Order 실패 기록을 DB에 남긴다")
+  void confirm_RecordFailure_WhenTossConfirmFails() {
+    // given
+    // payment 객체 생성
+    Payment payment = transactionTemplate.execute(status -> {
+      User user = saveUser();
+      Store store = saveStore();
+      Category category = saveCategory();
+      Product product = saveProduct(store, category);
+      ProductVariant variant = saveVariant(product);
+
+      Order order = Order.createOrder(
+          "ORD-TEST-001",
+          user,
+          35000L,
+          0L,
+          0L,
+          35000L,
+          "초콜릿"
+      );
+      order.markPaymentPending();
+      orderRepo.save(order);
+//      em.persist(order);
+
+      OrderItem orderItem = OrderItem.createOrderItem(
+          order,
+          variant,
+          "초콜릿",
+          "기본",
+          35000L,
+          1,
+          "https://image.example/choco.png"
+      );
+      orderItemRepo.save(orderItem);
+//      em.persist(orderItem);
+
+      Payment readyPayment = Payment.createReadyPayment(
+          order,
+          "ORD-TEST-001-PAY-001",
+          "idem-key",
+          35000L,
+          LocalDateTime.now()
+      );
+      paymentRepo.save(readyPayment);
+//      em.persist(readyPayment);
+      em.flush();
+      return readyPayment;
+    });
+
+    PaymentConfirmRequest request = new PaymentConfirmRequest(
+        "payment-key",
+        payment.getTossOrderId(),
+        35000L
+    );
+    when(tossPaymentsClient.confirm(
+        "payment-key",
+        payment.getTossOrderId(),
+        35000L,
+        payment.getIdempotencyKey()
+    )).thenThrow(new TossPaymentsException(
+        "REJECT_CARD",
+        "카드 승인이 거절되었습니다."
+    ));
+
+    // when
+    assertThatThrownBy(() -> paymentService.confirm(payment.getOrder().getUser().getId(), request))
+        .isInstanceOf(BusinessException.class);
+
+    // then
+    Payment savedPayment = paymentRepo.findById(payment.getPaymentId()).orElseThrow();
+    Order savedOrder = orderRepo.findById(payment.getOrder().getOrderId()).orElseThrow();
+    assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    assertThat(savedPayment.getFailCode()).isEqualTo("REJECT_CARD");
+    assertThat(savedPayment.getFailMessage()).isEqualTo("카드 승인이 거절되었습니다.");
+    assertThat(savedPayment.getFailedAt()).isNotNull();
+    assertThat(savedOrder.getOrderStatus()).isEqualTo(OrderStatus.PAYMENT_FAILED);
+  }
+
+  private User saveUser() {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    User user = User.builder()
+        .auth(auth)
+        .nickname("테스트유저")
+        .name("테스트유저")
+        .phone("01012345678")
+        .gender(Gender.NONE)
+        .build();
+    em.persist(user);
+    return user;
+  }
+
+  private Store saveStore() {
+    Auth auth = Auth.builder().build();
+    em.persist(auth);
+
+    Seller seller = Seller.builder()
+        .auth(auth)
+        .buzNo(String.valueOf(System.nanoTime()).substring(0, 10))
+        .name("테스트판매자")
+        .phone("010-0000-0000")
+        .build();
+    em.persist(seller);
+
+    Store store = Store.builder()
+        .seller(seller)
+        .name("테스트스토어")
+        .description("설명")
+        .phone("010-0000-0000")
+        .build();
+    em.persist(store);
+    return store;
+  }
+
+  private Category saveCategory() {
+    Category cat = new Category();
+    ReflectionTestUtils.setField(cat, "name", "테스트카테고리");
+    ReflectionTestUtils.setField(cat, "depth", 1);
+    em.persist(cat);
+    return cat;
+  }
+
+  private Product saveProduct(Store store, Category category) {
+    Product product = Product.builder()
+        .store(store)
+        .category(category)
+        .name("초콜릿")
+        .price(35000)
+        .discountedPrice(35000)
+        .status(SaleStatus.ON_SALE)
+        .likeCount(0)
+        .build();
+    em.persist(product);
+    return product;
+  }
+
+  private ProductVariant saveVariant(Product product) {
+    ProductVariant variant = ProductVariant.builder()
+        .product(product)
+        .name("기본")
+        .stock(10)
+        .status(SaleStatus.ON_SALE)
+        .build();
+    em.persist(variant);
+    return variant;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 public class PaymentServiceTest {
@@ -53,6 +54,9 @@ public class PaymentServiceTest {
 
   @Mock
   private TossPaymentsClient tossPaymentsClient;
+
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks
   private PaymentService paymentService;


### PR DESCRIPTION
## 📌 관련 이슈
- #87 

## 📝 작업 내용
- 토스 결제 승인 실패 시 PaymentFailRecorder를 통해 실패 상태를 기록

- 실패 기록 저장을 REQUIRES_NEW 트랜잭션으로 분리

- 승인 실패 후 rollback되어도 Payment와 Order 실패 상태가 남도록 통합 테스트 추가

## ✅ 작업 결과 
- 트랜잭션 분리 전
<img width="1522" height="407" alt="image" src="https://github.com/user-attachments/assets/ed276aea-4a6d-4231-b901-4afc7565fef6" />
<img width="2444" height="448" alt="image" src="https://github.com/user-attachments/assets/09f9b92e-e610-4bb8-a62b-a44a2b795252" />

-  트랜잭션 분리 후 
<img width="1504" height="450" alt="image" src="https://github.com/user-attachments/assets/f0fae4b2-1e87-4eb7-8629-8a5cb9bdb917" />
<img width="1457" height="383" alt="image" src="https://github.com/user-attachments/assets/4be87e1b-229d-4119-88b8-2be4ffa169f7" />


## 🎸 기타
- close #87 
