### PR TITLE
Test: 채팅 도메인 서비스 코드 테스트 커버리지 확장

### DIFF
--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepoTest.java
@@ -74,6 +74,29 @@ class ChatMessageRepoTest {
   }
 
   @Test
+  @DisplayName("메시지 조회 시 요청한 채팅방 메시지가 내림차순으로 조회")
+  void findMessagesByCursorOrderingTest() {
+    // given
+    ChatRoom myRoom = createRoom();
+    ChatRoom otherRoom = createRoom();
+    ChatMessage myMsg1 = createMessage(myRoom, "내 방 메시지1");
+    ChatMessage myMsg2 = createMessage(myRoom, "내 방 메시지2");
+    createMessage(otherRoom, "다른 방 메시지");
+
+    // when
+    Slice<ChatMessage> result = chatMessageRepo.findMessagesByCursor(
+        myRoom.getId(), null, PageRequest.of(0, 10)
+    );
+
+    // then
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent().get(0).getId()).isEqualTo(myMsg2.getId());
+    assertThat(result.getContent().get(1).getId()).isEqualTo(myMsg1.getId());
+    assertThat(result.getContent()).extracting("content")
+        .doesNotContain("다른 방 메시지");
+  }
+
+  @Test
   @DisplayName("책갈피가 null일 때 방의 전체 메시지 개수를 반환")
   void countUnreadMessagesByNullId() {
     // given
@@ -104,6 +127,40 @@ class ChatMessageRepoTest {
 
     // then
     assertThat(unreadCount).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("다른 채팅방 메시지는 조회되지 않는다")
+  void findMessagesOnlyTargetRoom() {
+
+    // given
+    ChatRoom room1 = createRoom();
+    ChatRoom room2 = createRoom();
+    createMessage(room1, "room1");
+    createMessage(room2, "room2");
+
+    // when
+    Slice<ChatMessage> result = chatMessageRepo.findMessagesByCursor(room1.getId(), null,
+        PageRequest.of(0, 10));
+
+    // then
+    assertThat(result.getContent()).extracting(ChatMessage::getContent).containsExactly("room1");
+  }
+
+  @Test
+  @DisplayName("마지막 메시지까지 읽은 경우 unreadCount는 0")
+  void countUnreadMessagesZero() {
+
+    // given
+    ChatRoom room = createRoom();
+    createMessage(room, "1");
+    ChatMessage latest = createMessage(room, "2");
+
+    // when
+    int count = chatMessageRepo.countUnreadMessages(room.getId(), latest.getId());
+
+    // then
+    assertThat(count).isZero();
   }
 
   // -- 헬퍼 메서드 --

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepoTest.java
@@ -17,7 +17,8 @@ import org.springframework.data.domain.Slice;
 
 @DataJpaTest(properties = {
     "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
-    "spring.jpa.hibernate.ddl-auto=create-drop"
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false"
 })
 @Import(JpaConfig.class)
 class ChatMessageRepoTest {

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatMessageRepoTest.java
@@ -92,7 +92,7 @@ class ChatMessageRepoTest {
     assertThat(result.getContent()).hasSize(2);
     assertThat(result.getContent().get(0).getId()).isEqualTo(myMsg2.getId());
     assertThat(result.getContent().get(1).getId()).isEqualTo(myMsg1.getId());
-    assertThat(result.getContent()).extracting("content")
+    assertThat(result.getContent()).extracting(ChatMessage::getContent)
         .doesNotContain("다른 방 메시지");
   }
 

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepoTest.java
@@ -117,6 +117,43 @@ class ChatParticipantRepoTest {
   }
 
   @Test
+  @DisplayName("같은 방에 없는 유저는 조회되지 않음")
+  void findChatRoomByUsersNotFound() {
+
+    // given
+    ChatRoom room = createRoom(RoomType.SINGLE, LocalDateTime.now());
+
+    joinRoom(room, 1L);
+    joinRoom(room, 2L);
+
+    // when
+    Optional<ChatRoom> result = chatParticipantRepo.findChatRoomByUsers(1L, 3L);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("내가 참여하지 않은 방은 조회되지 않는다")
+  void findMyChatRoomsOnlyMine() {
+
+    // given
+    Long myId = 1L;
+    ChatRoom myRoom = createRoom(RoomType.SINGLE, LocalDateTime.now());
+    ChatRoom otherRoom = createRoom(RoomType.SINGLE, LocalDateTime.now().minusDays(1));
+    joinRoom(myRoom, myId);
+    joinRoom(otherRoom, 999L);
+
+    // when
+    Slice<ChatParticipant> result = chatParticipantRepo.findMyChatRooms(myId, null, null,
+        PageRequest.of(0, 10));
+
+    // then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().getFirst().getChatRoom().getId()).isEqualTo(myRoom.getId());
+  }
+
+  @Test
   @DisplayName("특정 방 참여자들의 마지막으로 읽은 메시지 목록 반환")
   void findAllParticipantsLastReadMessageIds() {
     // given

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepoTest.java
@@ -23,7 +23,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest(properties = {
     "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
-    "spring.jpa.hibernate.ddl-auto=create-drop"
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.flyway.enabled=false"
 })
 @Import(JpaConfig.class)
 class ChatParticipantRepoTest {

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepoTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/repo/ChatParticipantRepoTest.java
@@ -139,8 +139,9 @@ class ChatParticipantRepoTest {
 
     // given
     Long myId = 1L;
-    ChatRoom myRoom = createRoom(RoomType.SINGLE, LocalDateTime.now());
-    ChatRoom otherRoom = createRoom(RoomType.SINGLE, LocalDateTime.now().minusDays(1));
+    LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+    ChatRoom myRoom = createRoom(RoomType.SINGLE, now);
+    ChatRoom otherRoom = createRoom(RoomType.SINGLE, now.minusDays(1));
     joinRoom(myRoom, myId);
     joinRoom(otherRoom, 999L);
 

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageServiceTest.java
@@ -57,6 +57,7 @@ class ChatMessageServiceTest {
   @Mock
   private UserRepo userRepo;
 
+  // 구분용: 메시지전송
   @Test
   @DisplayName("메시지 전송 성공")
   void sendMessageSuccess() {
@@ -113,6 +114,52 @@ class ChatMessageServiceTest {
 
     // then
     assertThat(result.content()).isEqualTo("답장");
+  }
+
+  @Test
+  @DisplayName("모든 참여자가 읽은 상태면 unreadCount 0")
+  void sendMessageAllReadUnreadCountZero() {
+    // given
+    User user = createUser(USER_ID, "나");
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+
+    givenSaveMessage(); // 반환되는 메시지 ID는 2L로 세팅됨
+    // 두 명의 참여자가 모두 최신 메시지(2L) 이상을 읽었다고 가정
+    givenUnreadIds(2L, 5L);
+
+    // when
+    ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
+
+    // then
+    assertThat(result.unreadCount()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("읽지 않은 참여자 존재 시 unreadCount 증가")
+  void sendMessageUnreadCountCalculated() {
+    // given
+    User user = createUser(USER_ID, "나");
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+    givenSaveMessage();
+    givenUnreadIds(1L, null);
+
+    // when
+    ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
+
+    // then
+    assertThat(result.unreadCount()).isEqualTo(2);
   }
 
   @Test
@@ -186,6 +233,7 @@ class ChatMessageServiceTest {
         .isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
   }
 
+  // 구분용: 목록조회쪽
   @Test
   @DisplayName("메시지 목록 조회 성공")
   void getMessageListSuccess() {
@@ -254,6 +302,51 @@ class ChatMessageServiceTest {
     // then
     assertThat(result.messageList()).isEmpty();
     assertThat(result.nextCursorId()).isNull();
+  }
+
+  @Test
+  @DisplayName("마지막 페이지 조회 시 반환 잘 되는지")
+  void getMessageListLastPageReturnsNullCursor() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+    ChatMessage message = createMessage(room, 5L, USER_ID, "마지막 메시지");
+
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    givenMessageSlice(false, message);
+    givenUnreadIds();
+    given(userRepo.findAllById(any())).willReturn(List.of());
+
+    // when
+    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
+
+    // then
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.nextCursorId()).isNull();
+  }
+
+  @Test
+  @DisplayName("기존 읽음 메시지가 최신이면 updateLastReadMessage 미호출")
+  void getMessageListKeepLastReadMessageWhenAlreadyLatest() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+    ChatMessage alreadyReadMessage = createMessage(room, 20L, USER_ID, "읽은 메시지");
+    participant.updateLastReadMessage(alreadyReadMessage);
+    ChatMessage fetchedMessage = createMessage(room, 10L, 2L, "과거 메시지");
+
+    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+        Optional.of(participant));
+    givenMessageSlice(true, fetchedMessage);
+    givenUnreadIds();
+    given(userRepo.findAllById(any())).willReturn(List.of());
+
+    // when
+    chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
+
+    // then
+    assertThat(participant.getLastReadMessage().getId()).isEqualTo(20L);
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatMessageServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -56,312 +57,6 @@ class ChatMessageServiceTest {
 
   @Mock
   private UserRepo userRepo;
-
-  // 구분용: 메시지전송
-  @Test
-  @DisplayName("메시지 전송 성공")
-  void sendMessageSuccess() {
-    // given
-    User user = createUser(USER_ID, "나");
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
-
-    givenUnreadIds(2L, null);
-    givenSaveMessage();
-
-    // when
-    ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
-
-    // then
-    assertThat(result.content()).isEqualTo("안녕");
-    assertThat(result.nickname()).isEqualTo("나");
-    assertThat(result.unreadCount()).isEqualTo(1);
-    assertThat(room.getLastMessageContent()).isEqualTo("안녕");
-    assertThat(participant.getLastReadMessage()).isNotNull();
-
-    verify(chatMessageRepo).saveAndFlush(any(ChatMessage.class));
-  }
-
-  @Test
-  @DisplayName("답장 메시지 전송 성공")
-  void sendMessageAnswerSuccess() {
-    // given
-    User user = createUser(USER_ID, "나");
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-    ChatMessage answer = createMessage(room, 10L, USER_ID, "원본");
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
-    given(chatMessageRepo.findById(10L)).willReturn(Optional.of(answer));
-
-    givenUnreadIds(1L);
-    givenSaveMessage();
-
-    // when
-    ChatMessageResponse result = chatMessageService.sendMessage(
-        USER_ID,
-        ROOM_ID,
-        new ChatMessageRequest("답장", MessageType.TEXT, 10L)
-    );
-
-    // then
-    assertThat(result.content()).isEqualTo("답장");
-  }
-
-  @Test
-  @DisplayName("모든 참여자가 읽은 상태면 unreadCount 0")
-  void sendMessageAllReadUnreadCountZero() {
-    // given
-    User user = createUser(USER_ID, "나");
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
-
-    givenSaveMessage(); // 반환되는 메시지 ID는 2L로 세팅됨
-    // 두 명의 참여자가 모두 최신 메시지(2L) 이상을 읽었다고 가정
-    givenUnreadIds(2L, 5L);
-
-    // when
-    ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
-
-    // then
-    assertThat(result.unreadCount()).isEqualTo(0);
-  }
-
-  @Test
-  @DisplayName("읽지 않은 참여자 존재 시 unreadCount 증가")
-  void sendMessageUnreadCountCalculated() {
-    // given
-    User user = createUser(USER_ID, "나");
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
-    givenSaveMessage();
-    givenUnreadIds(1L, null);
-
-    // when
-    ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
-
-    // then
-    assertThat(result.unreadCount()).isEqualTo(2);
-  }
-
-  @Test
-  @DisplayName("채팅방이 없으면 예외 발생")
-  void sendMessageRoomNotFoundFail() {
-    // given
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.ROOM_NOT_FOUND);
-  }
-
-  @Test
-  @DisplayName("채팅 참여자가 아니면 예외 발생")
-  void sendMessageNotParticipantFail() {
-    // given
-    ChatRoom room = createRoom();
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.NOT_CHAT_PARTICIPANT);
-  }
-
-  @Test
-  @DisplayName("유저가 없으면 예외 발생")
-  void sendMessageUserNotFoundFail() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    given(userRepo.findById(USER_ID)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.USER_NOT_FOUND);
-  }
-
-  @Test
-  @DisplayName("답장 메시지가 없으면 예외 발생")
-  void sendMessageAnswerMessageNotFoundFail() {
-    // given
-    User user = createUser(USER_ID, "나");
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
-    given(chatMessageRepo.findById(99L)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID,
-        new ChatMessageRequest("답장", MessageType.TEXT, 99L)))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
-  }
-
-  // 구분용: 목록조회쪽
-  @Test
-  @DisplayName("메시지 목록 조회 성공")
-  void getMessageListSuccess() {
-    // given
-    User user = createUser(USER_ID, "나");
-    User otherUser = createUser(2L, "너");
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    ChatMessage message1 = createMessage(room, 10L, USER_ID, "안녕");
-    ChatMessage message2 = createMessage(room, 9L, 2L, "반가워");
-
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    givenMessageSlice(true, message1, message2);
-    givenUnreadIds(9L);
-    given(userRepo.findAllById(any())).willReturn(List.of(user, otherUser));
-
-    // when
-    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
-
-    // then
-    assertThat(result.messageList()).hasSize(2);
-    assertThat(result.hasNext()).isTrue();
-    assertThat(result.nextCursorId()).isEqualTo(9L);
-    assertThat(participant.getLastReadMessage().getId()).isEqualTo(10L);
-  }
-
-  @Test
-  @DisplayName("닉네임이 없으면 알 수 없음 처리")
-  void getMessageListUnknownNicknameSuccess() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-    ChatMessage message = createMessage(room, 10L, 999L, "hello");
-
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    givenMessageSlice(false, message);
-    givenUnreadIds();
-    given(userRepo.findAllById(any())).willReturn(List.of());
-
-    // when
-    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
-
-    // then
-    assertThat(result.messageList().getFirst().nickname()).isEqualTo("(알 수 없음)");
-  }
-
-  @Test
-  @DisplayName("메시지가 없으면 빈 목록 반환")
-  void getMessageListEmptySuccess() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    givenMessageSlice(false);
-    givenUnreadIds();
-    given(userRepo.findAllById(any())).willReturn(List.of());
-
-    // when
-    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
-
-    // then
-    assertThat(result.messageList()).isEmpty();
-    assertThat(result.nextCursorId()).isNull();
-  }
-
-  @Test
-  @DisplayName("마지막 페이지 조회 시 반환 잘 되는지")
-  void getMessageListLastPageReturnsNullCursor() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-    ChatMessage message = createMessage(room, 5L, USER_ID, "마지막 메시지");
-
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    givenMessageSlice(false, message);
-    givenUnreadIds();
-    given(userRepo.findAllById(any())).willReturn(List.of());
-
-    // when
-    ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
-
-    // then
-    assertThat(result.hasNext()).isFalse();
-    assertThat(result.nextCursorId()).isNull();
-  }
-
-  @Test
-  @DisplayName("기존 읽음 메시지가 최신이면 updateLastReadMessage 미호출")
-  void getMessageListKeepLastReadMessageWhenAlreadyLatest() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-    ChatMessage alreadyReadMessage = createMessage(room, 20L, USER_ID, "읽은 메시지");
-    participant.updateLastReadMessage(alreadyReadMessage);
-    ChatMessage fetchedMessage = createMessage(room, 10L, 2L, "과거 메시지");
-
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.of(participant));
-    givenMessageSlice(true, fetchedMessage);
-    givenUnreadIds();
-    given(userRepo.findAllById(any())).willReturn(List.of());
-
-    // when
-    chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
-
-    // then
-    assertThat(participant.getLastReadMessage().getId()).isEqualTo(20L);
-  }
-
-  @Test
-  @DisplayName("참여자가 아니면 메시지 조회 실패")
-  void getMessageListNotParticipantFail() {
-    // given
-    given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
-        Optional.empty());
-
-    // when & then
-    assertThatThrownBy(() -> chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.NOT_CHAT_PARTICIPANT);
-  }
 
   // -- 헬퍼 메서드 --
   private void givenUnreadIds(Long... ids) {
@@ -426,5 +121,323 @@ class ChatMessageServiceTest {
 
   private ChatMessageRequest request() {
     return new ChatMessageRequest("안녕", MessageType.TEXT, null);
+  }
+
+  @Nested
+  @DisplayName("메시지 전송")
+  class SendMessage {
+
+    @Test
+    @DisplayName("메시지 전송 성공")
+    void sendMessageSuccess() {
+      // given
+      User user = createUser(USER_ID, "나");
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+
+      givenUnreadIds(2L, null);
+      givenSaveMessage();
+
+      // when
+      ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
+
+      // then
+      assertThat(result.content()).isEqualTo("안녕");
+      assertThat(result.nickname()).isEqualTo("나");
+      assertThat(result.unreadCount()).isEqualTo(1);
+      assertThat(room.getLastMessageContent()).isEqualTo("안녕");
+      assertThat(participant.getLastReadMessage()).isNotNull();
+
+      verify(chatMessageRepo).saveAndFlush(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("답장 메시지 전송 성공")
+    void sendMessageAnswerSuccess() {
+      // given
+      User user = createUser(USER_ID, "나");
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+      ChatMessage answer = createMessage(room, 10L, USER_ID, "원본");
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+      given(chatMessageRepo.findById(10L)).willReturn(Optional.of(answer));
+
+      givenUnreadIds(1L);
+      givenSaveMessage();
+
+      // when
+      ChatMessageResponse result = chatMessageService.sendMessage(
+          USER_ID,
+          ROOM_ID,
+          new ChatMessageRequest("답장", MessageType.TEXT, 10L)
+      );
+
+      // then
+      assertThat(result.content()).isEqualTo("답장");
+    }
+
+    @Test
+    @DisplayName("모든 참여자가 읽은 상태면 unreadCount 0")
+    void sendMessageAllReadUnreadCountZero() {
+      // given
+      User user = createUser(USER_ID, "나");
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+
+      givenSaveMessage(); // 반환되는 메시지 ID는 2L로 세팅됨
+      // 두 명의 참여자가 모두 최신 메시지(2L) 이상을 읽었다고 가정
+      givenUnreadIds(2L, 5L);
+
+      // when
+      ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
+
+      // then
+      assertThat(result.unreadCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 참여자 존재 시 unreadCount 증가")
+    void sendMessageUnreadCountCalculated() {
+      // given
+      User user = createUser(USER_ID, "나");
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+      givenSaveMessage();
+      givenUnreadIds(1L, null);
+
+      // when
+      ChatMessageResponse result = chatMessageService.sendMessage(USER_ID, ROOM_ID, request());
+
+      // then
+      assertThat(result.unreadCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("채팅방이 없으면 예외 발생")
+    void sendMessageRoomNotFoundFail() {
+      // given
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("채팅 참여자가 아니면 예외 발생")
+    void sendMessageNotParticipantFail() {
+      // given
+      ChatRoom room = createRoom();
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.NOT_CHAT_PARTICIPANT);
+    }
+
+    @Test
+    @DisplayName("유저가 없으면 예외 발생")
+    void sendMessageUserNotFoundFail() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      given(userRepo.findById(USER_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID, request()))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("답장 메시지가 없으면 예외 발생")
+    void sendMessageAnswerMessageNotFoundFail() {
+      // given
+      User user = createUser(USER_ID, "나");
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatRoomRepo.findById(ROOM_ID)).willReturn(Optional.of(room));
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(user));
+      given(chatMessageRepo.findById(99L)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> chatMessageService.sendMessage(USER_ID, ROOM_ID,
+          new ChatMessageRequest("답장", MessageType.TEXT, 99L)))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.MESSAGE_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("메시지 내역 조회")
+  class GetMessageList {
+
+    @Test
+    @DisplayName("성공")
+    void getMessageListSuccess() {
+      // given
+      User user = createUser(USER_ID, "나");
+      User otherUser = createUser(2L, "너");
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      ChatMessage message1 = createMessage(room, 10L, USER_ID, "안녕");
+      ChatMessage message2 = createMessage(room, 9L, 2L, "반가워");
+
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      givenMessageSlice(true, message1, message2);
+      givenUnreadIds(9L);
+      given(userRepo.findAllById(any())).willReturn(List.of(user, otherUser));
+
+      // when
+      ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null,
+          20);
+
+      // then
+      assertThat(result.messageList()).hasSize(2);
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.nextCursorId()).isEqualTo(9L);
+      assertThat(participant.getLastReadMessage().getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("닉네임이 없으면 알 수 없음 처리")
+    void getMessageListUnknownNicknameSuccess() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+      ChatMessage message = createMessage(room, 10L, 999L, "hello");
+
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      givenMessageSlice(false, message);
+      givenUnreadIds();
+      given(userRepo.findAllById(any())).willReturn(List.of());
+
+      // when
+      ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null,
+          20);
+
+      // then
+      assertThat(result.messageList().getFirst().nickname()).isEqualTo("(알 수 없음)");
+    }
+
+    @Test
+    @DisplayName("메시지가 없으면 빈 목록 반환")
+    void getMessageListEmptySuccess() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      givenMessageSlice(false);
+      givenUnreadIds();
+      given(userRepo.findAllById(any())).willReturn(List.of());
+
+      // when
+      ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null,
+          20);
+
+      // then
+      assertThat(result.messageList()).isEmpty();
+      assertThat(result.nextCursorId()).isNull();
+    }
+
+    @Test
+    @DisplayName("마지막 페이지 조회 시 반환 잘 되는지")
+    void getMessageListLastPageReturnsNullCursor() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+      ChatMessage message = createMessage(room, 5L, USER_ID, "마지막 메시지");
+
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      givenMessageSlice(false, message);
+      givenUnreadIds();
+      given(userRepo.findAllById(any())).willReturn(List.of());
+
+      // when
+      ChatMessageListResponse result = chatMessageService.getMessageList(USER_ID, ROOM_ID, null,
+          20);
+
+      // then
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.nextCursorId()).isNull();
+    }
+
+    @Test
+    @DisplayName("기존 읽음 메시지가 최신이면 updateLastReadMessage 미호출")
+    void getMessageListKeepLastReadMessageWhenAlreadyLatest() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+      ChatMessage alreadyReadMessage = createMessage(room, 20L, USER_ID, "읽은 메시지");
+      participant.updateLastReadMessage(alreadyReadMessage);
+      ChatMessage fetchedMessage = createMessage(room, 10L, 2L, "과거 메시지");
+
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.of(participant));
+      givenMessageSlice(true, fetchedMessage);
+      givenUnreadIds();
+      given(userRepo.findAllById(any())).willReturn(List.of());
+
+      // when
+      chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20);
+
+      // then
+      assertThat(participant.getLastReadMessage().getId()).isEqualTo(20L);
+    }
+
+    @Test
+    @DisplayName("참여자가 아니면 메시지 조회 실패")
+    void getMessageListNotParticipantFail() {
+      // given
+      given(chatParticipantRepo.findByChatRoomIdAndUserId(ROOM_ID, USER_ID)).willReturn(
+          Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> chatMessageService.getMessageList(USER_ID, ROOM_ID, null, 20))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.NOT_CHAT_PARTICIPANT);
+    }
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -59,244 +60,6 @@ class ChatRoomServiceTest {
 
   @Mock
   private ChatMessageRepo chatMessageRepo;
-
-  // 채팅방 생성
-  @Test
-  @DisplayName("채팅방 생성 성공 - 기존 방 존재 시 조회")
-  void createChatRoomWhenRoomExists_ReturnsExistingRoom() {
-    // given
-    User me = createUser(USER_ID, "나");
-    User receiver = createUser(RECEIVER_ID, "상대방");
-    ChatRoom room = createRoom();
-
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
-    given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.of(receiver));
-    given(chatParticipantRepo.findChatRoomByUsers(USER_ID, RECEIVER_ID)).willReturn(
-        Optional.of(room));
-
-    // when
-    ChatRoomResponse result = chatRoomService.createChatRoom(USER_ID,
-        new ChatRoomCreateRequest(RECEIVER_ID));
-
-    // then
-    assertThat(result.chatRoomId()).isEqualTo(ROOM_ID);
-    assertThat(result.participants()).hasSize(2);
-    verify(chatRoomRepo, never()).save(any());
-  }
-
-  @Test
-  @DisplayName("채팅방 생성 성공 - 새 방 생성")
-  void createChatRoomWhenNewRoomReturnsCreatedRoom() {
-    // given
-    User me = createUser(USER_ID, "나");
-    User receiver = createUser(RECEIVER_ID, "상대방");
-    ChatRoom room = createRoom();
-
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
-    given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.of(receiver));
-    given(chatParticipantRepo.findChatRoomByUsers(USER_ID, RECEIVER_ID)).willReturn(
-        Optional.empty());
-    given(chatRoomRepo.save(any(ChatRoom.class))).willReturn(room);
-
-    // when
-    ChatRoomResponse result = chatRoomService.createChatRoom(USER_ID,
-        new ChatRoomCreateRequest(RECEIVER_ID));
-
-    // then
-    assertThat(result.chatRoomId()).isEqualTo(ROOM_ID);
-    assertThat(result.roomType()).isEqualTo(RoomType.SINGLE);
-    verify(chatRoomRepo, times(1)).save(any(ChatRoom.class));
-    verify(chatParticipantRepo, times(2)).save(any(ChatParticipant.class));
-  }
-
-  @Test
-  @DisplayName("자기 자신과 채팅방 생성 시 예외 발생")
-  void createChatRoomWhenSelfThrowsException() {
-    // when & then
-    assertThatThrownBy(
-        () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(USER_ID)))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.CANNOT_CHAT_SELF);
-  }
-
-  @Test
-  @DisplayName("내 유저 정보가 없으면 예외 발생")
-  void createChatRoomWhenMyUserNotFoundThrowsException() {
-    // given
-    given(userRepo.findById(USER_ID)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(
-        () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(RECEIVER_ID)))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.USER_NOT_FOUND);
-  }
-
-  @Test
-  @DisplayName("상대 유저 정보가 없으면 예외 발생")
-  void createChatRoomWhenReceiverNotFoundThrowsException() {
-    // given
-    User me = createUser(USER_ID, "나");
-
-    given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
-    given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.empty());
-
-    // when & then
-    assertThatThrownBy(
-        () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(RECEIVER_ID)))
-        .isInstanceOf(BusinessException.class)
-        .extracting("errorCode")
-        .isEqualTo(ErrorCode.USER_NOT_FOUND);
-  }
-
-  // 채팅방 목록 조회
-  @Test
-  @DisplayName("채팅방 목록 조회 성공")
-  void getChatRoomListWhenRoomsExistReturnsList() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
-        .willReturn(createSlice(true, participant));
-    given(chatMessageRepo.countUnreadMessages(ROOM_ID, null))
-        .willReturn(3);
-
-    // when
-    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    assertThat(result.rooms()).hasSize(1);
-    assertThat(result.hasNext()).isTrue();
-    assertThat(result.nextCursorId()).isEqualTo(ROOM_ID);
-    assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(3);
-  }
-
-  @Test
-  @DisplayName("마지막 페이지 조회 시 nextLastMessageAt은 null")
-  void getChatRoomListLastPageReturnsNullCursors() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
-        .willReturn(createSlice(false, participant));
-    given(chatMessageRepo.countUnreadMessages(eq(ROOM_ID), any())).willReturn(0);
-
-    // when
-    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    assertThat(result.hasNext()).isFalse();
-    assertThat(result.nextCursorId()).isNull();
-    assertThat(result.nextLastMessageAt()).isNull();
-  }
-
-  @Test
-  @DisplayName("다음 페이지가 존재하면 nextLastMessageAt 반환")
-  void getChatRoomListReturnsNextLastMessageAt() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(
-        chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20))).willReturn(
-        createSlice(true, participant));
-
-    given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(0);
-
-    // when
-    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    assertThat(result.nextLastMessageAt()).isEqualTo(room.getLastMessageAt());
-  }
-
-  @Test
-  @DisplayName("마지막 읽은 메시지가 없을 때 전체 안읽은 수 계산")
-  void getChatRoomListWhenLastReadMessageIsNullUnreadCount() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-
-    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
-        .willReturn(createSlice(false, participant));
-    given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(5);
-
-    // when
-    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    verify(chatMessageRepo).countUnreadMessages(ROOM_ID, null);
-    assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(5);
-  }
-
-  @Test
-  @DisplayName("읽은 메시지 정보가 있을 때 읽지 않은 메시지 개수 계산 성공")
-  void getChatRoomListWithLastReadMessageReturnsUnreadCount() {
-    // given
-    ChatRoom room = createRoom();
-    ChatParticipant participant = createParticipant(room);
-    ChatMessage lastRead = createMessage(room);
-    participant.updateLastReadMessage(lastRead);
-
-    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
-        .willReturn(createSlice(false, participant));
-    given(chatMessageRepo.countUnreadMessages(ROOM_ID, 10L))
-        .willReturn(1);
-
-    // when
-    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(1);
-  }
-
-  @Test
-  @DisplayName("채팅방이 없으면 빈 목록 반환")
-  void getChatRoomListWhenEmptyReturnsEmptyList() {
-    // given
-    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
-        .willReturn(createSlice(false));
-
-    // when
-    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    assertThat(result.rooms()).isEmpty();
-    assertThat(result.hasNext()).isFalse();
-    assertThat(result.nextCursorId()).isNull();
-  }
-
-  @Test
-  @DisplayName("채팅방 수만큼 unread 조회")
-  void getChatRoomListCallsUnreadCountPerRoom() {
-
-    // given
-    ChatRoom room1 = createRoom();
-    ChatRoom room2 = ChatRoom.builder().roomType(RoomType.SINGLE).participantCount(2).build();
-    ReflectionTestUtils.setField(room2, "id", 200L);
-    ChatParticipant participant1 = createParticipant(room1);
-
-    ChatParticipant participant2 = ChatParticipant.builder().chatRoom(room2).userId(USER_ID)
-        .roomTitle("상대방2").roomImage("profile2.png").build();
-
-    ReflectionTestUtils.setField(participant2, "id", 20L);
-
-    given(
-        chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20))).willReturn(
-        createSlice(false, participant1, participant2));
-
-    given(chatMessageRepo.countUnreadMessages(any(), any())).willReturn(0);
-
-    // when
-    chatRoomService.getChatRoomList(USER_ID, null, null, 20);
-
-    // then
-    verify(chatMessageRepo, times(2)).countUnreadMessages(any(), any());
-  }
 
   // -- 헬퍼 메서드 --
   private User createUser(Long id, String nickname) {
@@ -347,5 +110,252 @@ class ChatRoomServiceTest {
 
   private Slice<ChatParticipant> createSlice(boolean hasNext, ChatParticipant... participants) {
     return new SliceImpl<>(List.of(participants), PageRequest.of(0, 20), hasNext);
+  }
+
+  @Nested
+  @DisplayName("채팅방 생성")
+  class CreateChatRoom {
+
+    @Test
+    @DisplayName("성공 - 기존 방 존재 시 조회")
+    void createChatRoomWhenRoomExists_ReturnsExistingRoom() {
+      // given
+      User me = createUser(USER_ID, "나");
+      User receiver = createUser(RECEIVER_ID, "상대방");
+      ChatRoom room = createRoom();
+
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
+      given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.of(receiver));
+      given(chatParticipantRepo.findChatRoomByUsers(USER_ID, RECEIVER_ID)).willReturn(
+          Optional.of(room));
+
+      // when
+      ChatRoomResponse result = chatRoomService.createChatRoom(USER_ID,
+          new ChatRoomCreateRequest(RECEIVER_ID));
+
+      // then
+      assertThat(result.chatRoomId()).isEqualTo(ROOM_ID);
+      assertThat(result.participants()).hasSize(2);
+      verify(chatRoomRepo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("성공 - 새 방 생성")
+    void createChatRoomWhenNewRoomReturnsCreatedRoom() {
+      // given
+      User me = createUser(USER_ID, "나");
+      User receiver = createUser(RECEIVER_ID, "상대방");
+      ChatRoom room = createRoom();
+
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
+      given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.of(receiver));
+      given(chatParticipantRepo.findChatRoomByUsers(USER_ID, RECEIVER_ID)).willReturn(
+          Optional.empty());
+      given(chatRoomRepo.save(any(ChatRoom.class))).willReturn(room);
+
+      // when
+      ChatRoomResponse result = chatRoomService.createChatRoom(USER_ID,
+          new ChatRoomCreateRequest(RECEIVER_ID));
+
+      // then
+      assertThat(result.chatRoomId()).isEqualTo(ROOM_ID);
+      assertThat(result.roomType()).isEqualTo(RoomType.SINGLE);
+      verify(chatRoomRepo, times(1)).save(any(ChatRoom.class));
+      verify(chatParticipantRepo, times(2)).save(any(ChatParticipant.class));
+    }
+
+    @Test
+    @DisplayName("자기 자신과 채팅방 생성 시 예외 발생")
+    void createChatRoomWhenSelfThrowsException() {
+      // when & then
+      assertThatThrownBy(
+          () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(USER_ID)))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.CANNOT_CHAT_SELF);
+    }
+
+    @Test
+    @DisplayName("내 유저 정보가 없으면 예외 발생")
+    void createChatRoomWhenMyUserNotFoundThrowsException() {
+      // given
+      given(userRepo.findById(USER_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(
+          () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(RECEIVER_ID)))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("상대 유저 정보가 없으면 예외 발생")
+    void createChatRoomWhenReceiverNotFoundThrowsException() {
+      // given
+      User me = createUser(USER_ID, "나");
+
+      given(userRepo.findById(USER_ID)).willReturn(Optional.of(me));
+      given(userRepo.findById(RECEIVER_ID)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(
+          () -> chatRoomService.createChatRoom(USER_ID, new ChatRoomCreateRequest(RECEIVER_ID)))
+          .isInstanceOf(BusinessException.class)
+          .extracting("errorCode")
+          .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+  }
+
+  @Nested
+  @DisplayName("채팅방 목록 조회")
+  class GetChatRoomList {
+
+    @Test
+    @DisplayName("성공")
+    void getChatRoomListWhenRoomsExistReturnsList() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+          .willReturn(createSlice(true, participant));
+      given(chatMessageRepo.countUnreadMessages(ROOM_ID, null))
+          .willReturn(3);
+
+      // when
+      ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      assertThat(result.rooms()).hasSize(1);
+      assertThat(result.hasNext()).isTrue();
+      assertThat(result.nextCursorId()).isEqualTo(ROOM_ID);
+      assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("마지막 페이지 조회 시 nextLastMessageAt은 null")
+    void getChatRoomListLastPageReturnsNullCursors() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+          .willReturn(createSlice(false, participant));
+      given(chatMessageRepo.countUnreadMessages(eq(ROOM_ID), any())).willReturn(0);
+
+      // when
+      ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.nextCursorId()).isNull();
+      assertThat(result.nextLastMessageAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("다음 페이지가 존재하면 nextLastMessageAt 반환")
+    void getChatRoomListReturnsNextLastMessageAt() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(
+          chatParticipantRepo.findMyChatRooms(USER_ID, null, null,
+              PageRequest.of(0, 20))).willReturn(
+          createSlice(true, participant));
+
+      given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(0);
+
+      // when
+      ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      assertThat(result.nextLastMessageAt()).isEqualTo(room.getLastMessageAt());
+    }
+
+    @Test
+    @DisplayName("마지막 읽은 메시지가 없을 때 전체 안읽은 수 계산")
+    void getChatRoomListWhenLastReadMessageIsNullUnreadCount() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+
+      given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+          .willReturn(createSlice(false, participant));
+      given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(5);
+
+      // when
+      ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      verify(chatMessageRepo).countUnreadMessages(ROOM_ID, null);
+      assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("읽은 메시지 정보가 있을 때 읽지 않은 메시지 개수 계산 성공")
+    void getChatRoomListWithLastReadMessageReturnsUnreadCount() {
+      // given
+      ChatRoom room = createRoom();
+      ChatParticipant participant = createParticipant(room);
+      ChatMessage lastRead = createMessage(room);
+      participant.updateLastReadMessage(lastRead);
+
+      given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+          .willReturn(createSlice(false, participant));
+      given(chatMessageRepo.countUnreadMessages(ROOM_ID, 10L))
+          .willReturn(1);
+
+      // when
+      ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("채팅방이 없으면 빈 목록 반환")
+    void getChatRoomListWhenEmptyReturnsEmptyList() {
+      // given
+      given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+          .willReturn(createSlice(false));
+
+      // when
+      ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      assertThat(result.rooms()).isEmpty();
+      assertThat(result.hasNext()).isFalse();
+      assertThat(result.nextCursorId()).isNull();
+    }
+
+    @Test
+    @DisplayName("채팅방 수만큼 unread 조회")
+    void getChatRoomListCallsUnreadCountPerRoom() {
+      // given
+      ChatRoom room1 = createRoom();
+      ChatRoom room2 = ChatRoom.builder().roomType(RoomType.SINGLE).participantCount(2).build();
+      ReflectionTestUtils.setField(room2, "id", 200L);
+      ChatParticipant participant1 = createParticipant(room1);
+
+      ChatParticipant participant2 = ChatParticipant.builder().chatRoom(room2).userId(USER_ID)
+          .roomTitle("상대방2").roomImage("profile2.png").build();
+
+      ReflectionTestUtils.setField(participant2, "id", 20L);
+
+      given(
+          chatParticipantRepo.findMyChatRooms(USER_ID, null, null,
+              PageRequest.of(0, 20))).willReturn(
+          createSlice(false, participant1, participant2));
+
+      given(chatMessageRepo.countUnreadMessages(any(), any())).willReturn(0);
+
+      // when
+      chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+      // then
+      verify(chatMessageRepo, times(2)).countUnreadMessages(any(), any());
+    }
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.domain.chat.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -59,6 +60,7 @@ class ChatRoomServiceTest {
   @Mock
   private ChatMessageRepo chatMessageRepo;
 
+  // 채팅방 생성
   @Test
   @DisplayName("채팅방 생성 성공 - 기존 방 존재 시 조회")
   void createChatRoomWhenRoomExists_ReturnsExistingRoom() {
@@ -149,6 +151,7 @@ class ChatRoomServiceTest {
         .isEqualTo(ErrorCode.USER_NOT_FOUND);
   }
 
+  // 채팅방 목록 조회
   @Test
   @DisplayName("채팅방 목록 조회 성공")
   void getChatRoomListWhenRoomsExistReturnsList() {
@@ -169,6 +172,64 @@ class ChatRoomServiceTest {
     assertThat(result.hasNext()).isTrue();
     assertThat(result.nextCursorId()).isEqualTo(ROOM_ID);
     assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("마지막 페이지 조회 시 nextLastMessageAt은 null")
+  void getChatRoomListLastPageReturnsNullCursors() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+        .willReturn(createSlice(false, participant));
+    given(chatMessageRepo.countUnreadMessages(eq(ROOM_ID), any())).willReturn(0);
+
+    // when
+    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    assertThat(result.hasNext()).isFalse();
+    assertThat(result.nextCursorId()).isNull();
+    assertThat(result.nextLastMessageAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("다음 페이지가 존재하면 nextLastMessageAt 반환")
+  void getChatRoomListReturnsNextLastMessageAt() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(
+        chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20))).willReturn(
+        createSlice(true, participant));
+
+    given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(0);
+
+    // when
+    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    assertThat(result.nextLastMessageAt()).isEqualTo(room.getLastMessageAt());
+  }
+
+  @Test
+  @DisplayName("마지막 읽은 메시지가 없을 때 전체 안읽은 수 계산")
+  void getChatRoomListWhenLastReadMessageIsNullUnreadCount() {
+    // given
+    ChatRoom room = createRoom();
+    ChatParticipant participant = createParticipant(room);
+
+    given(chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20)))
+        .willReturn(createSlice(false, participant));
+    given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(5);
+
+    // when
+    chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    verify(chatMessageRepo).countUnreadMessages(ROOM_ID, null);
   }
 
   @Test
@@ -206,6 +267,34 @@ class ChatRoomServiceTest {
     assertThat(result.rooms()).isEmpty();
     assertThat(result.hasNext()).isFalse();
     assertThat(result.nextCursorId()).isNull();
+  }
+
+  @Test
+  @DisplayName("채팅방 수만큼 unread 조회")
+  void getChatRoomListCallsUnreadCountPerRoom() {
+
+    // given
+    ChatRoom room1 = createRoom();
+    ChatRoom room2 = ChatRoom.builder().roomType(RoomType.SINGLE).participantCount(2).build();
+    ReflectionTestUtils.setField(room2, "id", 200L);
+    ChatParticipant participant1 = createParticipant(room1);
+
+    ChatParticipant participant2 = ChatParticipant.builder().chatRoom(room2).userId(USER_ID)
+        .roomTitle("상대방2").roomImage("profile2.png").build();
+
+    ReflectionTestUtils.setField(participant2, "id", 20L);
+
+    given(
+        chatParticipantRepo.findMyChatRooms(USER_ID, null, null, PageRequest.of(0, 20))).willReturn(
+        createSlice(false, participant1, participant2));
+
+    given(chatMessageRepo.countUnreadMessages(any(), any())).willReturn(0);
+
+    // when
+    chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+
+    // then
+    verify(chatMessageRepo, times(2)).countUnreadMessages(any(), any());
   }
 
   // -- 헬퍼 메서드 --

--- a/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/chat/service/ChatRoomServiceTest.java
@@ -226,10 +226,11 @@ class ChatRoomServiceTest {
     given(chatMessageRepo.countUnreadMessages(ROOM_ID, null)).willReturn(5);
 
     // when
-    chatRoomService.getChatRoomList(USER_ID, null, null, 20);
+    ChatRoomListResponse result = chatRoomService.getChatRoomList(USER_ID, null, null, 20);
 
     // then
     verify(chatMessageRepo).countUnreadMessages(ROOM_ID, null);
+    assertThat(result.rooms().getFirst().unreadCount()).isEqualTo(5);
   }
 
   @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #126 

## 📝 작업 내용
- 채팅 도메인 서비스 코드 테스트 커버리지 브랜치 기준 80% 이상 달성

## ✅ 작업 결과 
- repo, service 단위 테스트 코드 추가 작업
- <img width="1241" height="807" alt="image" src="https://github.com/user-attachments/assets/2cd5e37f-e4c2-421f-9861-6a9f81a923b9" />

## 🎸 기타
- 그냥 실행하면 오류가 떠서 `./gradlew clean test --tests "com.example.WonkaoTalk.domain.chat.*" jacocoTestReport`로 실행했습니다 그래서 사진 상으로 다른 도메인 커버리지는 안 보입니다
