### PR TITLE
Test/132: Order/Payment 테스트코드 커버리지 확장

### DIFF
--- a/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
@@ -20,6 +20,8 @@ import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderDetailResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderItemDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderListResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderPreviewRequest;
+import com.example.WonkaoTalk.domain.order.dto.OrderPreviewResponse;
 import com.example.WonkaoTalk.domain.order.entity.Delivery;
 import com.example.WonkaoTalk.domain.order.entity.DeliveryStatus;
 import com.example.WonkaoTalk.domain.order.entity.Order;
@@ -87,11 +89,115 @@ public class OrderServiceTest {
   @DisplayName("주문 미리보기 검증")
   class PreviewOrderTest {
 
-    // TODO: success_previewOrder
-    // TODO: fail_previewOrder_duplicatedVariantId - 중복 variantId면 BAD_REQUEST
-    // TODO: fail_previewOrder_variantNotFound - 존재하지 않는 variantId면 NOT_FOUND
-    // TODO: fail_previewOrder_variantUnavailable - ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE
-    // TODO: fail_previewOrder_stockInsufficient - 재고 부족이면 PROD_STOCK_INSUFFICIENT
+    @Test
+    @DisplayName("주문 미리보기 성공")
+    public void success_previewOrder() {
+      //given
+      OrderPreviewRequest request = mockOrderPreviewRequest();
+      ProductVariant productVariant = mockProductVariant();
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(productVariant));
+      when(productVariant.getId()).thenReturn(10L);
+      when(productVariant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(productVariant.getStock()).thenReturn(2);
+
+      Product product = mock(Product.class);
+      when(productVariant.getProduct()).thenReturn(product);
+      when(product.getId()).thenReturn(100L);
+      when(product.getName()).thenReturn("테스트 상품");
+      when(product.getThumbnail()).thenReturn("thumbnail.jpg");
+      when(product.getPrice()).thenReturn(12000);
+      when(product.getDiscountedPrice()).thenReturn(10000);
+
+      //when
+      OrderPreviewResponse response = orderService.previewOrder(request);
+
+      //then
+      assertThat(response.items()).hasSize(1);
+      assertThat(response.items().getFirst().productId()).isEqualTo(100L);
+      assertThat(response.items().getFirst().variantId()).isEqualTo(10L);
+      assertThat(response.items().getFirst().productName()).isEqualTo("테스트 상품");
+      assertThat(response.items().getFirst().price()).isEqualTo(12000L);
+      assertThat(response.items().getFirst().discountedPrice()).isEqualTo(10000L);
+      assertThat(response.items().getFirst().quantity()).isEqualTo(2);
+      assertThat(response.items().getFirst().itemOriginalAmount()).isEqualTo(24000L);
+      assertThat(response.items().getFirst().itemDiscountAmount()).isEqualTo(4000L);
+      assertThat(response.items().getFirst().itemFinalAmount()).isEqualTo(20000L);
+
+      assertThat(response.summary().originalAmount()).isEqualTo(24000L);
+      assertThat(response.summary().discountAmount()).isEqualTo(4000L);
+      assertThat(response.summary().finalAmount()).isEqualTo(20000L);
+
+    }
+
+    @Test
+    @DisplayName("중복 variantId면 BAD_REQUEST를 반환한다.")
+    public void fail_previewOrder_duplicatedVariantId() {
+      //given
+      OrderPreviewRequest request = new OrderPreviewRequest(
+          List.of(
+              new OrderItemDto(10L, 2),
+              new OrderItemDto(10L, 2))
+      );
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.previewOrder(request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 variantId면 NOT_FOUND 반환")
+    public void fail_previewOrder_variantNotFound() {
+      //given
+      OrderPreviewRequest request = mockOrderPreviewRequest();
+      ProductVariant variant = mock(ProductVariant.class);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(Collections.emptyList());
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.previewOrder(request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE를 반환한다.")
+    public void fail_previewOrder_variantUnavailable() {
+      //given
+      OrderPreviewRequest request = mockOrderPreviewRequest();
+      ProductVariant productVariant = mock(ProductVariant.class);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(productVariant));
+      when(productVariant.getId()).thenReturn(10L);
+      when(productVariant.getStatus()).thenReturn(SaleStatus.STOP_SALE);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.previewOrder(request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_VARIANT_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("재고 부족이면 PROD_STOCK_INSUFFICIENT를 반환한다.")
+    public void fail_previewOrder_stockInsufficient() {
+      //given
+      OrderPreviewRequest request = mockOrderPreviewRequest();
+      ProductVariant variant = mock(ProductVariant.class);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(variant));
+      when(variant.getId()).thenReturn(10L);
+      when(variant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(variant.getStock()).thenReturn(1);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.previewOrder(request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
+    }
   }
 
   @Nested
@@ -163,7 +269,6 @@ public class OrderServiceTest {
       verify(orderStockService, never()).decreaseStocks(anyList());
     }
 
-    // TODO: fail_createOrder_duplicatedVariantId - 중복 variantId면 BAD_REQUEST
     @Test
     @DisplayName("중복 variantId면 BAD_REQUEST")
     public void fail_createOrder_duplicatedVariantId() {
@@ -184,7 +289,6 @@ public class OrderServiceTest {
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
     }
 
-    // TODO: fail_createOrder_variantNotFound - 존재하지 않는 variantId면 NOT_FOUND
     @Test
     @DisplayName("존재하지 않는 variantId면 NOT_FOUND")
     public void fail_createOrder_variantNotFound() {
@@ -202,7 +306,6 @@ public class OrderServiceTest {
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
     }
 
-    // TODO: fail_createOrder_variantUnavailable - ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE
     @Test
     @DisplayName("ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE")
     public void fail_createOrder_variantUnavailable() {
@@ -224,7 +327,6 @@ public class OrderServiceTest {
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_VARIANT_UNAVAILABLE);
     }
 
-    // TODO: fail_createOrder_stockInsufficient - 재고 부족이면 PROD_STOCK_INSUFFICIENT
     @Test
     @DisplayName("요청 수량보다 재고가 부족하면 PROD_STOCK_INSUFFICIENT 예외가 발생한다.")
     public void fail_createOrder_stockInsufficient() {
@@ -246,7 +348,6 @@ public class OrderServiceTest {
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
     }
 
-    // TODO: success_createOrder_retryDuplicatedOrderNumber - 주문번호 중복 후 재시도 성공
     @Test
     @DisplayName("주문번호가 중복되면 재시도 후 주문을 생성한다.")
     public void success_createOrder_retryDuplicatedOrderNumber() {
@@ -280,7 +381,6 @@ public class OrderServiceTest {
 
     }
 
-    // TODO: fail_createOrder_orderNumberDuplicatedFiveTimes - 5회 모두 중복이면 SERVER_ERROR
     @Test
     @DisplayName("OrderNumber가 5회 모두 중복이면 SERVER_ERROR를 발생한다.")
     public void fail_createOrder_orderNumberDuplicatedFiveTimes() {
@@ -315,7 +415,6 @@ public class OrderServiceTest {
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SERVER_ERROR);
     }
 
-    // TODO: success_createOrder_multipleItems_orderTitle - 상품 2개 이상이면 "상품명 외 N건"
     @Test
     @DisplayName("상품 2개 이상이면 주문 명에 상품명 외 N건을 반환한다.")
     public void success_createOrder_multipleItems_orderTitle() {
@@ -376,7 +475,6 @@ public class OrderServiceTest {
   @DisplayName("주문 목록 조회 검증")
   class GetOrdersTest {
 
-    // TODO: success_getOrders - 주문 목록과 PageInfo를 반환한다.
     @Test
     @DisplayName("주문 목록과 PageInfo를 반환한다.")
     public void success_getOrders() {
@@ -411,7 +509,6 @@ public class OrderServiceTest {
   @DisplayName("주문 상세 조회 검증")
   class GetOrderDetailTest {
 
-    // TODO: success_getOrderDetail - 주문, 주문 상품, 결제 목록을 반환한다.
     @Test
     @DisplayName("주문, 주문 상품, 결제 목록을 반환한다.")
     public void success_getOrderDetail() {
@@ -440,7 +537,6 @@ public class OrderServiceTest {
           .containsExactly("포카칩", "썬칩");
     }
 
-    // TODO: fail_getOrderDetail_orderNotFound - 주문이 없으면 ORDER_NOT_FOUND
     @Test
     @DisplayName("주문 상세 조회 시 주문이 없으면 ORDER_NOT_FOUND를 반환한다.")
     public void fail_getOrderDetail_orderNotFound() {
@@ -456,7 +552,6 @@ public class OrderServiceTest {
       assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ORDER_NOT_FOUND);
     }
 
-    // TODO: fail_getOrderDetail_orderItemNotFound - 주문 상품이 비어 있으면 ORDER_ITEM_NOT_FOUND
     @Test
     @DisplayName("주문 상세 조회 시 주문 아이템 비어 있으면 ORDER_ITEM_NOT_FOUND를 반환한다.")
     public void fail_getOrderDetail_orderItemNotFound() {
@@ -473,6 +568,7 @@ public class OrderServiceTest {
           () -> orderService.getOrderDetail(1L, order.getOrderId()));
 
       //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ORDER_ITEM_NOT_FOUND);
     }
   }
 
@@ -705,5 +801,11 @@ public class OrderServiceTest {
     lenient().when(payment.getApprovedAt()).thenReturn(LocalDateTime.now());
 
     return payment;
+  }
+
+  private OrderPreviewRequest mockOrderPreviewRequest() {
+    return new OrderPreviewRequest(
+        List.of(new OrderItemDto(10L, 2))
+    );
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/order/service/OrderServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,20 +17,29 @@ import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateRequest.DeliveryRequestDto;
 import com.example.WonkaoTalk.domain.order.dto.OrderCreateResponse;
+import com.example.WonkaoTalk.domain.order.dto.OrderDetailResponse;
 import com.example.WonkaoTalk.domain.order.dto.OrderItemDto;
+import com.example.WonkaoTalk.domain.order.dto.OrderListResponse;
 import com.example.WonkaoTalk.domain.order.entity.Delivery;
 import com.example.WonkaoTalk.domain.order.entity.DeliveryStatus;
 import com.example.WonkaoTalk.domain.order.entity.Order;
 import com.example.WonkaoTalk.domain.order.entity.OrderItem;
+import com.example.WonkaoTalk.domain.order.entity.OrderStatus;
 import com.example.WonkaoTalk.domain.order.repo.DeliveryRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderItemRepo;
 import com.example.WonkaoTalk.domain.order.repo.OrderRepo;
+import com.example.WonkaoTalk.domain.payment.entity.Payment;
+import com.example.WonkaoTalk.domain.payment.entity.PaymentStatus;
+import com.example.WonkaoTalk.domain.payment.entity.PgProvider;
+import com.example.WonkaoTalk.domain.payment.repo.PaymentRepo;
 import com.example.WonkaoTalk.domain.product.entity.Product;
 import com.example.WonkaoTalk.domain.product.entity.ProductVariant;
 import com.example.WonkaoTalk.domain.product.enums.SaleStatus;
 import com.example.WonkaoTalk.domain.product.repo.ProductVariantRepo;
 import com.example.WonkaoTalk.domain.user.entity.User;
 import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,6 +51,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 public class OrderServiceTest {
@@ -61,122 +75,23 @@ public class OrderServiceTest {
   private DeliveryRepo deliveryRepo;
 
   @Mock
+  private PaymentRepo paymentRepo;
+
+  @Mock
   private OrderStockService orderStockService;
 
   @InjectMocks
   private OrderService orderService;
 
   @Nested
-  @DisplayName("중복 variantId 검증")
-  class ValidateDuplicateVariantTest {
+  @DisplayName("주문 미리보기 검증")
+  class PreviewOrderTest {
 
-    @Test
-    @DisplayName("중복 variantId가 있으면 BAD_REQUEST 예외가 발생한다.")
-    public void fail_validateDuplicateVariant_duplicatedVariantId() {
-      //given
-      OrderItemDto item1 = new OrderItemDto(1L, 1);
-      OrderItemDto item2 = new OrderItemDto(1L, 2);
-
-      //when
-      BusinessException exception = assertThrows(BusinessException.class,
-          () -> orderService.validateDuplicateVariant(List.of(item1, item2)));
-
-      //then
-      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
-    }
-
-    @Test
-    @DisplayName("중복 variantId가 없으면 예외가 발생하지 않는다.")
-    public void success_validateDuplicateVariant() {
-      //given
-      OrderItemDto item1 = new OrderItemDto(1L, 1);
-      OrderItemDto item2 = new OrderItemDto(2L, 2);
-
-      //when then
-      assertThatCode(() -> orderService.validateDuplicateVariant(List.of(item1, item2)))
-          .doesNotThrowAnyException();
-    }
-  }
-
-  @Nested
-  @DisplayName("variant 존재 검증")
-  class ValidateVariantExistTest {
-
-    @Test
-    @DisplayName("조회하지 않은 variantId가 있으면 NOT_FOUND 예외가 발생한다.")
-    public void fail_validateVariantExist_variantIdNotFound() {
-      //given
-      List<Long> variantIds = List.of(1L, 2L);
-      ProductVariant variant = mock(ProductVariant.class);
-      Map<Long, ProductVariant> variantMap = Map.of(1L, variant);
-
-      //when
-      BusinessException exception = assertThrows(BusinessException.class,
-          () -> orderService.validateVariantExist(variantIds, variantMap));
-
-      //then
-      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("요청한 variantId가 모두 있으면 예외가 발생하지 않는다.")
-    public void success_validateVariantExist() {
-      //given
-      List<Long> variantIds = List.of(1L, 2L);
-      ProductVariant variant1 = mock(ProductVariant.class);
-      ProductVariant variant2 = mock(ProductVariant.class);
-      Map<Long, ProductVariant> variantMap = Map.of(1L, variant1, 2L, variant2);
-
-      //when then
-      assertThatCode(() -> orderService.validateVariantExist(variantIds, variantMap))
-          .doesNotThrowAnyException();
-    }
-  }
-
-  @Nested
-  @DisplayName("variant 재고 검증")
-  class ValidateVariantStockTest {
-
-    @Test
-    @DisplayName("요청한 수량보다 재고가 많으면 예외가 발생하지 않는다.")
-    public void success_validateVariantStock() {
-      //given
-      OrderItemDto item1 = new OrderItemDto(1L, 1);
-      OrderItemDto item2 = new OrderItemDto(2L, 2);
-
-      ProductVariant variant1 = mock(ProductVariant.class);
-      ProductVariant variant2 = mock(ProductVariant.class);
-      Map<Long, ProductVariant> variantMap = Map.of(1L, variant1, 2L, variant2);
-
-      when(variant1.getStock()).thenReturn(10);
-      when(variant2.getStock()).thenReturn(10);
-
-      //when then
-      assertThatCode(() -> orderService.validateVariantStock(List.of(item1, item2), variantMap))
-          .doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("요청한 수량보다 재고가 적으면 PROD_STOCK_INSUFFICIENT 예외가 발생한다.")
-    public void fail_validateVariantStock_stockIsNotEnough() {
-      //given
-      OrderItemDto item1 = new OrderItemDto(1L, 1);
-      OrderItemDto item2 = new OrderItemDto(2L, 2);
-
-      ProductVariant variant1 = mock(ProductVariant.class);
-      ProductVariant variant2 = mock(ProductVariant.class);
-      Map<Long, ProductVariant> variantMap = Map.of(1L, variant1, 2L, variant2);
-
-      when(variant1.getStock()).thenReturn(10);
-      when(variant2.getStock()).thenReturn(1);
-
-      //when
-      BusinessException exception = assertThrows(BusinessException.class,
-          () -> orderService.validateVariantStock(List.of(item1, item2), variantMap));
-
-      //then
-      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
-    }
+    // TODO: success_previewOrder
+    // TODO: fail_previewOrder_duplicatedVariantId - 중복 variantId면 BAD_REQUEST
+    // TODO: fail_previewOrder_variantNotFound - 존재하지 않는 variantId면 NOT_FOUND
+    // TODO: fail_previewOrder_variantUnavailable - ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE
+    // TODO: fail_previewOrder_stockInsufficient - 재고 부족이면 PROD_STOCK_INSUFFICIENT
   }
 
   @Nested
@@ -247,6 +162,318 @@ public class OrderServiceTest {
       verify(orderRepo, never()).save(any(Order.class));
       verify(orderStockService, never()).decreaseStocks(anyList());
     }
+
+    // TODO: fail_createOrder_duplicatedVariantId - 중복 variantId면 BAD_REQUEST
+    @Test
+    @DisplayName("중복 variantId면 BAD_REQUEST")
+    public void fail_createOrder_duplicatedVariantId() {
+      //given
+      OrderCreateRequest request = new OrderCreateRequest(
+          List.of(new OrderItemDto(10L, 2), new OrderItemDto(10L, 2)),
+          mockDeliveryRequest(),
+          0L
+      );
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.createOrder(1L, request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    // TODO: fail_createOrder_variantNotFound - 존재하지 않는 variantId면 NOT_FOUND
+    @Test
+    @DisplayName("존재하지 않는 variantId면 NOT_FOUND")
+    public void fail_createOrder_variantNotFound() {
+      //given
+      OrderCreateRequest request = mockOrderCreateRequest();
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+      // 또는 when(productVariantRepo.findAllById(anyList())).thenReturn(Collection.EmptyList());
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of());
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.createOrder(1L, request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    // TODO: fail_createOrder_variantUnavailable - ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE
+    @Test
+    @DisplayName("ON_SALE이 아니면 PROD_VARIANT_UNAVAILABLE")
+    public void fail_createOrder_variantUnavailable() {
+      //given
+      OrderCreateRequest request = mockOrderCreateRequest();
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+      ProductVariant productVariant = mock(ProductVariant.class);
+      when(productVariant.getId()).thenReturn(10L);
+      when(productVariant.getStatus()).thenReturn(SaleStatus.STOP_SALE);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(productVariant));
+
+      // variantLId 목록으로
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.createOrder(1L, request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_VARIANT_UNAVAILABLE);
+    }
+
+    // TODO: fail_createOrder_stockInsufficient - 재고 부족이면 PROD_STOCK_INSUFFICIENT
+    @Test
+    @DisplayName("요청 수량보다 재고가 부족하면 PROD_STOCK_INSUFFICIENT 예외가 발생한다.")
+    public void fail_createOrder_stockInsufficient() {
+      //given
+      OrderCreateRequest request = mockOrderCreateRequest();
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+      ProductVariant productVariant = mock(ProductVariant.class);
+      when(productVariant.getId()).thenReturn(10L);
+      when(productVariant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(productVariant));
+      when(productVariant.getStock()).thenReturn(1);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.createOrder(1L, request));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
+    }
+
+    // TODO: success_createOrder_retryDuplicatedOrderNumber - 주문번호 중복 후 재시도 성공
+    @Test
+    @DisplayName("주문번호가 중복되면 재시도 후 주문을 생성한다.")
+    public void success_createOrder_retryDuplicatedOrderNumber() {
+      //given
+      OrderCreateRequest request = mockOrderCreateRequest();
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+      ProductVariant productVariant = mock(ProductVariant.class);
+      when(productVariant.getId()).thenReturn(10L);
+      when(productVariant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(productVariant));
+      when(productVariant.getStock()).thenReturn(2);
+      when(orderRepo.existsByOrderNumber(any()))
+          .thenReturn(true)
+          .thenReturn(false);
+      when(orderRepo.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+      when(orderItemRepo.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      Product product = mock(Product.class);
+      when(productVariant.getProduct()).thenReturn(product);
+      when(product.getId()).thenReturn(100L);
+      when(product.getName()).thenReturn("테스트 상품");
+      when(product.getThumbnail()).thenReturn("thumbnail.jpg");
+      when(product.getPrice()).thenReturn(12000);
+      when(product.getDiscountedPrice()).thenReturn(10000);
+      //when
+      OrderCreateResponse response = orderService.createOrder(1L, request);
+
+      //then
+      verify(orderRepo, times(2)).existsByOrderNumber(any());
+
+    }
+
+    // TODO: fail_createOrder_orderNumberDuplicatedFiveTimes - 5회 모두 중복이면 SERVER_ERROR
+    @Test
+    @DisplayName("OrderNumber가 5회 모두 중복이면 SERVER_ERROR를 발생한다.")
+    public void fail_createOrder_orderNumberDuplicatedFiveTimes() {
+      //given
+      OrderCreateRequest request = mockOrderCreateRequest();
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+      ProductVariant productVariant = mock(ProductVariant.class);
+      when(productVariant.getId()).thenReturn(10L);
+      when(productVariant.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(productVariantRepo.findAllById(List.of(10L))).thenReturn(List.of(productVariant));
+      when(productVariant.getStock()).thenReturn(2);
+      when(orderRepo.existsByOrderNumber(any()))
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(true);
+
+      Product product = mock(Product.class);
+      when(productVariant.getProduct()).thenReturn(product);
+      when(product.getId()).thenReturn(100L);
+      when(product.getName()).thenReturn("테스트 상품");
+      when(product.getThumbnail()).thenReturn("thumbnail.jpg");
+      when(product.getPrice()).thenReturn(12000);
+      when(product.getDiscountedPrice()).thenReturn(10000);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.createOrder(1L, request));
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SERVER_ERROR);
+    }
+
+    // TODO: success_createOrder_multipleItems_orderTitle - 상품 2개 이상이면 "상품명 외 N건"
+    @Test
+    @DisplayName("상품 2개 이상이면 주문 명에 상품명 외 N건을 반환한다.")
+    public void success_createOrder_multipleItems_orderTitle() {
+      //given
+      OrderCreateRequest request = new OrderCreateRequest(
+          List.of(new OrderItemDto(10L, 2), new OrderItemDto(11L, 2)),
+          mockDeliveryRequest(),
+          0L
+      );
+      User user = mock(User.class);
+      when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+      ProductVariant productVariant1 = mock(ProductVariant.class);
+      ProductVariant productVariant2 = mock(ProductVariant.class);
+
+      when(productVariant1.getId()).thenReturn(10L);
+      when(productVariant1.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(productVariant1.getStock()).thenReturn(2);
+      when(productVariant1.getName()).thenReturn("검정");
+
+      when(productVariant2.getId()).thenReturn(11L);
+      when(productVariant2.getStatus()).thenReturn(SaleStatus.ON_SALE);
+      when(productVariant2.getStock()).thenReturn(2);
+      when(productVariant2.getName()).thenReturn("흰색");
+
+      when(productVariantRepo.findAllById(List.of(10L, 11L))).thenReturn(
+          List.of(productVariant1, productVariant2));
+      when(orderRepo.existsByOrderNumber(any()))
+          .thenReturn(false);
+      when(orderRepo.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+      when(orderItemRepo.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+      Product product1 = mock(Product.class);
+
+      when(productVariant1.getProduct()).thenReturn(product1);
+      when(product1.getId()).thenReturn(100L);
+      when(product1.getName()).thenReturn("테스트 상품1");
+      when(product1.getThumbnail()).thenReturn("thumbnail.jpg");
+      when(product1.getPrice()).thenReturn(12000);
+      when(product1.getDiscountedPrice()).thenReturn(10000);
+
+      Product product2 = mock(Product.class);
+      when(productVariant2.getProduct()).thenReturn(product2);
+      when(product2.getId()).thenReturn(101L);
+      when(product2.getName()).thenReturn("테스트 상품2");
+      when(product2.getThumbnail()).thenReturn("thumbnail.jpg");
+      when(product2.getPrice()).thenReturn(12000);
+      when(product2.getDiscountedPrice()).thenReturn(10000);
+
+      //when
+      OrderCreateResponse response = orderService.createOrder(1L, request);
+
+      //then
+      assertThat(response.orderInfo().orderTitle()).isEqualTo("테스트 상품1 외 1건");
+    }
+  }
+
+  @Nested
+  @DisplayName("주문 목록 조회 검증")
+  class GetOrdersTest {
+
+    // TODO: success_getOrders - 주문 목록과 PageInfo를 반환한다.
+    @Test
+    @DisplayName("주문 목록과 PageInfo를 반환한다.")
+    public void success_getOrders() {
+      //given
+      Order order = mockOrder();
+      Pageable pageable = PageRequest.of(0, 10);
+      Page<Order> orderPage = new PageImpl<>(
+          List.of(order),
+          pageable,
+          1
+      );
+      when(orderRepo.findByUserId(1L, pageable)).thenReturn((orderPage));
+
+      //when
+      OrderListResponse response = orderService.getOrders(1L, pageable);
+
+      //then
+      assertThat(response).isNotNull();
+      assertThat(response.orders()).hasSize(1);
+
+      assertThat(response.pageInfo()).isNotNull();
+      assertThat(response.pageInfo().page()).isEqualTo(0);
+      assertThat(response.pageInfo().size()).isEqualTo(10);
+      assertThat(response.pageInfo().totalElements()).isEqualTo(1);
+      assertThat(response.pageInfo().totalPages()).isEqualTo(1);
+
+      assertThat(response.orders().get(0).orderId()).isEqualTo(order.getOrderId());
+    }
+  }
+
+  @Nested
+  @DisplayName("주문 상세 조회 검증")
+  class GetOrderDetailTest {
+
+    // TODO: success_getOrderDetail - 주문, 주문 상품, 결제 목록을 반환한다.
+    @Test
+    @DisplayName("주문, 주문 상품, 결제 목록을 반환한다.")
+    public void success_getOrderDetail() {
+      //given
+      Order order = mockOrder();
+      List<OrderItem> orderItems = List.of(
+          mockOrderItem(order, 1L, "포카칩"),
+          mockOrderItem(order, 2L, "썬칩"));
+      Payment payment = mockPayment();
+      when(orderRepo.findByUserIdAndOrderId(1L, order.getOrderId())).thenReturn(Optional.of(order));
+      when(orderItemRepo.findByOrder(order)).thenReturn(orderItems);
+      when(paymentRepo.findByOrder_OrderIdOrderByCreatedAtDesc(order.getOrderId())).thenReturn(
+          List.of(payment));
+
+      //when
+      OrderDetailResponse response = orderService.getOrderDetail(1L, order.getOrderId());
+
+      //then
+      assertThat(response).isNotNull();
+      assertThat(response.orderInfo()).isNotNull();
+      assertThat(response.orderItemInfoList()).hasSize(2);
+      assertThat(response.paymentInfo()).hasSize(1);
+
+      assertThat(response.orderItemInfoList())
+          .extracting("productName")
+          .containsExactly("포카칩", "썬칩");
+    }
+
+    // TODO: fail_getOrderDetail_orderNotFound - 주문이 없으면 ORDER_NOT_FOUND
+    @Test
+    @DisplayName("주문 상세 조회 시 주문이 없으면 ORDER_NOT_FOUND를 반환한다.")
+    public void fail_getOrderDetail_orderNotFound() {
+      //given
+      Order order = mockOrder();
+      when(orderRepo.findByUserIdAndOrderId(1L, order.getOrderId())).thenReturn(Optional.empty());
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.getOrderDetail(1L, order.getOrderId()));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ORDER_NOT_FOUND);
+    }
+
+    // TODO: fail_getOrderDetail_orderItemNotFound - 주문 상품이 비어 있으면 ORDER_ITEM_NOT_FOUND
+    @Test
+    @DisplayName("주문 상세 조회 시 주문 아이템 비어 있으면 ORDER_ITEM_NOT_FOUND를 반환한다.")
+    public void fail_getOrderDetail_orderItemNotFound() {
+      //given
+      Order order = mockOrder();
+      Payment payment = mockPayment();
+      when(orderRepo.findByUserIdAndOrderId(1L, order.getOrderId())).thenReturn(Optional.of(order));
+      when(orderItemRepo.findByOrder(order)).thenReturn(Collections.emptyList());
+      when(paymentRepo.findByOrder_OrderIdOrderByCreatedAtDesc(order.getOrderId())).thenReturn(
+          List.of(payment));
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.getOrderDetail(1L, order.getOrderId()));
+
+      //then
+    }
   }
 
   @Nested
@@ -289,17 +516,113 @@ public class OrderServiceTest {
     }
   }
 
+  @Nested
+  @DisplayName("주문 생성/미리보기 공통 검증")
+  class OrderValidationTest {
+
+    @Test
+    @DisplayName("중복 variantId가 있으면 BAD_REQUEST 예외가 발생한다.")
+    public void fail_validateDuplicateVariant_duplicatedVariantId() {
+      //given
+      OrderItemDto item1 = new OrderItemDto(1L, 1);
+      OrderItemDto item2 = new OrderItemDto(1L, 2);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.validateDuplicateVariant(List.of(item1, item2)));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("중복 variantId가 없으면 예외가 발생하지 않는다.")
+    public void success_validateDuplicateVariant() {
+      //given
+      OrderItemDto item1 = new OrderItemDto(1L, 1);
+      OrderItemDto item2 = new OrderItemDto(2L, 2);
+
+      //when then
+      assertThatCode(() -> orderService.validateDuplicateVariant(List.of(item1, item2)))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("조회하지 않은 variantId가 있으면 NOT_FOUND 예외가 발생한다.")
+    public void fail_validateVariantExist_variantIdNotFound() {
+      //given
+      List<Long> variantIds = List.of(1L, 2L);
+      ProductVariant variant = mock(ProductVariant.class);
+      Map<Long, ProductVariant> variantMap = Map.of(1L, variant);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.validateVariantExist(variantIds, variantMap));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("요청한 variantId가 모두 있으면 예외가 발생하지 않는다.")
+    public void success_validateVariantExist() {
+      //given
+      List<Long> variantIds = List.of(1L, 2L);
+      ProductVariant variant1 = mock(ProductVariant.class);
+      ProductVariant variant2 = mock(ProductVariant.class);
+      Map<Long, ProductVariant> variantMap = Map.of(1L, variant1, 2L, variant2);
+
+      //when then
+      assertThatCode(() -> orderService.validateVariantExist(variantIds, variantMap))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("요청한 수량보다 재고가 많으면 예외가 발생하지 않는다.")
+    public void success_validateVariantStock() {
+      //given
+      OrderItemDto item1 = new OrderItemDto(1L, 1);
+      OrderItemDto item2 = new OrderItemDto(2L, 2);
+
+      ProductVariant variant1 = mock(ProductVariant.class);
+      ProductVariant variant2 = mock(ProductVariant.class);
+      Map<Long, ProductVariant> variantMap = Map.of(1L, variant1, 2L, variant2);
+
+      when(variant1.getStock()).thenReturn(10);
+      when(variant2.getStock()).thenReturn(10);
+
+      //when then
+      assertThatCode(() -> orderService.validateVariantStock(List.of(item1, item2), variantMap))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("요청한 수량보다 재고가 적으면 PROD_STOCK_INSUFFICIENT 예외가 발생한다.")
+    public void fail_validateVariantStock_stockIsNotEnough() {
+      //given
+      OrderItemDto item1 = new OrderItemDto(1L, 1);
+      OrderItemDto item2 = new OrderItemDto(2L, 2);
+
+      ProductVariant variant1 = mock(ProductVariant.class);
+      ProductVariant variant2 = mock(ProductVariant.class);
+      Map<Long, ProductVariant> variantMap = Map.of(1L, variant1, 2L, variant2);
+
+      when(variant1.getStock()).thenReturn(10);
+      when(variant2.getStock()).thenReturn(1);
+
+      //when
+      BusinessException exception = assertThrows(BusinessException.class,
+          () -> orderService.validateVariantStock(List.of(item1, item2), variantMap));
+
+      //then
+      assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PROD_STOCK_INSUFFICIENT);
+    }
+  }
+
   private OrderCreateRequest mockOrderCreateRequest() {
     return new OrderCreateRequest(
         List.of(new OrderItemDto(10L, 2)),
-        new DeliveryRequestDto(
-            "홍길동",
-            "010-1234-5678",
-            "06234",
-            "서울특별시 강남구 테헤란로",
-            "101동 1001호",
-            "문 앞에 놔주세요"
-        ),
+        mockDeliveryRequest(),
         0L
     );
   }
@@ -326,5 +649,61 @@ public class OrderServiceTest {
     lenient().when(product.getThumbnail()).thenReturn("thumbnail.jpg");
     lenient().when(product.getPrice()).thenReturn(12000);
     lenient().when(product.getDiscountedPrice()).thenReturn(10000);
+  }
+
+  private DeliveryRequestDto mockDeliveryRequest() {
+    return new DeliveryRequestDto(
+        "홍길동",
+        "010-1234-5678",
+        "06234",
+        "서울특별시 강남구 테헤란로",
+        "101동 1001호",
+        "문 앞에 놔주세요"
+    );
+  }
+
+  private Order mockOrder() {
+    Order order = mock(Order.class);
+
+    lenient().when(order.getOrderId()).thenReturn(1L);
+    lenient().when(order.getOrderNumber()).thenReturn("ORD-123");
+    lenient().when(order.getOrderTitle()).thenReturn("테스트 상품");
+    lenient().when(order.getOrderStatus()).thenReturn(OrderStatus.PAYMENT_PENDING);
+    lenient().when(order.getFinalAmount()).thenReturn(10000L);
+    lenient().when(order.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+    return order;
+  }
+
+  private OrderItem mockOrderItem(Order order, Long itemId, String productName) {
+    OrderItem item = mock(OrderItem.class);
+
+    lenient().when(item.getId()).thenReturn(itemId);
+    lenient().when(item.getOrder()).thenReturn(order);
+    lenient().when(item.getProductName()).thenReturn(productName);
+    lenient().when(item.getOptionSummary()).thenReturn(productName + "옵션");
+    lenient().when(item.getProductAmount()).thenReturn(10000L);
+    lenient().when(item.getQuantity()).thenReturn(1);
+    lenient().when(item.getProductImageUrl()).thenReturn(productName + "thumbnail.jpg");
+
+    return item;
+  }
+
+  private ProductVariant mockProductVariant() {
+    ProductVariant variant = mock(ProductVariant.class);
+
+    return variant;
+  }
+
+  private Payment mockPayment() {
+    Payment payment = mock(Payment.class);
+    lenient().when(payment.getPaymentId()).thenReturn(1L);
+    lenient().when(payment.getStatus()).thenReturn(PaymentStatus.PAID);
+    lenient().when(payment.getPgProvider()).thenReturn(PgProvider.TOSS_PAYMENTS);
+    lenient().when(payment.getTotalAmount()).thenReturn(10000L);
+    lenient().when(payment.getRequestedAt()).thenReturn(LocalDateTime.now());
+    lenient().when(payment.getApprovedAt()).thenReturn(LocalDateTime.now());
+
+    return payment;
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
@@ -236,11 +236,13 @@ public class PaymentServiceTest {
       Long userId = 1L;
       Long orderId = 1L;
       Long paymentId = 10L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, paymentId, request.orderId(), 35000L);
-      TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(), "DONE",
+      TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(),
+          "DONE",
           35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
@@ -272,7 +274,8 @@ public class PaymentServiceTest {
     public void fail_confirm_paymentNotFound() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.empty());
 
@@ -290,7 +293,8 @@ public class PaymentServiceTest {
     public void fail_confirm_forbidden() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(2L, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
@@ -311,7 +315,8 @@ public class PaymentServiceTest {
     public void fail_confirm_invalidPaymentStatus() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
@@ -333,7 +338,8 @@ public class PaymentServiceTest {
     public void fail_confirm_invalidOrderStatus() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.CREATED, "가나 초콜릿 외 1건", 35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
 
@@ -353,7 +359,8 @@ public class PaymentServiceTest {
     public void fail_confirm_orderMismatch() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, "ORD-5678PAY", 35000L);
@@ -376,7 +383,8 @@ public class PaymentServiceTest {
     public void fail_confirm_amountMismatch() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 30000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          30000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
@@ -399,7 +407,8 @@ public class PaymentServiceTest {
     public void fail_confirm_emptyTossResponse() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
@@ -423,7 +432,8 @@ public class PaymentServiceTest {
     public void fail_confirm_tossOrderMismatch() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
@@ -449,11 +459,13 @@ public class PaymentServiceTest {
     public void fail_confirm_tossAmountMismatch() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
-      TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(), "DONE",
+      TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(),
+          "DONE",
           30000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
@@ -475,11 +487,13 @@ public class PaymentServiceTest {
     public void fail_confirm_tossStatusNotDone() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
-      TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(), "WAITING",
+      TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(),
+          "WAITING",
           35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
@@ -501,7 +515,8 @@ public class PaymentServiceTest {
     public void fail_confirm_tossPaymentsException() {
       //given
       Long userId = 1L;
-      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
+      PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY",
+          35000L);
       Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
           35000L);
       Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
@@ -602,6 +617,34 @@ public class PaymentServiceTest {
       Long paymentId = 10L;
       PaymentFailRequest request = new PaymentFailRequest(
           " ",
+          "REJECT_CARD_COMPANY",
+          "카드사에서 결제를 거절했습니다."
+      );
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, "ORD-1234PAY", 35000L);
+
+      when(paymentRepo.findById(paymentId)).thenReturn(Optional.of(payment));
+
+      //when
+      PaymentFailResponse response = paymentService.fail(userId, paymentId, request);
+
+      //then
+      assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
+      assertThat(response.paymentId()).isEqualTo(paymentId);
+      assertThat(response.tossOrderId()).isEqualTo("ORD-1234PAY");
+      assertThat(response.status()).isEqualTo("FAILED");
+    }
+
+    @Test
+    @DisplayName("요청 orderId가 null이면 paymentId로 Payment를 찾아 실패 처리한다.")
+    public void success_fail_findPaymentByPaymentIdWhenOrderIdIsNull() {
+      //given
+      Long userId = 1L;
+      Long orderId = 1L;
+      Long paymentId = 10L;
+      PaymentFailRequest request = new PaymentFailRequest(
+          null,
           "REJECT_CARD_COMPANY",
           "카드사에서 결제를 거절했습니다."
       );
@@ -734,7 +777,8 @@ public class PaymentServiceTest {
       String tossOrderId,
       Long totalAmount
   ) {
-    Payment payment = Payment.createPendingPayment(order, tossOrderId, "idempotencyKey", totalAmount,
+    Payment payment = Payment.createPendingPayment(order, tossOrderId, "idempotencyKey",
+        totalAmount,
         LocalDateTime.now());
     ReflectionTestUtils.setField(payment, "paymentId", paymentId);
     return payment;

--- a/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/payment/service/PaymentServiceTest.java
@@ -237,7 +237,9 @@ public class PaymentServiceTest {
       Long orderId = 1L;
       Long paymentId = 10L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, orderId, paymentId, request.orderId(), 35000L);
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, request.orderId(), 35000L);
       TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(), "DONE",
           35000L);
 
@@ -252,7 +254,7 @@ public class PaymentServiceTest {
       assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
       assertThat(payment.getPaymentKey()).isEqualTo("paymentKey");
       assertThat(payment.getApprovedAt()).isNotNull();
-      verify(payment.getOrder()).markPaid();
+      verify(order).markPaid();
 
       assertThat(response.paymentId()).isEqualTo(paymentId);
       assertThat(response.orderId()).isEqualTo(orderId);
@@ -289,7 +291,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(2L, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(2L, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -308,7 +312,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
       payment.markPaid("alreadyPaidPaymentKey");
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
@@ -328,8 +334,8 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, null, request.orderId(), 35000L,
-          OrderStatus.CREATED);
+      Order order = mockOrder(userId, 1L, OrderStatus.CREATED, "가나 초콜릿 외 1건", 35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -348,7 +354,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, "ORD-5678PAY", 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, "ORD-5678PAY", 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -369,7 +377,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 30000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -390,7 +400,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
       when(tossPaymentsClient.confirm(request.paymentKey(), request.orderId(), 35000L,
@@ -412,7 +424,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
       TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", "ORD-5678PAY", "DONE",
           35000L);
 
@@ -436,7 +450,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
       TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(), "DONE",
           30000L);
 
@@ -460,7 +476,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
       TossPaymentConfirmResult result = mockTossConfirmResult("paymentKey", request.orderId(), "WAITING",
           35000L);
 
@@ -484,7 +502,9 @@ public class PaymentServiceTest {
       //given
       Long userId = 1L;
       PaymentConfirmRequest request = new PaymentConfirmRequest("paymentKey", "ORD-1234PAY", 35000L);
-      Payment payment = mockPendingPayment(userId, 1L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, 1L, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 1L, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
       when(tossPaymentsClient.confirm(request.paymentKey(), request.orderId(), 35000L,
@@ -517,7 +537,9 @@ public class PaymentServiceTest {
           "PAY_PROCESS_CANCELED",
           "사용자가 결제를 취소했습니다."
       );
-      Payment payment = mockPendingPayment(userId, orderId, paymentId, request.orderId(), 35000L);
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -549,7 +571,9 @@ public class PaymentServiceTest {
           "REJECT_CARD_COMPANY",
           "카드사에서 결제를 거절했습니다."
       );
-      Payment payment = mockPendingPayment(userId, orderId, paymentId, request.orderId(), 35000L);
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -581,7 +605,9 @@ public class PaymentServiceTest {
           "REJECT_CARD_COMPANY",
           "카드사에서 결제를 거절했습니다."
       );
-      Payment payment = mockPendingPayment(userId, orderId, paymentId, "ORD-1234PAY", 35000L);
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, "ORD-1234PAY", 35000L);
 
       when(paymentRepo.findById(paymentId)).thenReturn(Optional.of(payment));
 
@@ -621,7 +647,9 @@ public class PaymentServiceTest {
       Long orderId = 1L;
       Long paymentId = 10L;
       PaymentFailRequest request = new PaymentFailRequest("ORD-1234PAY", "FAIL_CODE", "결제 실패");
-      Payment payment = mockPendingPayment(userId, orderId, 20L, request.orderId(), 35000L);
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, 20L, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -641,7 +669,9 @@ public class PaymentServiceTest {
       Long orderId = 1L;
       Long paymentId = 10L;
       PaymentFailRequest request = new PaymentFailRequest("ORD-1234PAY", "FAIL_CODE", "결제 실패");
-      Payment payment = mockPendingPayment(2L, orderId, paymentId, request.orderId(), 35000L);
+      Order order = mockOrder(2L, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, request.orderId(), 35000L);
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
 
@@ -661,7 +691,9 @@ public class PaymentServiceTest {
       Long orderId = 1L;
       Long paymentId = 10L;
       PaymentFailRequest request = new PaymentFailRequest("ORD-1234PAY", "FAIL_CODE", "결제 실패");
-      Payment payment = mockPendingPayment(userId, orderId, paymentId, request.orderId(), 35000L);
+      Order order = mockOrder(userId, orderId, OrderStatus.PAYMENT_PENDING, "가나 초콜릿 외 1건",
+          35000L);
+      Payment payment = mockPendingPayment(order, paymentId, request.orderId(), 35000L);
       payment.markPaid("paymentKey");
 
       when(paymentRepo.findByTossOrderId(request.orderId())).thenReturn(Optional.of(payment));
@@ -697,35 +729,11 @@ public class PaymentServiceTest {
   }
 
   private Payment mockPendingPayment(
-      Long userId,
-      Long orderId,
-      String tossOrderId,
-      Long totalAmount
-  ) {
-    return mockPendingPayment(userId, orderId, null, tossOrderId, totalAmount);
-  }
-
-  private Payment mockPendingPayment(
-      Long userId,
-      Long orderId,
+      Order order,
       Long paymentId,
       String tossOrderId,
       Long totalAmount
   ) {
-    return mockPendingPayment(userId, orderId, paymentId, tossOrderId, totalAmount,
-        OrderStatus.PAYMENT_PENDING);
-  }
-
-  private Payment mockPendingPayment(
-      Long userId,
-      Long orderId,
-      Long paymentId,
-      String tossOrderId,
-      Long totalAmount,
-      OrderStatus orderStatus
-  ) {
-    Order order = mockOrder(userId, orderId, orderStatus, "가나 초콜릿 외 1건",
-        totalAmount);
     Payment payment = Payment.createPendingPayment(order, tossOrderId, "idempotencyKey", totalAmount,
         LocalDateTime.now());
     ReflectionTestUtils.setField(payment, "paymentId", paymentId);


### PR DESCRIPTION
## 📌 관련 이슈
- close #132 

## 📝 작업 내용
- OrderService 테스트 코드 구조 Nest 형식에 맞게 리펙터링
- OrderService Branch 테스트 100% 테스트 커버리지 완료
- PaymentService Branch 테스트 100% 테스트 커버리지 완료

## ✅ 작업 결과 
<img width="705" height="655" alt="image" src="https://github.com/user-attachments/assets/8895a76a-0c40-40a9-a477-01e2dedc0f1a" />

## 🎸 기타
- 이런걸 중점적으로 봐주세요 등 있으면 기재
