### PR TITLE
refactor: 상품 검색에 es 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ postgres/
 kafka/
 minio/
 
+### 대용량 데이터 생성 도구 (로컬 전용) ###
+docker-compose.override.yml
+src/test/java/com/example/WonkaoTalk/domain/product/datagen/
+
 ### macOS ###
 .DS_Store
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
 
+    // --- Elasticsearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
     // --- Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-websocket-test'
@@ -84,6 +87,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    systemProperty 'volume', System.getProperty('volume', '100')
     finalizedBy tasks.named('jacocoTestReport')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:testcontainers-postgresql'
     testImplementation 'org.testcontainers:testcontainers-kafka'
+    testImplementation 'org.testcontainers:testcontainers-elasticsearch'
+    testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'com.redis:testcontainers-redis'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,10 +83,13 @@ services:
       "
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
+    build:
+      context: .
+      dockerfile: elasticsearch.Dockerfile
     container_name: wonkao-talk-es
     ports:
       - "9200:9200"
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+

--- a/elasticsearch.Dockerfile
+++ b/elasticsearch.Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.2.8
+RUN elasticsearch-plugin install --batch analysis-nori

--- a/src/main/java/com/example/WonkaoTalk/WonkaoTalkApplication.java
+++ b/src/main/java/com/example/WonkaoTalk/WonkaoTalkApplication.java
@@ -2,7 +2,9 @@ package com.example.WonkaoTalk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class WonkaoTalkApplication {
 

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                 "/api/v1/users/signup",
                 "/api/v1/sellers/signup",
                 "/api/v1/search",
+                "/api/v1/search/reindex/**",
                 "/ws/**",
                 "/v3/api-docs/**",
                 "/swagger-ui/**",

--- a/src/main/java/com/example/WonkaoTalk/domain/product/event/ProductIndexRequestedEvent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/event/ProductIndexRequestedEvent.java
@@ -1,0 +1,20 @@
+package com.example.WonkaoTalk.domain.product.event;
+
+/**
+ * 상품 검색 색인 갱신 요청 이벤트. 색인 필드(상품명/옵션값/상태/가격/카테고리)를 바꾸는 변경 후 발행한다.
+ * 동기화 필요 판단 기준은 docs/search-elasticsearch-sync-guideline.md 참고.
+ */
+public record ProductIndexRequestedEvent(Long productId, IndexOp op) {
+
+  public enum IndexOp {
+    UPSERT, DELETE
+  }
+
+  public static ProductIndexRequestedEvent upsert(Long productId) {
+    return new ProductIndexRequestedEvent(productId, IndexOp.UPSERT);
+  }
+
+  public static ProductIndexRequestedEvent delete(Long productId) {
+    return new ProductIndexRequestedEvent(productId, IndexOp.DELETE);
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/product/event/ProductIndexRequestedEvent.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/event/ProductIndexRequestedEvent.java
@@ -2,13 +2,8 @@ package com.example.WonkaoTalk.domain.product.event;
 
 /**
  * 상품 검색 색인 갱신 요청 이벤트. 색인 필드(상품명/옵션값/상태/가격/카테고리)를 바꾸는 변경 후 발행한다.
- * 동기화 필요 판단 기준은 docs/search-elasticsearch-sync-guideline.md 참고.
  */
 public record ProductIndexRequestedEvent(Long productId, IndexOp op) {
-
-  public enum IndexOp {
-    UPSERT, DELETE
-  }
 
   public static ProductIndexRequestedEvent upsert(Long productId) {
     return new ProductIndexRequestedEvent(productId, IndexOp.UPSERT);
@@ -16,5 +11,9 @@ public record ProductIndexRequestedEvent(Long productId, IndexOp op) {
 
   public static ProductIndexRequestedEvent delete(Long productId) {
     return new ProductIndexRequestedEvent(productId, IndexOp.DELETE);
+  }
+
+  public enum IndexOp {
+    UPSERT, DELETE
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductOptionRepo.java
@@ -3,10 +3,25 @@ package com.example.WonkaoTalk.domain.product.repo;
 import com.example.WonkaoTalk.domain.product.entity.ProductOption;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductOptionRepo extends JpaRepository<ProductOption, Long> {
 
   List<ProductOption> findByProductOptionGroupId(Long productOptionGroupId);
 
   List<ProductOption> findByProductOptionGroupIdIn(List<Long> groupIds);
+
+  /** 상품의 모든 옵션값(ProductOption.name) — ES 단건 색인용. */
+  @Query("SELECT po.name FROM ProductOption po "
+      + "WHERE po.productOptionGroup.product.id = :productId")
+  List<String> findOptionNamesByProductId(@Param("productId") Long productId);
+
+  /**
+   * 여러 상품의 옵션값을 한 번에 조회 — ES 전체 재색인 배치용(N+1 회피).
+   * 각 행은 [productId, optionName] 형태로 반환된다.
+   */
+  @Query("SELECT po.productOptionGroup.product.id, po.name FROM ProductOption po "
+      + "WHERE po.productOptionGroup.product.id IN :productIds")
+  List<Object[]> findOptionNamesByProductIds(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepo.java
@@ -1,8 +1,11 @@
 package com.example.WonkaoTalk.domain.product.repo;
 
 import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +16,20 @@ public interface ProductRepo extends JpaRepository<Product, Long>, ProductRepoCu
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("SELECT p FROM Product p WHERE p.id = :id")
   Optional<Product> findByIdWithLock(@Param("id") Long id);
+
+  /** ES 검색 결과 ID 목록으로 Store 까지 fetch (방식 A). 정렬은 호출 측에서 ES 순서로 재정렬. */
+  @Query("SELECT p FROM Product p JOIN FETCH p.store WHERE p.id IN :ids")
+  List<Product> findWithStoreByIdIn(@Param("ids") List<Long> ids);
+
+  /**
+   * 색인 대상(삭제되지 않고 판매상태가 노출 대상) 상품을 id 키셋 페이징으로 조회 — 전체 재색인 배치용.
+   * category 를 fetch join 하여 N+1 을 피한다. {@code lastId} 이후부터 {@code pageable} 크기만큼 반환.
+   */
+  @Query("SELECT p FROM Product p JOIN FETCH p.category "
+      + "WHERE p.deletedAt IS NULL AND p.status IN :statuses AND p.id > :lastId "
+      + "ORDER BY p.id")
+  List<Product> findIndexableForReindex(
+      @Param("statuses") List<SaleStatus> statuses,
+      @Param("lastId") Long lastId,
+      Pageable pageable);
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepo.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepo.java
@@ -17,7 +17,7 @@ public interface ProductRepo extends JpaRepository<Product, Long>, ProductRepoCu
   @Query("SELECT p FROM Product p WHERE p.id = :id")
   Optional<Product> findByIdWithLock(@Param("id") Long id);
 
-  /** ES 검색 결과 ID 목록으로 Store 까지 fetch (방식 A). 정렬은 호출 측에서 ES 순서로 재정렬. */
+  /** ES 검색 결과 ID 목록으로 Store 까지 fetch. 정렬은 호출 측에서 ES 순서로 재정렬. */
   @Query("SELECT p FROM Product p JOIN FETCH p.store WHERE p.id IN :ids")
   List<Product> findWithStoreByIdIn(@Param("ids") List<Long> ids);
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/repo/ProductRepoCustomImpl.java
@@ -90,7 +90,8 @@ public class ProductRepoCustomImpl implements ProductRepoCustom {
     predicates.add(p.get("status").in(SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK));
 
     p.fetch("store", JoinType.LEFT);
-    // TODO: ElasticSearch 등 검색 엔진 도입 시 동의어(예: 레드-빨강) 처리 및 스코어 기반 정렬로 교체 필요
+    // 상품 검색은 ElasticSearch(ProductSearchQueryRepository)로 전환됨. 이 메서드는 ES 불가 시
+    // search.product.engine=database 로 전환되는 폴백 경로다. 옵션값 매칭/형태소 분석은 ES만 지원한다.
 
     predicates.add(cb.like(p.get("name"), "%" + keyword + "%"));
 

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductCreateService.java
@@ -20,6 +20,7 @@ import com.example.WonkaoTalk.domain.product.entity.VariantOptionMap;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.enums.StockChangeReason;
 import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
+import com.example.WonkaoTalk.domain.product.event.ProductIndexRequestedEvent;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductImageRepo;
@@ -146,6 +147,7 @@ public class ProductCreateService {
     if (!objectKeysToMove.isEmpty()) {
       eventPublisher.publishEvent(new ProductCreatedEvent(objectKeysToMove));
     }
+    eventPublisher.publishEvent(ProductIndexRequestedEvent.upsert(product.getId()));
 
     return new ProductCreateResponse(
         product.getId(),

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteService.java
@@ -5,6 +5,7 @@ import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
 import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
 import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.event.ProductIndexRequestedEvent;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
@@ -12,6 +13,7 @@ import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ public class ProductDeleteService {
   private final StoreRepo storeRepo;
   private final ProductRepo productRepo;
   private final OrderItemRepo orderItemRepo;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public void delete(Long authId, Long productId) {
@@ -37,6 +40,7 @@ public class ProductDeleteService {
     }
 
     product.softDelete();
+    eventPublisher.publishEvent(ProductIndexRequestedEvent.delete(productId));
   }
 
   private Store resolveStore(Long authId) {

--- a/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/product/service/ProductUpdateService.java
@@ -20,6 +20,7 @@ import com.example.WonkaoTalk.domain.product.entity.ProductOption;
 import com.example.WonkaoTalk.domain.product.entity.ProductOptionGroup;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.event.ProductCreatedEvent;
+import com.example.WonkaoTalk.domain.product.event.ProductIndexRequestedEvent;
 import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.DeletedProductImageRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductDetailRepo;
@@ -174,6 +175,7 @@ public class ProductUpdateService {
     if (!objectKeysToMove.isEmpty()) {
       eventPublisher.publishEvent(new ProductCreatedEvent(objectKeysToMove));
     }
+    eventPublisher.publishEvent(ProductIndexRequestedEvent.upsert(product.getId()));
 
     return new ProductUpdateResponse(
         product.getId(),

--- a/src/main/java/com/example/WonkaoTalk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/controller/SearchController.java
@@ -3,6 +3,8 @@ package com.example.WonkaoTalk.domain.search.controller;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
+import com.example.WonkaoTalk.domain.search.indexer.ProductReindexService;
+import com.example.WonkaoTalk.domain.search.indexer.ProductReindexService.ReindexStatus;
 import com.example.WonkaoTalk.domain.search.service.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController {
 
     private final SearchService searchService;
+    private final ProductReindexService reindexService;
 
     @Operation(summary = "통합 검색", description = "검색어와 필터 조건으로 상품과 스토어를 검색합니다.")
     @GetMapping("/search")
@@ -27,5 +31,20 @@ public class SearchController {
         @ModelAttribute SearchRequest request) {
         SearchResponse response = searchService.search(request);
         return ResponseEntity.ok(ApiResponse.success("조회가 완료되었습니다", response));
+    }
+
+    @Operation(summary = "전체 재색인 (비동기)", description = "데이터베이스의 상품 데이터를 전체 재색인합니다.")
+    @PostMapping("/search/reindex")
+    public ResponseEntity<ApiResponse<ReindexStatus>> reindex() {
+        reindexService.reindexAllAsync();
+        return ResponseEntity.accepted()
+            .body(ApiResponse.success("재색인 작업이 시작되었습니다.", reindexService.getStatus()));
+    }
+
+    @Operation(summary = "재색인 작업 상태 조회", description = "현재 진행 중인 재색인 작업 상태를 조회합니다.")
+    @GetMapping("/search/reindex/status")
+    public ResponseEntity<ApiResponse<ReindexStatus>> getReindexStatus() {
+        return ResponseEntity.ok(
+            ApiResponse.success("재색인 작업 상태 조회 성공", reindexService.getStatus()));
     }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
@@ -1,0 +1,72 @@
+package com.example.WonkaoTalk.domain.search.document;
+
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import java.time.ZoneOffset;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+/**
+ * 상품 검색용 ElasticSearch 문서.
+ *
+ * <p>방식 A(구현 계획 §3): 검색·필터·정렬에 필요한 최소 필드만 색인하고, 표시용 상세 데이터는 DB에서 fetch 한다.
+ * {@code name} 과 {@code optionValues} 는 {@code searchText} 로 copy_to 되어, 단일 필드 매칭만으로
+ * "흰색 티셔츠"(옵션값 + 상품명) 같은 멀티 토큰 질의를 처리한다.
+ */
+@Document(indexName = "products", createIndex = false)
+@Setting(settingPath = "elasticsearch/product-settings.json")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class ProductDocument {
+
+  @Id
+  private Long id;
+
+  @Field(type = FieldType.Text, analyzer = "nori_analyzer", copyTo = "searchText")
+  private String name;
+
+  @Field(type = FieldType.Text, analyzer = "nori_analyzer", copyTo = "searchText")
+  private List<String> optionValues;
+
+  @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+  private String searchText;
+
+  @Field(type = FieldType.Long)
+  private Long categoryId;
+
+  @Field(type = FieldType.Integer)
+  private Integer discountedPrice;
+
+  @Field(type = FieldType.Integer)
+  private Integer likeCount;
+
+  @Field(type = FieldType.Date, format = DateFormat.epoch_millis)
+  private Long createdAt;
+
+  @Field(type = FieldType.Keyword)
+  private String status;
+
+  public static ProductDocument from(Product product, List<String> optionValues) {
+    return ProductDocument.builder()
+        .id(product.getId())
+        .name(product.getName())
+        .optionValues(optionValues)
+        .categoryId(product.getCategory().getId())
+        .discountedPrice(product.getDiscountedPrice())
+        .likeCount(product.getLikeCount())
+        .createdAt(product.getCreatedAt().toInstant(ZoneOffset.UTC).toEpochMilli())
+        .status(product.getStatus().name())
+        .build();
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
@@ -72,7 +72,7 @@ public class ProductDocument {
         .id(product.getId())
         .name(product.getName())
         .optionValues(optionValues)
-        .categoryId(product.getCategory().getId())
+        .categoryId(product.getCategory() != null ? product.getCategory().getId() : null)
         .discountedPrice(product.getDiscountedPrice())
         .likeCount(product.getLikeCount())
         .createdAt(product.getCreatedAt().toInstant(ZoneOffset.UTC).toEpochMilli())

--- a/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
@@ -20,7 +20,7 @@ import org.springframework.data.elasticsearch.annotations.Setting;
 /**
  * 상품 검색용 ElasticSearch 문서.
  *
- * <p>방식 A(구현 계획 §3): 검색·필터·정렬에 필요한 최소 필드만 색인하고, 표시용 상세 데이터는 DB에서 fetch 한다.
+ * 방식 A(구현 계획 §3): 검색·필터·정렬에 필요한 최소 필드만 색인하고, 표시용 상세 데이터는 DB에서 fetch 한다.
  * {@code name} 과 {@code optionValues} 는 {@code searchText} 로 copy_to 되어, 단일 필드 매칭만으로
  * "흰색 티셔츠"(옵션값 + 상품명) 같은 멀티 토큰 질의를 처리한다.
  */
@@ -44,7 +44,7 @@ public class ProductDocument {
   /**
    * {@code name} + {@code optionValues} 가 copy_to 되는 통합 검색 필드.
    *
-   * <p>본필드는 nori(형태소 단위 통째 토큰 매칭)로, {@code searchText.ngram} 서브필드는 ngram(부분 문자열)으로
+   * 본필드는 nori(형태소 단위 통째 토큰 매칭)로, {@code searchText.ngram} 서브필드는 ngram(부분 문자열)으로
    * 색인한다. nori 만으로는 "티셔츠"가 단일 토큰이라 "셔츠" 부분 검색이 매칭되지 않으므로 ngram 으로 보완한다.
    */
   @MultiField(

--- a/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/document/ProductDocument.java
@@ -13,6 +13,8 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
 /**
@@ -39,7 +41,15 @@ public class ProductDocument {
   @Field(type = FieldType.Text, analyzer = "nori_analyzer", copyTo = "searchText")
   private List<String> optionValues;
 
-  @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+  /**
+   * {@code name} + {@code optionValues} 가 copy_to 되는 통합 검색 필드.
+   *
+   * <p>본필드는 nori(형태소 단위 통째 토큰 매칭)로, {@code searchText.ngram} 서브필드는 ngram(부분 문자열)으로
+   * 색인한다. nori 만으로는 "티셔츠"가 단일 토큰이라 "셔츠" 부분 검색이 매칭되지 않으므로 ngram 으로 보완한다.
+   */
+  @MultiField(
+      mainField = @Field(type = FieldType.Text, analyzer = "nori_analyzer"),
+      otherFields = @InnerField(suffix = "ngram", type = FieldType.Text, analyzer = "ngram_analyzer"))
   private String searchText;
 
   @Field(type = FieldType.Long)

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexEventListener.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexEventListener.java
@@ -1,0 +1,32 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import com.example.WonkaoTalk.domain.product.event.ProductIndexRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 상품 변경 트랜잭션 커밋(AFTER_COMMIT) 후 ES 색인을 갱신한다.
+ * ES 장애가 비즈니스 트랜잭션을 롤백시키지 않도록 예외를 격리하고, 드리프트는 재색인 배치로 회복한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductIndexEventListener {
+
+  private final ProductIndexService indexService;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handle(ProductIndexRequestedEvent event) {
+    try {
+      switch (event.op()) {
+        case UPSERT -> indexService.indexById(event.productId());
+        case DELETE -> indexService.deleteById(event.productId());
+      }
+    } catch (Exception e) {
+      log.error("상품 색인 동기화 실패 productId={}, op={}", event.productId(), event.op(), e);
+    }
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexEventListener.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexEventListener.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.search.indexer;
 import com.example.WonkaoTalk.domain.product.event.ProductIndexRequestedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -18,6 +19,7 @@ public class ProductIndexEventListener {
 
   private final ProductIndexService indexService;
 
+  @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handle(ProductIndexRequestedEvent event) {
     try {

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexService.java
@@ -1,0 +1,48 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 상품 문서 색인/삭제 로직. productId 기준으로 DB 에서 문서 전체를 다시 읽어 멱등하게 재색인한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class ProductIndexService {
+
+  /** 검색에 노출되는(=색인 대상) 판매상태. */
+  private static final List<SaleStatus> INDEXABLE_STATUSES =
+      List.of(SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK);
+
+  private final ProductRepo productRepo;
+  private final ProductOptionRepo productOptionRepo;
+  private final ProductSearchRepository searchRepository;
+
+  /** productId 의 현재 상태를 색인에 반영. 색인 대상이 아니면 문서를 제거한다. */
+  @Transactional(readOnly = true)
+  public void indexById(Long productId) {
+    Product product = productRepo.findById(productId).orElse(null);
+    if (product == null || !isIndexable(product)) {
+      searchRepository.deleteById(productId);
+      return;
+    }
+    List<String> optionValues = productOptionRepo.findOptionNamesByProductId(productId);
+    searchRepository.save(ProductDocument.from(product, optionValues));
+  }
+
+  public void deleteById(Long productId) {
+    searchRepository.deleteById(productId);
+  }
+
+  private boolean isIndexable(Product product) {
+    return product.getDeletedAt() == null && INDEXABLE_STATUSES.contains(product.getStatus());
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
@@ -10,9 +10,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 /**
@@ -37,8 +40,43 @@ public class ProductReindexService {
   private final ProductOptionRepo productOptionRepo;
   private final ProductSearchRepository searchRepository;
 
-  /** 색인 대상 전체를 청크 단위로 다시 색인한다. 총 색인 건수를 반환. */
+  private final AtomicBoolean isRunning = new AtomicBoolean(false);
+  private volatile ReindexStatus status = new ReindexStatus("IDLE", 0, 0L, null);
+
+  public record ReindexStatus(String state, int totalIndexed, long lastId, String errorMessage) {}
+
+  public ReindexStatus getStatus() {
+    return status;
+  }
+
+  /** 색인 대상 전체를 청크 단위로 다시 색인한다. 총 색인 건수를 반환 (동기 방식). */
   public int reindexAll() {
+    int total = runReindexing(null);
+    log.info("상품 전체 재색인 완료: {} 건", total);
+    return total;
+  }
+
+  /** 백그라운드 스레드에서 전체 재색인 작업을 실행한다 (비동기 방식). */
+  @Async
+  public void reindexAllAsync() {
+    if (!isRunning.compareAndSet(false, true)) {
+      log.warn("이미 재색인 작업이 진행 중입니다.");
+      return;
+    }
+    status = new ReindexStatus("RUNNING", 0, 0L, null);
+    try {
+      int total = runReindexing((t, id) -> status = new ReindexStatus("RUNNING", t, id, null));
+      status = new ReindexStatus("COMPLETED", total, status.lastId(), null);
+      log.info("상품 전체 재색인 완료: {} 건", total);
+    } catch (Exception e) {
+      log.error("재색인 중 에러 발생", e);
+      status = new ReindexStatus("FAILED", status.totalIndexed(), status.lastId(), e.getMessage());
+    } finally {
+      isRunning.set(false);
+    }
+  }
+
+  private int runReindexing(BiConsumer<Integer, Long> progressConsumer) {
     int total = 0;
     long lastId = 0L;
 
@@ -59,10 +97,11 @@ public class ProductReindexService {
 
       total += docs.size();
       lastId = ids.get(ids.size() - 1);
+      if (progressConsumer != null) {
+        progressConsumer.accept(total, lastId);
+      }
       log.info("상품 재색인 진행: 누적 {} 건 (마지막 id={})", total, lastId);
     }
-
-    log.info("상품 전체 재색인 완료: {} 건", total);
     return total;
   }
 

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
@@ -1,0 +1,78 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * 전체 재색인 배치 — 최초 도입 시 기존 상품 일괄 색인 및 드리프트 발생 시 정합성 회복용.
+ *
+ * <p>대용량을 고려해 (1) id 키셋 페이징으로 청크 단위 조회, (2) 청크별 옵션값을 한 번에 조회(N+1 회피),
+ * (3) ES bulk 색인({@code saveAll})으로 처리한다. 문서 ID = product.id 이므로 멱등하게 재실행 가능.
+ *
+ * <p>긴 단일 트랜잭션/영속성 컨텍스트 누적을 피하려고 클래스 레벨 트랜잭션을 두지 않는다.
+ * category 는 fetch join 으로 초기화되고 나머지 색인 필드는 모두 즉시 로딩이라 지연 로딩 문제는 없다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductReindexService {
+
+  private static final List<SaleStatus> INDEXABLE_STATUSES =
+      List.of(SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK);
+  private static final int BATCH_SIZE = 1000;
+
+  private final ProductRepo productRepo;
+  private final ProductOptionRepo productOptionRepo;
+  private final ProductSearchRepository searchRepository;
+
+  /** 색인 대상 전체를 청크 단위로 다시 색인한다. 총 색인 건수를 반환. */
+  public int reindexAll() {
+    int total = 0;
+    long lastId = 0L;
+
+    while (true) {
+      List<Product> batch = productRepo.findIndexableForReindex(
+          INDEXABLE_STATUSES, lastId, PageRequest.of(0, BATCH_SIZE));
+      if (batch.isEmpty()) {
+        break;
+      }
+
+      List<Long> ids = batch.stream().map(Product::getId).toList();
+      Map<Long, List<String>> optionsByProduct = groupOptionNames(ids);
+
+      List<ProductDocument> docs = batch.stream()
+          .map(p -> ProductDocument.from(p, optionsByProduct.getOrDefault(p.getId(), List.of())))
+          .toList();
+      searchRepository.saveAll(docs); // ES bulk 색인
+
+      total += docs.size();
+      lastId = ids.get(ids.size() - 1);
+      log.info("상품 재색인 진행: 누적 {} 건 (마지막 id={})", total, lastId);
+    }
+
+    log.info("상품 전체 재색인 완료: {} 건", total);
+    return total;
+  }
+
+  private Map<Long, List<String>> groupOptionNames(List<Long> productIds) {
+    Map<Long, List<String>> optionsByProduct = new HashMap<>();
+    for (Object[] row : productOptionRepo.findOptionNamesByProductIds(productIds)) {
+      Long productId = (Long) row[0];
+      String optionName = (String) row[1];
+      optionsByProduct.computeIfAbsent(productId, k -> new ArrayList<>()).add(optionName);
+    }
+    return optionsByProduct;
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
@@ -1,11 +1,11 @@
 package com.example.WonkaoTalk.domain.search.indexer;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.search.document.ProductDocument;
-import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import jakarta.annotation.PreDestroy;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.RefreshPolicy;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -35,11 +38,14 @@ public class ProductReindexService {
 
   private static final List<SaleStatus> INDEXABLE_STATUSES =
       List.of(SaleStatus.ON_SALE, SaleStatus.OUT_OF_STOCK);
-  private static final int BATCH_SIZE = 1000;
+  private static final int BATCH_SIZE = 2000;
+  private static final String INDEX_NAME = "products";
+  private static final String DEFAULT_REFRESH_INTERVAL = "1s";
 
   private final ProductRepo productRepo;
   private final ProductOptionRepo productOptionRepo;
-  private final ProductSearchRepository searchRepository;
+  private final ElasticsearchOperations operations;
+  private final ElasticsearchClient esClient;
 
   private final AtomicBoolean isRunning = new AtomicBoolean(false);
   private volatile ReindexStatus status = new ReindexStatus("IDLE", 0, 0L, null);
@@ -98,29 +104,62 @@ public class ProductReindexService {
     int total = 0;
     long lastId = 0L;
 
-    while (!cancelled && !Thread.currentThread().isInterrupted()) {
-      List<Product> batch = productRepo.findIndexableForReindex(
-          INDEXABLE_STATUSES, lastId, PageRequest.of(0, BATCH_SIZE));
-      if (batch.isEmpty()) {
-        break;
+    // 대량 적재 동안 refresh 를 멈춰 세그먼트 양산/머지 부하를 없앤다. 종료 시 반드시 복원.
+    pauseRefresh();
+    try {
+      while (!cancelled && !Thread.currentThread().isInterrupted()) {
+        List<Product> batch = productRepo.findIndexableForReindex(
+            INDEXABLE_STATUSES, lastId, PageRequest.of(0, BATCH_SIZE));
+        if (batch.isEmpty()) {
+          break;
+        }
+
+        List<Long> ids = batch.stream().map(Product::getId).toList();
+        Map<Long, List<String>> optionsByProduct = groupOptionNames(ids);
+
+        List<ProductDocument> docs = batch.stream()
+            .map(p -> ProductDocument.from(p, optionsByProduct.getOrDefault(p.getId(), List.of())))
+            .toList();
+        // bulk 마다 refresh 를 강제하지 않도록 RefreshPolicy.NONE 으로 색인한다.
+        operations.withRefreshPolicy(RefreshPolicy.NONE)
+            .save(docs, IndexCoordinates.of(INDEX_NAME));
+
+        total += docs.size();
+        lastId = ids.get(ids.size() - 1);
+        if (progressConsumer != null) {
+          progressConsumer.accept(total, lastId);
+        }
+        log.info("상품 재색인 진행: 누적 {} 건 (마지막 id={})", total, lastId);
       }
-
-      List<Long> ids = batch.stream().map(Product::getId).toList();
-      Map<Long, List<String>> optionsByProduct = groupOptionNames(ids);
-
-      List<ProductDocument> docs = batch.stream()
-          .map(p -> ProductDocument.from(p, optionsByProduct.getOrDefault(p.getId(), List.of())))
-          .toList();
-      searchRepository.saveAll(docs); // ES bulk 색인
-
-      total += docs.size();
-      lastId = ids.get(ids.size() - 1);
-      if (progressConsumer != null) {
-        progressConsumer.accept(total, lastId);
-      }
-      log.info("상품 재색인 진행: 누적 {} 건 (마지막 id={})", total, lastId);
+    } finally {
+      resumeRefresh();
     }
     return total;
+  }
+
+  /** 재색인 동안 refresh_interval 을 -1 로 설정해 자동 refresh 를 멈춘다. 실패해도 재색인은 진행. */
+  private void pauseRefresh() {
+    try {
+      esClient.indices().putSettings(p -> p
+          .index(INDEX_NAME)
+          .settings(s -> s.refreshInterval(t -> t.time("-1"))));
+      log.info("재색인 시작: refresh_interval 비활성화(-1)");
+    } catch (Exception e) {
+      log.warn("refresh_interval 비활성화 실패 — 기본 설정으로 재색인을 진행합니다.", e);
+    }
+  }
+
+  /** refresh_interval 을 기본값으로 복원하고 1회 수동 refresh 하여 적재 문서를 검색 가능하게 만든다. */
+  private void resumeRefresh() {
+    try {
+      esClient.indices().putSettings(p -> p
+          .index(INDEX_NAME)
+          .settings(s -> s.refreshInterval(t -> t.time(DEFAULT_REFRESH_INTERVAL))));
+      esClient.indices().refresh(r -> r.index(INDEX_NAME));
+      log.info("재색인 종료: refresh_interval 복원({}) 및 수동 refresh 완료", DEFAULT_REFRESH_INTERVAL);
+    } catch (Exception e) {
+      log.error("refresh_interval 복원 실패 — 인덱스가 refresh 비활성 상태로 남을 수 있습니다. 수동 확인 필요.", e);
+    }
   }
 
   private Map<Long, List<String>> groupOptionNames(List<Long> productIds) {

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexService.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.annotation.PreDestroy;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -21,10 +22,10 @@ import org.springframework.stereotype.Service;
 /**
  * 전체 재색인 배치 — 최초 도입 시 기존 상품 일괄 색인 및 드리프트 발생 시 정합성 회복용.
  *
- * <p>대용량을 고려해 (1) id 키셋 페이징으로 청크 단위 조회, (2) 청크별 옵션값을 한 번에 조회(N+1 회피),
+ * 대용량을 고려해 (1) id 키셋 페이징으로 청크 단위 조회, (2) 청크별 옵션값을 한 번에 조회(N+1 회피),
  * (3) ES bulk 색인({@code saveAll})으로 처리한다. 문서 ID = product.id 이므로 멱등하게 재실행 가능.
  *
- * <p>긴 단일 트랜잭션/영속성 컨텍스트 누적을 피하려고 클래스 레벨 트랜잭션을 두지 않는다.
+ * 긴 단일 트랜잭션/영속성 컨텍스트 누적을 피하려고 클래스 레벨 트랜잭션을 두지 않는다.
  * category 는 fetch join 으로 초기화되고 나머지 색인 필드는 모두 즉시 로딩이라 지연 로딩 문제는 없다.
  */
 @Slf4j
@@ -42,8 +43,7 @@ public class ProductReindexService {
 
   private final AtomicBoolean isRunning = new AtomicBoolean(false);
   private volatile ReindexStatus status = new ReindexStatus("IDLE", 0, 0L, null);
-
-  public record ReindexStatus(String state, int totalIndexed, long lastId, String errorMessage) {}
+  private volatile boolean cancelled = false;
 
   public ReindexStatus getStatus() {
     return status;
@@ -51,6 +51,7 @@ public class ProductReindexService {
 
   /** 색인 대상 전체를 청크 단위로 다시 색인한다. 총 색인 건수를 반환 (동기 방식). */
   public int reindexAll() {
+    cancelled = false;
     int total = runReindexing(null);
     log.info("상품 전체 재색인 완료: {} 건", total);
     return total;
@@ -64,23 +65,40 @@ public class ProductReindexService {
       return;
     }
     status = new ReindexStatus("RUNNING", 0, 0L, null);
+    cancelled = false;
     try {
       int total = runReindexing((t, id) -> status = new ReindexStatus("RUNNING", t, id, null));
-      status = new ReindexStatus("COMPLETED", total, status.lastId(), null);
-      log.info("상품 전체 재색인 완료: {} 건", total);
+      if (cancelled) {
+        status = new ReindexStatus("STOPPED", total, status.lastId(), "Application shutdown");
+        log.info("상품 전체 재색인 작업이 중단되었습니다: {} 건", total);
+      } else {
+        status = new ReindexStatus("COMPLETED", total, status.lastId(), null);
+        log.info("상품 전체 재색인 완료: {} 건", total);
+      }
     } catch (Exception e) {
-      log.error("재색인 중 에러 발생", e);
-      status = new ReindexStatus("FAILED", status.totalIndexed(), status.lastId(), e.getMessage());
+      if (cancelled) {
+        log.warn("애플리케이션 종료 중 재색인 중단 (예상된 예외): {}", e.getMessage());
+        status = new ReindexStatus("STOPPED", status.totalIndexed(), status.lastId(), "Application shutdown");
+      } else {
+        log.error("재색인 중 에러 발생", e);
+        status = new ReindexStatus("FAILED", status.totalIndexed(), status.lastId(), e.getMessage());
+      }
     } finally {
       isRunning.set(false);
     }
+  }
+
+  @PreDestroy
+  public void cancel() {
+    this.cancelled = true;
+    log.info("애플리케이션 종료 감지: 재색인 작업을 중단합니다.");
   }
 
   private int runReindexing(BiConsumer<Integer, Long> progressConsumer) {
     int total = 0;
     long lastId = 0L;
 
-    while (true) {
+    while (!cancelled && !Thread.currentThread().isInterrupted()) {
       List<Product> batch = productRepo.findIndexableForReindex(
           INDEXABLE_STATUSES, lastId, PageRequest.of(0, BATCH_SIZE));
       if (batch.isEmpty()) {
@@ -114,4 +132,6 @@ public class ProductReindexService {
     }
     return optionsByProduct;
   }
+
+  public record ReindexStatus(String state, int totalIndexed, long lastId, String errorMessage) {}
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductSearchIndexInitializer.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductSearchIndexInitializer.java
@@ -1,0 +1,40 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.stereotype.Component;
+
+/**
+ * 부팅 시 products 인덱스가 없으면 settings(nori)/mapping 과 함께 생성한다.
+ *
+ * <p>{@code @Document(createIndex = false)} 로 SDE 의 즉시 생성을 끄고 이 컴포넌트가 명시적으로 생성한다.
+ * ES 연결 실패 시에도 애플리케이션 부팅을 막지 않도록 예외를 격리한다.
+ * 테스트 등 ES 없는 환경은 {@code search.index.auto-create=false} 로 비활성화한다.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "search.index.auto-create", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+public class ProductSearchIndexInitializer implements ApplicationRunner {
+
+  private final ElasticsearchOperations operations;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    try {
+      IndexOperations indexOps = operations.indexOps(ProductDocument.class);
+      if (!indexOps.exists()) {
+        indexOps.createWithMapping();
+        log.info("ES products 인덱스를 생성했습니다.");
+      }
+    } catch (Exception e) {
+      log.warn("ES products 인덱스 초기화 실패 — 검색 사용 전 ES 연결 및 재색인을 확인하세요.", e);
+    }
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductSearchIndexInitializer.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/indexer/ProductSearchIndexInitializer.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 /**
  * 부팅 시 products 인덱스가 없으면 settings(nori)/mapping 과 함께 생성한다.
  *
- * <p>{@code @Document(createIndex = false)} 로 SDE 의 즉시 생성을 끄고 이 컴포넌트가 명시적으로 생성한다.
+ * {@code @Document(createIndex = false)} 로 SDE 의 즉시 생성을 끄고 이 컴포넌트가 명시적으로 생성한다.
  * ES 연결 실패 시에도 애플리케이션 부팅을 막지 않도록 예외를 격리한다.
  * 테스트 등 ES 없는 환경은 {@code search.index.auto-create=false} 로 비활성화한다.
  */

--- a/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchQueryRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchQueryRepository.java
@@ -1,0 +1,22 @@
+package com.example.WonkaoTalk.domain.search.repo;
+
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import java.util.List;
+
+/**
+ * ES 기반 상품 검색 쿼리. 상품명 + 옵션값을 통합 매칭하고 필터/정렬/커서를 적용하여
+ * 상품 ID 목록과 다음 커서를 산출한다.
+ */
+public interface ProductSearchQueryRepository {
+
+  ProductSearchResult search(
+      String keyword,
+      List<Long> categoryIds,
+      Integer minPrice,
+      Integer maxPrice,
+      ProductSortType sortType,
+      Long lastId,
+      Long lastSortValue,
+      int size
+  );
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchQueryRepositoryImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchQueryRepositoryImpl.java
@@ -38,11 +38,21 @@ public class ProductSearchQueryRepositoryImpl implements ProductSearchQueryRepos
       Long lastSortValue,
       int size
   ) {
-    // 상품명 + 옵션값(searchText copy_to)에 모든 토큰이 존재해야 매칭(AND). nori 가 토큰화/형태소 분석 담당.
-    Query match = Query.of(q -> q.match(m -> m
+    // 상품명 + 옵션값(searchText copy_to)에 모든 토큰이 존재해야 매칭(AND).
+    // nori(형태소 통째 토큰)로 못 잡는 부분 문자열("셔츠"→"티셔츠")은 ngram 서브필드로 보완한다.
+    // 두 방식 중 하나라도 매칭되면(should/min 1) 결과에 포함.
+    Query noriMatch = Query.of(q -> q.match(m -> m
         .field("searchText")
         .query(keyword)
         .operator(Operator.And)));
+    Query ngramMatch = Query.of(q -> q.match(m -> m
+        .field("searchText.ngram")
+        .query(keyword)
+        .operator(Operator.And)));
+    Query match = Query.of(q -> q.bool(b -> b
+        .should(noriMatch)
+        .should(ngramMatch)
+        .minimumShouldMatch("1")));
 
     List<Query> filters = buildFilters(categoryIds, minPrice, maxPrice);
 

--- a/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchQueryRepositoryImpl.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchQueryRepositoryImpl.java
@@ -1,0 +1,131 @@
+package com.example.WonkaoTalk.domain.search.repo;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.json.JsonData;
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductSearchQueryRepositoryImpl implements ProductSearchQueryRepository {
+
+  private static final List<FieldValue> VISIBLE_STATUSES =
+      List.of(FieldValue.of("ON_SALE"), FieldValue.of("OUT_OF_STOCK"));
+
+  private final ElasticsearchOperations operations;
+
+  @Override
+  public ProductSearchResult search(
+      String keyword,
+      List<Long> categoryIds,
+      Integer minPrice,
+      Integer maxPrice,
+      ProductSortType sortType,
+      Long lastId,
+      Long lastSortValue,
+      int size
+  ) {
+    // 상품명 + 옵션값(searchText copy_to)에 모든 토큰이 존재해야 매칭(AND). nori 가 토큰화/형태소 분석 담당.
+    Query match = Query.of(q -> q.match(m -> m
+        .field("searchText")
+        .query(keyword)
+        .operator(Operator.And)));
+
+    List<Query> filters = buildFilters(categoryIds, minPrice, maxPrice);
+
+    Query query = Query.of(q -> q.bool(b -> b.must(match).filter(filters)));
+
+    Sort sort = Sort.by(primaryDirection(sortType), sortField(sortType))
+        .and(Sort.by(Sort.Direction.DESC, "id"));
+
+    NativeQueryBuilder builder = NativeQuery.builder()
+        .withQuery(query)
+        .withPageable(PageRequest.of(0, size + 1, sort));
+
+    if (lastId != null && lastSortValue != null) {
+      builder.withSearchAfter(List.of(lastSortValue, lastId));
+    }
+
+    SearchHits<ProductDocument> hits = operations.search(builder.build(), ProductDocument.class);
+
+    List<SearchHit<ProductDocument>> hitList = hits.getSearchHits();
+    boolean hasNext = hitList.size() > size;
+    if (hasNext) {
+      hitList = hitList.subList(0, size);
+    }
+
+    List<Long> ids = hitList.stream()
+        .map(h -> h.getContent().getId())
+        .toList();
+
+    Long nextCursorId = null;
+    Long nextCursorSortValue = null;
+    if (hasNext && !hitList.isEmpty()) {
+      List<Object> sortValues = hitList.get(hitList.size() - 1).getSortValues();
+      nextCursorSortValue = ((Number) sortValues.get(0)).longValue();
+      nextCursorId = ((Number) sortValues.get(1)).longValue();
+    }
+
+    return new ProductSearchResult(ids, hasNext, nextCursorId, nextCursorSortValue);
+  }
+
+  private List<Query> buildFilters(List<Long> categoryIds, Integer minPrice, Integer maxPrice) {
+    List<Query> filters = new ArrayList<>();
+
+    filters.add(Query.of(q -> q.terms(t -> t
+        .field("status")
+        .terms(tt -> tt.value(VISIBLE_STATUSES)))));
+
+    if (categoryIds != null && !categoryIds.isEmpty()) {
+      List<FieldValue> values = categoryIds.stream()
+          .map(id -> FieldValue.of(id.longValue()))
+          .toList();
+      filters.add(Query.of(q -> q.terms(t -> t
+          .field("categoryId")
+          .terms(tt -> tt.value(values)))));
+    }
+
+    if (minPrice != null || maxPrice != null) {
+      filters.add(Query.of(q -> q.range(r -> r.untyped(u -> {
+        u.field("discountedPrice");
+        if (minPrice != null) {
+          u.gte(JsonData.of(minPrice));
+        }
+        if (maxPrice != null) {
+          u.lte(JsonData.of(maxPrice));
+        }
+        return u;
+      }))));
+    }
+
+    return filters;
+  }
+
+  private String sortField(ProductSortType sortType) {
+    return switch (sortType) {
+      case POPULAR -> "likeCount";
+      case LATEST -> "createdAt";
+      case PRICE_ASC, PRICE_DESC -> "discountedPrice";
+    };
+  }
+
+  private Sort.Direction primaryDirection(ProductSortType sortType) {
+    return switch (sortType) {
+      case POPULAR, LATEST, PRICE_DESC -> Sort.Direction.DESC;
+      case PRICE_ASC -> Sort.Direction.ASC;
+    };
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchRepository.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchRepository.java
@@ -1,0 +1,12 @@
+package com.example.WonkaoTalk.domain.search.repo;
+
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+/**
+ * 상품 문서 색인/삭제용 Spring Data Elasticsearch 레포지토리.
+ * 검색(매칭/정렬/페이지네이션)은 {@link ProductSearchQueryRepository} 에서 처리한다.
+ */
+public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchResult.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/repo/ProductSearchResult.java
@@ -1,0 +1,19 @@
+package com.example.WonkaoTalk.domain.search.repo;
+
+import java.util.List;
+
+/**
+ * ES 상품 검색 결과 — 매칭/정렬된 상품 ID 목록과 커서 정보.
+ * 상세 데이터는 이 ID 목록으로 DB 에서 fetch 한다(구현 계획 §3 방식 A).
+ */
+public record ProductSearchResult(
+    List<Long> ids,
+    boolean hasNext,
+    Long nextCursorId,
+    Long nextCursorSortValue
+) {
+
+  public static ProductSearchResult empty() {
+    return new ProductSearchResult(List.of(), false, null, null);
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/service/SearchService.java
@@ -23,10 +23,12 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -66,9 +68,18 @@ public class SearchService {
       categoryIds = getAllCategoryIds(request.categoryId());
     }
 
-    ProductSearchPage productPage = useDatabaseEngine()
-        ? searchProductsViaDatabase(request, categoryIds, sortType, size)
-        : searchProductsViaElasticsearch(request, categoryIds, sortType, size);
+    ProductSearchPage productPage;
+    if (useDatabaseEngine()) {
+      productPage = searchProductsViaDatabase(request, categoryIds, sortType, size);
+    } else {
+      try {
+        productPage = searchProductsViaElasticsearch(request, categoryIds, sortType, size);
+      } catch (Exception e) {
+        log.error("Elasticsearch 검색 중 장애 발생 — DB 검색 엔진으로 Fallback을 수행합니다. keyword={}",
+            request.keyword(), e);
+        productPage = searchProductsViaDatabase(request, categoryIds, sortType, size);
+      }
+    }
 
     List<StoreResult> storeResults = storeRepository.findByNameContaining(request.keyword())
         .stream()

--- a/src/main/java/com/example/WonkaoTalk/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/search/service/SearchService.java
@@ -11,12 +11,19 @@ import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse.ProductResult;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse.StoreInfo;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse.StoreResult;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchQueryRepository;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchResult;
 import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +35,11 @@ public class SearchService {
   private final ProductRepo productRepository;
   private final CategoryRepo categoryRepository;
   private final StoreRepo storeRepository;
+  private final ProductSearchQueryRepository productSearchQueryRepository;
+
+  /** 상품 검색 엔진 선택: elasticsearch(기본) | database(폴백). */
+  @Value("${search.product.engine:elasticsearch}")
+  private String searchEngine;
 
   public SearchResponse search(SearchRequest request) {
     if (request.keyword() == null || request.keyword().isBlank()) {
@@ -54,16 +66,49 @@ public class SearchService {
       categoryIds = getAllCategoryIds(request.categoryId());
     }
 
+    ProductSearchPage productPage = useDatabaseEngine()
+        ? searchProductsViaDatabase(request, categoryIds, sortType, size)
+        : searchProductsViaElasticsearch(request, categoryIds, sortType, size);
+
+    List<StoreResult> storeResults = storeRepository.findByNameContaining(request.keyword())
+        .stream()
+        .map(s -> new StoreResult(s.getId(), s.getName(), s.getThumbnail(), s.getDescription()))
+        .toList();
+
+    return new SearchResponse(storeResults, productPage.products(), productPage.hasNext(),
+        productPage.nextCursorId(), productPage.nextCursorSortValue());
+  }
+
+  /** ES: 매칭·정렬·커서로 상품 ID 목록을 산출하고, 상세는 DB 에서 fetch 후 ES 순서로 재정렬(방식 A). */
+  private ProductSearchPage searchProductsViaElasticsearch(
+      SearchRequest request, List<Long> categoryIds, ProductSortType sortType, int size) {
+    ProductSearchResult es = productSearchQueryRepository.search(
+        request.keyword(), categoryIds, request.minPrice(), request.maxPrice(),
+        sortType, request.lastId(), request.lastSortValue(), size);
+
+    if (es.ids().isEmpty()) {
+      return new ProductSearchPage(List.of(), false, null, null);
+    }
+
+    Map<Long, Product> byId = productRepository.findWithStoreByIdIn(es.ids()).stream()
+        .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+    List<ProductResult> productResults = es.ids().stream()
+        .map(byId::get)
+        .filter(Objects::nonNull)
+        .map(this::toProductResult)
+        .toList();
+
+    return new ProductSearchPage(productResults, es.hasNext(), es.nextCursorId(),
+        es.nextCursorSortValue());
+  }
+
+  /** DB LIKE 폴백 경로 — ES 불가 시 가용성 확보용(search.product.engine=database). */
+  private ProductSearchPage searchProductsViaDatabase(
+      SearchRequest request, List<Long> categoryIds, ProductSortType sortType, int size) {
     List<Product> products = productRepository.findWithSearch(
-        request.keyword(),
-        categoryIds,
-        request.minPrice(),
-        request.maxPrice(),
-        sortType,
-        request.lastId(),
-        request.lastSortValue(),
-        size
-    );
+        request.keyword(), categoryIds, request.minPrice(), request.maxPrice(),
+        sortType, request.lastId(), request.lastSortValue(), size);
 
     boolean hasNext = products.size() > size;
     if (hasNext) {
@@ -82,14 +127,11 @@ public class SearchService {
         .map(this::toProductResult)
         .toList();
 
-    // TODO: ElasticSearch 등 검색 엔진 도입 시 동의어(예: 레드-빨강) 처리 및 스코어 기반 정렬 고도화 필요
-    List<StoreResult> storeResults = storeRepository.findByNameContaining(request.keyword())
-        .stream()
-        .map(s -> new StoreResult(s.getId(), s.getName(), s.getThumbnail(), s.getDescription()))
-        .toList();
+    return new ProductSearchPage(productResults, hasNext, nextCursorId, nextCursorSortValue);
+  }
 
-    return new SearchResponse(storeResults, productResults, hasNext, nextCursorId,
-        nextCursorSortValue);
+  private boolean useDatabaseEngine() {
+    return "database".equalsIgnoreCase(searchEngine);
   }
 
   private ProductResult toProductResult(Product product) {
@@ -122,4 +164,12 @@ public class SearchService {
         .forEach(child -> result.add(child.getId()));
     return result;
   }
+
+  /** 상품 검색 결과 페이지(상품 목록 + 커서) — 엔진 공통 내부 표현. */
+  private record ProductSearchPage(
+      List<ProductResult> products,
+      boolean hasNext,
+      Long nextCursorId,
+      Long nextCursorSortValue
+  ) {}
 }

--- a/src/main/resources/elasticsearch/product-index-settings.json
+++ b/src/main/resources/elasticsearch/product-index-settings.json
@@ -1,0 +1,14 @@
+{
+  "analysis": {
+    "analyzer": {
+      "nori_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": [
+          "nori_part_of_speech",
+          "lowercase"
+        ]
+      }
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/product-settings.json
+++ b/src/main/resources/elasticsearch/product-settings.json
@@ -1,0 +1,17 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "nori_user_tokenizer": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
+      }
+    },
+    "analyzer": {
+      "nori_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_user_tokenizer",
+        "filter": ["lowercase", "nori_part_of_speech"]
+      }
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/product-settings.json
+++ b/src/main/resources/elasticsearch/product-settings.json
@@ -4,6 +4,12 @@
       "nori_user_tokenizer": {
         "type": "nori_tokenizer",
         "decompound_mode": "mixed"
+      },
+      "ngram_tokenizer": {
+        "type": "ngram",
+        "min_gram": 2,
+        "max_gram": 3,
+        "token_chars": ["letter", "digit"]
       }
     },
     "analyzer": {
@@ -11,6 +17,11 @@
         "type": "custom",
         "tokenizer": "nori_user_tokenizer",
         "filter": ["lowercase", "nori_part_of_speech"]
+      },
+      "ngram_analyzer": {
+        "type": "custom",
+        "tokenizer": "ngram_tokenizer",
+        "filter": ["lowercase"]
       }
     }
   }

--- a/src/test/java/com/example/WonkaoTalk/config/SearchTestContainerConfig.java
+++ b/src/test/java/com/example/WonkaoTalk/config/SearchTestContainerConfig.java
@@ -1,0 +1,37 @@
+package com.example.WonkaoTalk.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * ES 통합 테스트용 컨테이너 설정. ES + analysis-nori 플러그인 이미지를 인라인으로 빌드해
+ * {@code @ServiceConnection} 으로 spring.elasticsearch.uris 를 자동 주입한다.
+ *
+ * <p>운영용 elasticsearch.Dockerfile 과 동일한 구성(ES 9.2.8 + analysis-nori)을 유지한다.
+ * Dockerfile 을 직접 build context 로 쓰지 않고 인라인 빌더를 쓰는 이유는, 프로젝트 디렉터리 전체가
+ * Docker build context 로 전송되는 비용/이슈를 피하기 위함이다.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class SearchTestContainerConfig {
+
+  private static final String ES_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:9.2.8";
+
+  @Bean
+  @ServiceConnection
+  public ElasticsearchContainer elasticsearchContainer() throws Exception {
+    String image = new ImageFromDockerfile("wonkao-talk-es-nori", false)
+        .withDockerfileFromBuilder(builder -> builder
+            .from(ES_IMAGE)
+            .run("elasticsearch-plugin install --batch analysis-nori")
+            .build())
+        .get();
+    return new ElasticsearchContainer(
+        DockerImageName.parse(image)
+            .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
+        .withEnv("xpack.security.enabled", "false");
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/config/SearchTestContainerConfig.java
+++ b/src/test/java/com/example/WonkaoTalk/config/SearchTestContainerConfig.java
@@ -11,7 +11,7 @@ import org.testcontainers.utility.DockerImageName;
  * ES 통합 테스트용 컨테이너 설정. ES + analysis-nori 플러그인 이미지를 인라인으로 빌드해
  * {@code @ServiceConnection} 으로 spring.elasticsearch.uris 를 자동 주입한다.
  *
- * <p>운영용 elasticsearch.Dockerfile 과 동일한 구성(ES 9.2.8 + analysis-nori)을 유지한다.
+ * 운영용 elasticsearch.Dockerfile 과 동일한 구성(ES 9.2.8 + analysis-nori)을 유지한다.
  * Dockerfile 을 직접 build context 로 쓰지 않고 인라인 빌더를 쓰는 이유는, 프로젝트 디렉터리 전체가
  * Docker build context 로 전송되는 비용/이슈를 피하기 위함이다.
  */

--- a/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/product/service/ProductDeleteServiceTest.java
@@ -21,6 +21,7 @@ import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ class ProductDeleteServiceTest {
   @Mock private StoreRepo storeRepo;
   @Mock private ProductRepo productRepo;
   @Mock private OrderItemRepo orderItemRepo;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks private ProductDeleteService productDeleteService;
 

--- a/src/test/java/com/example/WonkaoTalk/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/controller/SearchControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
+import com.example.WonkaoTalk.domain.search.indexer.ProductReindexService;
 import com.example.WonkaoTalk.domain.search.service.SearchService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +27,9 @@ class SearchControllerTest {
   @Mock
   private SearchService searchService;
 
+  @Mock
+  private ProductReindexService reindexService;
+
   @InjectMocks
   private SearchController searchController;
 
@@ -42,5 +46,33 @@ class SearchControllerTest {
     assertThat(result.getBody()).isNotNull();
     assertThat(result.getBody().getStatus()).isEqualTo("SUCCESS");
     assertThat(result.getBody().getData()).isSameAs(serviceResult);
+  }
+
+  @Test
+  @DisplayName("재색인 시작 시 202 Accepted 응답을 반환한다")
+  void reindex_returnsAcceptedResponse() {
+    ProductReindexService.ReindexStatus status = new ProductReindexService.ReindexStatus("RUNNING", 0, 0L, null);
+    when(reindexService.getStatus()).thenReturn(status);
+
+    ResponseEntity<ApiResponse<ProductReindexService.ReindexStatus>> result = searchController.reindex();
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getStatus()).isEqualTo("SUCCESS");
+    assertThat(result.getBody().getData()).isSameAs(status);
+  }
+
+  @Test
+  @DisplayName("재색인 상태 조회 시 200 OK 응답을 반환한다")
+  void getReindexStatus_returnsOkResponse() {
+    ProductReindexService.ReindexStatus status = new ProductReindexService.ReindexStatus("COMPLETED", 100, 150L, null);
+    when(reindexService.getStatus()).thenReturn(status);
+
+    ResponseEntity<ApiResponse<ProductReindexService.ReindexStatus>> result = searchController.getReindexStatus();
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getStatus()).isEqualTo("SUCCESS");
+    assertThat(result.getBody().getData()).isSameAs(status);
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/controller/SearchControllerTest.java
@@ -1,0 +1,46 @@
+package com.example.WonkaoTalk.domain.search.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
+import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
+import com.example.WonkaoTalk.domain.search.service.SearchService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * 검색 컨트롤러 단위 테스트 — 서비스 결과를 200 OK + ApiResponse 로 감싸 반환하는지 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class SearchControllerTest {
+
+  @Mock
+  private SearchService searchService;
+
+  @InjectMocks
+  private SearchController searchController;
+
+  @Test
+  @DisplayName("검색 결과를 200 OK 와 SUCCESS 응답으로 감싸 반환한다")
+  void search_wrapsServiceResultInOkResponse() {
+    SearchRequest request = new SearchRequest("셔츠", null, null, null, "popular", null, null, 20);
+    SearchResponse serviceResult = new SearchResponse(List.of(), List.of(), false, null, null);
+    when(searchService.search(request)).thenReturn(serviceResult);
+
+    ResponseEntity<ApiResponse<SearchResponse>> result = searchController.search(request);
+
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getBody()).isNotNull();
+    assertThat(result.getBody().getStatus()).isEqualTo("SUCCESS");
+    assertThat(result.getBody().getData()).isSameAs(serviceResult);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexEventListenerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexEventListenerTest.java
@@ -1,0 +1,51 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.domain.product.event.ProductIndexRequestedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * 색인 이벤트 리스너 단위 테스트 — op 별 위임과 예외 격리(ES 장애가 트랜잭션을 깨지 않음)를 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProductIndexEventListenerTest {
+
+  @Mock
+  private ProductIndexService indexService;
+
+  @InjectMocks
+  private ProductIndexEventListener listener;
+
+  @Test
+  @DisplayName("UPSERT 이벤트는 indexById 로 위임한다")
+  void handle_upsert_delegatesToIndexById() {
+    listener.handle(ProductIndexRequestedEvent.upsert(1L));
+
+    verify(indexService).indexById(1L);
+  }
+
+  @Test
+  @DisplayName("DELETE 이벤트는 deleteById 로 위임한다")
+  void handle_delete_delegatesToDeleteById() {
+    listener.handle(ProductIndexRequestedEvent.delete(2L));
+
+    verify(indexService).deleteById(2L);
+  }
+
+  @Test
+  @DisplayName("색인 중 예외가 나도 밖으로 전파하지 않는다")
+  void handle_swallowsException() {
+    doThrow(new RuntimeException("ES down")).when(indexService).indexById(3L);
+
+    assertThatCode(() -> listener.handle(ProductIndexRequestedEvent.upsert(3L)))
+        .doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductIndexServiceTest.java
@@ -1,0 +1,129 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * 단건 색인 서비스 단위 테스트. ProductDocument.from() 의 문서 변환 경로까지 함께 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductIndexServiceTest {
+
+  @Mock
+  private ProductRepo productRepo;
+
+  @Mock
+  private ProductOptionRepo productOptionRepo;
+
+  @Mock
+  private ProductSearchRepository searchRepository;
+
+  @InjectMocks
+  private ProductIndexService indexService;
+
+  @Test
+  @DisplayName("색인 대상이면 옵션값을 포함한 문서를 저장한다")
+  void indexById_savesDocument_whenIndexable() {
+    Product product = indexableProduct(1L);
+    when(productRepo.findById(1L)).thenReturn(Optional.of(product));
+    when(productOptionRepo.findOptionNamesByProductId(1L)).thenReturn(List.of("흰색", "검정"));
+
+    indexService.indexById(1L);
+
+    ArgumentCaptor<ProductDocument> captor = ArgumentCaptor.forClass(ProductDocument.class);
+    verify(searchRepository).save(captor.capture());
+    ProductDocument doc = captor.getValue();
+    assertThat(doc.getId()).isEqualTo(1L);
+    assertThat(doc.getName()).isEqualTo("티셔츠");
+    assertThat(doc.getOptionValues()).containsExactly("흰색", "검정");
+    assertThat(doc.getCategoryId()).isEqualTo(10L);
+    assertThat(doc.getStatus()).isEqualTo("ON_SALE");
+    verify(searchRepository, never()).deleteById(any());
+  }
+
+  @Test
+  @DisplayName("상품이 존재하지 않으면 색인 문서를 삭제한다")
+  void indexById_deletesDocument_whenProductNotFound() {
+    when(productRepo.findById(1L)).thenReturn(Optional.empty());
+
+    indexService.indexById(1L);
+
+    verify(searchRepository).deleteById(1L);
+    verify(searchRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("소프트 삭제된 상품이면 색인 문서를 삭제한다")
+  void indexById_deletesDocument_whenSoftDeleted() {
+    Product product = org.mockito.Mockito.mock(Product.class);
+    when(product.getDeletedAt()).thenReturn(LocalDateTime.now());
+    when(productRepo.findById(1L)).thenReturn(Optional.of(product));
+
+    indexService.indexById(1L);
+
+    verify(searchRepository).deleteById(1L);
+    verify(searchRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("판매상태가 노출 대상이 아니면 색인 문서를 삭제한다")
+  void indexById_deletesDocument_whenStatusNotIndexable() {
+    Product product = org.mockito.Mockito.mock(Product.class);
+    when(product.getDeletedAt()).thenReturn(null);
+    when(product.getStatus()).thenReturn(SaleStatus.STOP_SALE);
+    when(productRepo.findById(1L)).thenReturn(Optional.of(product));
+
+    indexService.indexById(1L);
+
+    verify(searchRepository).deleteById(1L);
+    verify(searchRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("deleteById 는 색인 레포지토리에 위임한다")
+  void deleteById_delegatesToRepository() {
+    indexService.deleteById(9L);
+
+    verify(searchRepository).deleteById(9L);
+  }
+
+  private Product indexableProduct(Long id) {
+    Category category = org.mockito.Mockito.mock(Category.class);
+    when(category.getId()).thenReturn(10L);
+
+    Product product = org.mockito.Mockito.mock(Product.class);
+    when(product.getId()).thenReturn(id);
+    when(product.getName()).thenReturn("티셔츠");
+    when(product.getDeletedAt()).thenReturn(null);
+    when(product.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    when(product.getCategory()).thenReturn(category);
+    when(product.getDiscountedPrice()).thenReturn(10000);
+    when(product.getLikeCount()).thenReturn(5);
+    when(product.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 1, 0, 0));
+    return product;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexServiceTest.java
@@ -107,6 +107,24 @@ class ProductReindexServiceTest {
     verify(searchRepository, never()).saveAll(any());
   }
 
+  @Test
+  @DisplayName("재색인 중에 취소되면 작업을 중단한다")
+  void reindexAll_stops_whenCancelledDuringExecution() {
+    Product p1 = product(1L);
+    when(productRepo.findIndexableForReindex(any(), any(), any()))
+        .thenAnswer(invocation -> {
+          reindexService.cancel();
+          return List.of(p1);
+        });
+    when(productOptionRepo.findOptionNamesByProductIds(List.of(1L)))
+        .thenReturn(List.of());
+
+    int total = reindexService.reindexAll();
+
+    assertThat(total).isEqualTo(1);
+    verify(searchRepository).saveAll(any());
+  }
+
   private Product product(Long id) {
     Category category = org.mockito.Mockito.mock(Category.class);
     when(category.getId()).thenReturn(10L);

--- a/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexServiceTest.java
@@ -1,0 +1,124 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.domain.product.entity.Category;
+import com.example.WonkaoTalk.domain.product.entity.Product;
+import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
+import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
+import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * 전체 재색인 배치 단위 테스트 — 청크 반복, 옵션값 그룹핑, bulk 저장을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductReindexServiceTest {
+
+  @Mock
+  private ProductRepo productRepo;
+
+  @Mock
+  private ProductOptionRepo productOptionRepo;
+
+  @Mock
+  private ProductSearchRepository searchRepository;
+
+  @InjectMocks
+  private ProductReindexService reindexService;
+
+  @Captor
+  private ArgumentCaptor<List<ProductDocument>> docsCaptor;
+
+  @Test
+  @DisplayName("모든 청크를 색인하고 상품별 옵션값을 그룹핑한다")
+  void reindexAll_indexesBatch_andGroupsOptionsByProduct() {
+    Product p1 = product(1L);
+    Product p2 = product(2L);
+    // 첫 호출에 1건짜리 청크, 다음 호출에 빈 청크 → 루프 종료
+    when(productRepo.findIndexableForReindex(any(), any(), any()))
+        .thenReturn(List.of(p1, p2))
+        .thenReturn(List.of());
+    when(productOptionRepo.findOptionNamesByProductIds(List.of(1L, 2L)))
+        .thenReturn(List.of(
+            new Object[]{1L, "흰색"},
+            new Object[]{1L, "검정"},
+            new Object[]{2L, "블루"}));
+
+    int total = reindexService.reindexAll();
+
+    assertThat(total).isEqualTo(2);
+    verify(searchRepository).saveAll(docsCaptor.capture());
+    List<ProductDocument> docs = docsCaptor.getValue();
+    assertThat(docs).hasSize(2);
+
+    Map<Long, List<String>> optionsById = docs.stream()
+        .collect(Collectors.toMap(ProductDocument::getId, ProductDocument::getOptionValues));
+    assertThat(optionsById.get(1L)).containsExactlyInAnyOrder("흰색", "검정");
+    assertThat(optionsById.get(2L)).containsExactly("블루");
+  }
+
+  @Test
+  @DisplayName("옵션이 없는 상품은 빈 옵션값 목록으로 색인된다")
+  void reindexAll_indexesWithEmptyOptions_whenProductHasNoOptions() {
+    Product p1 = product(1L);
+    when(productRepo.findIndexableForReindex(any(), any(), any()))
+        .thenReturn(List.of(p1))
+        .thenReturn(List.of());
+    when(productOptionRepo.findOptionNamesByProductIds(List.of(1L)))
+        .thenReturn(List.of());
+
+    int total = reindexService.reindexAll();
+
+    assertThat(total).isEqualTo(1);
+    verify(searchRepository).saveAll(docsCaptor.capture());
+    assertThat(docsCaptor.getValue()).hasSize(1);
+    assertThat(docsCaptor.getValue().get(0).getOptionValues()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("색인 대상이 없으면 0을 반환하고 저장을 호출하지 않는다")
+  void reindexAll_returnsZero_whenNothingToIndex() {
+    when(productRepo.findIndexableForReindex(any(), any(), any())).thenReturn(List.of());
+
+    int total = reindexService.reindexAll();
+
+    assertThat(total).isZero();
+    verify(searchRepository, never()).saveAll(any());
+  }
+
+  private Product product(Long id) {
+    Category category = org.mockito.Mockito.mock(Category.class);
+    when(category.getId()).thenReturn(10L);
+
+    Product product = org.mockito.Mockito.mock(Product.class);
+    when(product.getId()).thenReturn(id);
+    when(product.getName()).thenReturn("티셔츠" + id);
+    when(product.getStatus()).thenReturn(SaleStatus.ON_SALE);
+    when(product.getCategory()).thenReturn(category);
+    when(product.getDiscountedPrice()).thenReturn(10000);
+    when(product.getLikeCount()).thenReturn(5);
+    when(product.getCreatedAt()).thenReturn(LocalDateTime.of(2024, 1, 1, 0, 0));
+    return product;
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductReindexServiceTest.java
@@ -6,13 +6,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.example.WonkaoTalk.domain.product.entity.Category;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.ProductOptionRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.search.document.ProductDocument;
-import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +27,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 
 /**
  * 전체 재색인 배치 단위 테스트 — 청크 반복, 옵션값 그룹핑, bulk 저장을 검증한다.
@@ -42,7 +44,10 @@ class ProductReindexServiceTest {
   private ProductOptionRepo productOptionRepo;
 
   @Mock
-  private ProductSearchRepository searchRepository;
+  private ElasticsearchOperations operations;
+
+  @Mock
+  private ElasticsearchClient esClient;
 
   @InjectMocks
   private ProductReindexService reindexService;
@@ -64,11 +69,12 @@ class ProductReindexServiceTest {
             new Object[]{1L, "흰색"},
             new Object[]{1L, "검정"},
             new Object[]{2L, "블루"}));
+    when(operations.withRefreshPolicy(any())).thenReturn(operations);
 
     int total = reindexService.reindexAll();
 
     assertThat(total).isEqualTo(2);
-    verify(searchRepository).saveAll(docsCaptor.capture());
+    verify(operations).save(docsCaptor.capture(), any(IndexCoordinates.class));
     List<ProductDocument> docs = docsCaptor.getValue();
     assertThat(docs).hasSize(2);
 
@@ -87,11 +93,12 @@ class ProductReindexServiceTest {
         .thenReturn(List.of());
     when(productOptionRepo.findOptionNamesByProductIds(List.of(1L)))
         .thenReturn(List.of());
+    when(operations.withRefreshPolicy(any())).thenReturn(operations);
 
     int total = reindexService.reindexAll();
 
     assertThat(total).isEqualTo(1);
-    verify(searchRepository).saveAll(docsCaptor.capture());
+    verify(operations).save(docsCaptor.capture(), any(IndexCoordinates.class));
     assertThat(docsCaptor.getValue()).hasSize(1);
     assertThat(docsCaptor.getValue().get(0).getOptionValues()).isEmpty();
   }
@@ -104,7 +111,7 @@ class ProductReindexServiceTest {
     int total = reindexService.reindexAll();
 
     assertThat(total).isZero();
-    verify(searchRepository, never()).saveAll(any());
+    verify(operations, never()).save(any(), any(IndexCoordinates.class));
   }
 
   @Test
@@ -118,11 +125,12 @@ class ProductReindexServiceTest {
         });
     when(productOptionRepo.findOptionNamesByProductIds(List.of(1L)))
         .thenReturn(List.of());
+    when(operations.withRefreshPolicy(any())).thenReturn(operations);
 
     int total = reindexService.reindexAll();
 
     assertThat(total).isEqualTo(1);
-    verify(searchRepository).saveAll(any());
+    verify(operations).save(any(), any(IndexCoordinates.class));
   }
 
   private Product product(Long id) {

--- a/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductSearchIndexInitializerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/indexer/ProductSearchIndexInitializerTest.java
@@ -1,0 +1,66 @@
+package com.example.WonkaoTalk.domain.search.indexer;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+
+/**
+ * 부팅 시 인덱스 초기화 단위 테스트 — 부재 시 생성, 존재 시 스킵, ES 장애 시 부팅 비차단을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProductSearchIndexInitializerTest {
+
+  @Mock
+  private ElasticsearchOperations operations;
+
+  @Mock
+  private IndexOperations indexOps;
+
+  @InjectMocks
+  private ProductSearchIndexInitializer initializer;
+
+  @Test
+  @DisplayName("인덱스가 없으면 매핑과 함께 생성한다")
+  void run_createsIndex_whenAbsent() {
+    when(operations.indexOps(ProductDocument.class)).thenReturn(indexOps);
+    when(indexOps.exists()).thenReturn(false);
+
+    initializer.run(null);
+
+    verify(indexOps).createWithMapping();
+  }
+
+  @Test
+  @DisplayName("인덱스가 이미 있으면 생성하지 않는다")
+  void run_skipsCreate_whenExists() {
+    when(operations.indexOps(ProductDocument.class)).thenReturn(indexOps);
+    when(indexOps.exists()).thenReturn(true);
+
+    initializer.run(null);
+
+    verify(indexOps, never()).createWithMapping();
+  }
+
+  @Test
+  @DisplayName("ES 연결 실패 시 예외를 격리하여 부팅을 막지 않는다")
+  void run_swallowsException_whenElasticsearchUnavailable() {
+    when(operations.indexOps(ProductDocument.class))
+        .thenThrow(new RuntimeException("ES unavailable"));
+
+    assertThatCode(() -> initializer.run(null)).doesNotThrowAnyException();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/search/integration/ProductSearchQueryRepositoryImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/integration/ProductSearchQueryRepositoryImplTest.java
@@ -1,0 +1,163 @@
+package com.example.WonkaoTalk.domain.search.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.WonkaoTalk.config.SearchTestContainerConfig;
+import com.example.WonkaoTalk.config.TestContainerConfig;
+import com.example.WonkaoTalk.domain.product.enums.ProductSortType;
+import com.example.WonkaoTalk.domain.search.document.ProductDocument;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchQueryRepository;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchResult;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * ES + nori 기반 상품 검색의 핵심(옵션값 매칭)을 실제 ElasticSearch 컨테이너로 검증한다.
+ * Docker 가 없는 환경에서는 자동으로 비활성화된다(disabledWithoutDocker).
+ */
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+@Import({TestContainerConfig.class, SearchTestContainerConfig.class})
+@TestPropertySource(properties = "search.index.auto-create=false")
+class ProductSearchQueryRepositoryImplTest {
+
+  @Autowired
+  private ElasticsearchOperations operations;
+
+  @Autowired
+  private ProductSearchRepository searchRepository;
+
+  @Autowired
+  private ProductSearchQueryRepository queryRepository;
+
+  private IndexOperations indexOps;
+
+  @BeforeEach
+  void setUp() {
+    indexOps = operations.indexOps(ProductDocument.class);
+    if (indexOps.exists()) {
+      indexOps.delete();
+    }
+    indexOps.createWithMapping();
+  }
+
+  @Test
+  @DisplayName("'흰색 티셔츠' 검색 시 상품명 '티셔츠' + 옵션 '흰색' 상품이 매칭된다")
+  void matchesProductByNameAndOptionValue() {
+    index(1L, "티셔츠", List.of("흰색", "검정"), 1L, 10000, 5);
+    index(2L, "티셔츠", List.of("빨강", "파랑"), 1L, 10000, 99);
+    index(3L, "셔츠", List.of("흰색"), 1L, 10000, 50);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "흰색 티셔츠", null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("옵션값 단일 토큰으로도 매칭된다")
+  void matchesByOptionValueOnly() {
+    index(1L, "후드티", List.of("아이보리"), 1L, 20000, 3);
+    index(2L, "후드티", List.of("블랙"), 1L, 20000, 7);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "아이보리", null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("모든 토큰이 매칭되지 않으면(AND) 결과에서 제외된다")
+  void excludesProduct_whenNotAllTokensMatch() {
+    // '흰색'은 매칭되나 '바지'는 상품명/옵션 어디에도 없음
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "흰색 바지", null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("POPULAR 정렬 시 likeCount 내림차순으로 정렬된다")
+  void sortsByLikeCountDesc_whenPopular() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 10);
+    index(2L, "반팔 티셔츠", List.of("흰색"), 1L, 10000, 80);
+    index(3L, "긴팔 티셔츠", List.of("흰색"), 1L, 10000, 40);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "티셔츠", null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(2L, 3L, 1L);
+  }
+
+  @Test
+  @DisplayName("가격 필터(discountedPrice)가 적용된다")
+  void appliesPriceFilter() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 8000, 5);
+    index(2L, "티셔츠", List.of("흰색"), 1L, 20000, 5);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "티셔츠", null, 10000, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(2L);
+  }
+
+  @Test
+  @DisplayName("size+1 조회로 hasNext 와 다음 커서를 산출한다")
+  void detectsHasNextAndCursor() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 30);
+    index(2L, "티셔츠", List.of("흰색"), 1L, 10000, 20);
+    index(3L, "티셔츠", List.of("흰색"), 1L, 10000, 10);
+    refresh();
+
+    ProductSearchResult page = queryRepository.search(
+        "티셔츠", null, null, null, ProductSortType.POPULAR, null, null, 2);
+
+    assertThat(page.ids()).containsExactly(1L, 2L);
+    assertThat(page.hasNext()).isTrue();
+    assertThat(page.nextCursorId()).isEqualTo(2L);
+    assertThat(page.nextCursorSortValue()).isEqualTo(20L);
+
+    // 커서 이후 페이지
+    ProductSearchResult next = queryRepository.search(
+        "티셔츠", null, null, null, ProductSortType.POPULAR,
+        page.nextCursorId(), page.nextCursorSortValue(), 2);
+
+    assertThat(next.ids()).containsExactly(3L);
+    assertThat(next.hasNext()).isFalse();
+  }
+
+  private void index(Long id, String name, List<String> optionValues, Long categoryId,
+      Integer discountedPrice, Integer likeCount) {
+    searchRepository.save(ProductDocument.builder()
+        .id(id)
+        .name(name)
+        .optionValues(optionValues)
+        .categoryId(categoryId)
+        .discountedPrice(discountedPrice)
+        .likeCount(likeCount)
+        .createdAt(1_700_000_000_000L + id)
+        .status("ON_SALE")
+        .build());
+  }
+
+  private void refresh() {
+    indexOps.refresh();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/search/integration/ProductSearchQueryRepositoryImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/integration/ProductSearchQueryRepositoryImplTest.java
@@ -79,6 +79,31 @@ class ProductSearchQueryRepositoryImplTest {
   }
 
   @Test
+  @DisplayName("상품명의 부분 문자열('셔츠'⊂'티셔츠')로도 매칭된다 — ngram 부분매칭")
+  void matchesByPartialSubstring() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    index(2L, "원피스", List.of("블루"), 1L, 10000, 50);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "셔츠", null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("부분 문자열이라도 어디에도 없으면 매칭되지 않는다")
+  void excludesProduct_whenSubstringAbsent() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "바지", null, null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).isEmpty();
+  }
+
+  @Test
   @DisplayName("모든 토큰이 매칭되지 않으면(AND) 결과에서 제외된다")
   void excludesProduct_whenNotAllTokensMatch() {
     // '흰색'은 매칭되나 '바지'는 상품명/옵션 어디에도 없음

--- a/src/test/java/com/example/WonkaoTalk/domain/search/integration/ProductSearchQueryRepositoryImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/integration/ProductSearchQueryRepositoryImplTest.java
@@ -131,6 +131,48 @@ class ProductSearchQueryRepositoryImplTest {
   }
 
   @Test
+  @DisplayName("categoryIds 필터에 해당하는 카테고리의 상품만 조회된다")
+  void appliesCategoryFilter() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    index(2L, "티셔츠", List.of("흰색"), 2L, 10000, 5);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "티셔츠", List.of(1L), null, null, ProductSortType.POPULAR, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(1L);
+  }
+
+  @Test
+  @DisplayName("PRICE_ASC 정렬 시 discountedPrice 오름차순으로 정렬된다")
+  void sortsByPriceAsc_whenPriceAsc() {
+    index(1L, "티셔츠", List.of("흰색"), 1L, 30000, 5);
+    index(2L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    index(3L, "티셔츠", List.of("흰색"), 1L, 20000, 5);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "티셔츠", null, null, null, ProductSortType.PRICE_ASC, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(2L, 3L, 1L);
+  }
+
+  @Test
+  @DisplayName("LATEST 정렬 시 createdAt 내림차순으로 정렬된다")
+  void sortsByCreatedAtDesc_whenLatest() {
+    // index 헬퍼가 createdAt = 1_700_000_000_000 + id 로 부여 → id 가 클수록 최신
+    index(1L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    index(2L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    index(3L, "티셔츠", List.of("흰색"), 1L, 10000, 5);
+    refresh();
+
+    ProductSearchResult result = queryRepository.search(
+        "티셔츠", null, null, null, ProductSortType.LATEST, null, null, 10);
+
+    assertThat(result.ids()).containsExactly(3L, 2L, 1L);
+  }
+
+  @Test
   @DisplayName("가격 필터(discountedPrice)가 적용된다")
   void appliesPriceFilter() {
     index(1L, "티셔츠", List.of("흰색"), 1L, 8000, 5);

--- a/src/test/java/com/example/WonkaoTalk/domain/search/integration/SearchRepoCustomImplTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/integration/SearchRepoCustomImplTest.java
@@ -1,7 +1,8 @@
 package com.example.WonkaoTalk.domain.search.integration;
 
-// TODO: ElasticSearch 도입 시 이 테스트 파일 전체를 재작성해야 합니다.
-//       현재는 JPA LIKE 기반의 단순 문자열 포함 검색을 검증합니다.
+// 이 테스트는 ProductRepoCustomImpl.findWithSearch(JPA LIKE) — 즉 ES 불가 시의
+// DB 폴백 경로(search.product.engine=database)를 검증한다.
+// 옵션값 매칭/형태소 분석을 포함한 기본 검색 경로(ES)는 ProductSearchQueryRepositoryImplTest 에서 검증한다.
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/example/WonkaoTalk/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/service/SearchServiceTest.java
@@ -197,6 +197,24 @@ class SearchServiceTest {
     assertThat(response.stores().get(0).storeName()).isEqualTo("셔츠스토어");
   }
 
+  @Test
+  @DisplayName("ES 검색 중 예외 발생 시 DB 검색으로 Fallback을 수행한다")
+  void fallbacksToDatabase_whenElasticsearchThrowsException() {
+    SearchRequest request = new SearchRequest("셔츠", null, null, null, "popular", null, null, 2);
+    when(productSearchQueryRepository.search(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenThrow(new RuntimeException("Elasticsearch connection failed"));
+
+    List<Product> products = mockProducts(2);
+    when(productRepository.findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(products);
+
+    SearchResponse response = searchService.search(request);
+
+    assertThat(response.products()).hasSize(2);
+    verify(productRepository).findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt());
+    verify(productRepository, never()).findWithStoreByIdIn(any());
+  }
+
   // ── DB 폴백 경로 (search.product.engine=database) ─────────────────────────────
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/search/service/SearchServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.WonkaoTalk.common.exception.BusinessException;
@@ -16,6 +18,8 @@ import com.example.WonkaoTalk.domain.product.repo.CategoryRepo;
 import com.example.WonkaoTalk.domain.product.repo.ProductRepo;
 import com.example.WonkaoTalk.domain.search.dto.SearchRequest;
 import com.example.WonkaoTalk.domain.search.dto.SearchResponse;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchQueryRepository;
+import com.example.WonkaoTalk.domain.search.repo.ProductSearchResult;
 import com.example.WonkaoTalk.domain.store.entity.Store;
 import com.example.WonkaoTalk.domain.store.repo.StoreRepo;
 import java.time.LocalDateTime;
@@ -31,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -44,6 +49,9 @@ class SearchServiceTest {
 
   @Mock
   private StoreRepo storeRepository;
+
+  @Mock
+  private ProductSearchQueryRepository productSearchQueryRepository;
 
   @InjectMocks
   private SearchService searchService;
@@ -130,11 +138,71 @@ class SearchServiceTest {
     assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PROD_CATEGORY_NOT_FOUND);
   }
 
-  // ── 페이지네이션 ────────────────────────────────────────────────────────────
+  // ── ES 검색 경로 ──────────────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("결과가 size보다 많으면 hasNext가 true이고 마지막 항목이 제거된다")
-  void hasNext_trueAndLastItemRemoved_whenResultsExceedSize() {
+  @DisplayName("ES 결과 ID 순서대로 상품을 반환하고 커서를 그대로 전달한다")
+  void returnsProductsInElasticsearchOrder_andPassesThroughCursor() {
+    SearchRequest request = new SearchRequest("셔츠", null, null, null, "popular", null, null, 2);
+    when(productSearchQueryRepository.search(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(new ProductSearchResult(List.of(2L, 1L), true, 1L, 50L));
+
+    Product p1 = mockProduct(1L, 10000, 8000, 10, LocalDateTime.now());
+    Product p2 = mockProduct(2L, 5000, 5000, 50, LocalDateTime.now());
+    // DB는 순서를 보장하지 않으므로 ES 순서(2,1)와 다른 순서로 반환
+    when(productRepository.findWithStoreByIdIn(List.of(2L, 1L))).thenReturn(List.of(p1, p2));
+
+    SearchResponse response = searchService.search(request);
+
+    assertThat(response.products()).extracting(SearchResponse.ProductResult::id)
+        .containsExactly(2L, 1L);
+    assertThat(response.hasNext()).isTrue();
+    assertThat(response.nextCursorId()).isEqualTo(1L);
+    assertThat(response.nextCursorSortValue()).isEqualTo(50L);
+  }
+
+  @Test
+  @DisplayName("ES 결과가 없으면 빈 상품 목록을 반환하고 DB 조회를 하지 않는다")
+  void returnsEmpty_whenElasticsearchHasNoMatch() {
+    SearchRequest request = defaultRequest("없는상품");
+    when(productSearchQueryRepository.search(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(ProductSearchResult.empty());
+
+    SearchResponse response = searchService.search(request);
+
+    assertThat(response.products()).isEmpty();
+    assertThat(response.hasNext()).isFalse();
+    assertThat(response.nextCursorId()).isNull();
+    verify(productRepository, never()).findWithStoreByIdIn(any());
+  }
+
+  @Test
+  @DisplayName("stores는 키워드로 검색된 스토어 목록을 반환한다(federated)")
+  void stores_returnsMatchingStores() {
+    SearchRequest request = defaultRequest("셔츠");
+    when(productSearchQueryRepository.search(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        .thenReturn(ProductSearchResult.empty());
+
+    Store store = mock(Store.class);
+    when(store.getId()).thenReturn(1L);
+    when(store.getName()).thenReturn("셔츠스토어");
+    when(store.getThumbnail()).thenReturn("http://thumbnail.png");
+    when(store.getDescription()).thenReturn("셔츠 전문점");
+    when(storeRepository.findByNameContaining("셔츠")).thenReturn(List.of(store));
+
+    SearchResponse response = searchService.search(request);
+
+    assertThat(response.stores()).hasSize(1);
+    assertThat(response.stores().get(0).storeId()).isEqualTo(1L);
+    assertThat(response.stores().get(0).storeName()).isEqualTo("셔츠스토어");
+  }
+
+  // ── DB 폴백 경로 (search.product.engine=database) ─────────────────────────────
+
+  @Test
+  @DisplayName("DB 폴백: 결과가 size보다 많으면 hasNext가 true이고 마지막 항목이 제거된다")
+  void databaseFallback_hasNext_trueAndLastItemRemoved() {
+    ReflectionTestUtils.setField(searchService, "searchEngine", "database");
     SearchRequest request = new SearchRequest("셔츠", null, null, null, "popular", null, null, 2);
     List<Product> products = mockProducts(3);
     when(productRepository.findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
@@ -149,25 +217,9 @@ class SearchServiceTest {
   }
 
   @Test
-  @DisplayName("결과가 size 이하면 hasNext가 false이고 커서가 null이다")
-  void hasNext_falseAndCursorNull_whenResultsWithinSize() {
-    SearchRequest request = new SearchRequest("셔츠", null, null, null, "popular", null, null, 5);
-    List<Product> products = mockProducts(3);
-    when(productRepository.findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
-        .thenReturn(products);
-
-    SearchResponse response = searchService.search(request);
-
-    assertThat(response.hasNext()).isFalse();
-    assertThat(response.nextCursorId()).isNull();
-    assertThat(response.nextCursorSortValue()).isNull();
-  }
-
-  // ── 커서 값 계산 ─────────────────────────────────────────────────────────────
-
-  @Test
-  @DisplayName("POPULAR 정렬의 커서값은 likeCount이다")
-  void cursorValue_isLikeCount_whenSortByPopular() {
+  @DisplayName("DB 폴백: POPULAR 정렬의 커서값은 likeCount이다")
+  void databaseFallback_cursorValue_isLikeCount_whenSortByPopular() {
+    ReflectionTestUtils.setField(searchService, "searchEngine", "database");
     SearchRequest request = new SearchRequest("셔츠", null, null, null, "popular", null, null, 1);
 
     Product first = mockProduct(1L, 10000, 8000, 42, LocalDateTime.now());
@@ -181,8 +233,9 @@ class SearchServiceTest {
   }
 
   @Test
-  @DisplayName("LATEST 정렬의 커서값은 createdAt의 epoch milliseconds이다")
-  void cursorValue_isCreatedAtEpochMillis_whenSortByLatest() {
+  @DisplayName("DB 폴백: LATEST 정렬의 커서값은 createdAt의 epoch milliseconds이다")
+  void databaseFallback_cursorValue_isCreatedAtEpochMillis_whenSortByLatest() {
+    ReflectionTestUtils.setField(searchService, "searchEngine", "database");
     LocalDateTime createdAt = LocalDateTime.of(2024, 6, 1, 12, 0, 0);
     long expectedMillis = createdAt.toInstant(ZoneOffset.UTC).toEpochMilli();
 
@@ -196,44 +249,6 @@ class SearchServiceTest {
     SearchResponse response = searchService.search(request);
 
     assertThat(response.nextCursorSortValue()).isEqualTo(expectedMillis);
-  }
-
-  @Test
-  @DisplayName("PRICE 정렬의 커서값은 discountedPrice이다")
-  void cursorValue_isDiscountedPrice_whenSortByPrice() {
-    SearchRequest request = new SearchRequest("셔츠", null, null, null, "price_asc", null, null, 1);
-
-    Product first = mockProduct(1L, 10000, 8000, 5, LocalDateTime.now());
-    Product second = mockProduct(2L, 15000, 15000, 3, LocalDateTime.now());
-    when(productRepository.findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
-        .thenReturn(List.of(first, second));
-
-    SearchResponse response = searchService.search(request);
-
-    assertThat(response.nextCursorSortValue()).isEqualTo(8000L);
-  }
-
-  // ── 응답 구조 ────────────────────────────────────────────────────────────────
-
-  @Test
-  @DisplayName("stores는 키워드로 검색된 스토어 목록을 반환한다")
-  void stores_returnsMatchingStores() {
-    SearchRequest request = defaultRequest("셔츠");
-    when(productRepository.findWithSearch(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
-        .thenReturn(List.of());
-
-    Store store = mock(Store.class);
-    when(store.getId()).thenReturn(1L);
-    when(store.getName()).thenReturn("셔츠스토어");
-    when(store.getThumbnail()).thenReturn("http://thumbnail.png");
-    when(store.getDescription()).thenReturn("셔츠 전문점");
-    when(storeRepository.findByNameContaining("셔츠")).thenReturn(List.of(store));
-
-    SearchResponse response = searchService.search(request);
-
-    assertThat(response.stores()).hasSize(1);
-    assertThat(response.stores().get(0).storeId()).isEqualTo(1L);
-    assertThat(response.stores().get(0).storeName()).isEqualTo("셔츠스토어");
   }
 
   // ── 헬퍼 ────────────────────────────────────────────────────────────────────

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,6 +5,14 @@ spring:
   profiles:
     active: local, secret
 
+# 테스트 기본값: ES 미연결 환경에서 부팅 가능하도록 인덱스 자동생성/ES 검색을 끈다.
+# ES 통합 테스트는 @TestPropertySource 로 elasticsearch 엔진과 auto-create 를 켠다.
+search:
+  index:
+    auto-create: false
+  product:
+    engine: database
+
 jwt:
   # TODO: 배포 시 환경변수로 jwt secret key 주입 필요
   # secret: ${JWT_SECRET_KEY} # 시스템 환경변수에서 값을 주입받음


### PR DESCRIPTION
## 📌 관련 이슈
- #124

## 📝 작업 내용
- 상품 검색 기능에 elasticsearch를 도입하였습니다.
- 이에 따라 테스트 코드를 수정했습니다.

## ✅ 작업 결과 
- es 도입 전 후 성능 지표 결과 (상품 데이터 100만건, 50VUs, 20s)
<img width="1273" height="597" alt="화면 캡처 2026-06-09 084227" src="https://github.com/user-attachments/assets/15b62b2e-02e3-4d73-bddd-14679f1dd3ca" />

## 🎸 기타
- 기존 도커 컨테이너를 down시킨 후 새로 띄워 주셔야 합니다. 최초 실행시에는 시간이 조금 걸릴 수 있습니다(nori 형태소 분석기 설치 관련)
- 아마 실행시키고 검색을 하면 결과가 안나올겁니다. 이때는 재색인 API (/search/reindex)를 실행해 주셔야 검색이 됩니다. 별도의 관리자 권한이 존재하지 않으므로, 원활한 테스트를 위해 특별한 권한 없이 실행할 수 있도록 만들었습니다.
- 재색인 작업은 백그라운드에서 진행됩니다.
- 동의어 처리의 경우, 동의어 사전을 따로 만들어야 해서 별도 이슈로 진행하겠습니다
- application-local에 다음 내용을 추가해야 합니다
```
spring:
  elasticsearch:
    uris: http://localhost:9200
 ```