### PR TITLE
Test: 인증, 사용자, 판매자, 친구, 스토어 도메인 단위 테스트 작성

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.WonkaoTalk.common.config.security;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtAuthenticationFilter;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtExceptionFilter;
 import com.example.WonkaoTalk.domain.auth.service.OAuth2UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,13 +37,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
-  private final JwtExceptionFilter jwtExceptionFilter;
   private final OAuth2UserService oAuth2UserService;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final ClientRegistrationRepository clientRegistrationRepository;
+  private final ObjectMapper objectMapper;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    JwtExceptionFilter jwtExceptionFilter = new JwtExceptionFilter(objectMapper);
     http
         // REST API 서버이므로 CSRF 보호 비활성화
         .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/jwt/JwtExceptionFilter.java
@@ -4,6 +4,8 @@ import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,11 +13,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 
-@Component
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
@@ -29,6 +29,10 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
   ) throws ServletException, IOException {
     try {
       filterChain.doFilter(request, response);
+    } catch (ExpiredJwtException e) {
+      setErrorResponse(response, ErrorCode.AUTH_EXPIRED_TOKEN);
+    } catch (JwtException | IllegalArgumentException e) {
+      setErrorResponse(response, ErrorCode.AUTH_INVALID_TOKEN);
     } catch (BusinessException e) {
       setErrorResponse(response, e.getErrorCode());
     } catch (Exception e) {

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -77,7 +77,7 @@ public class AuthController {
   @Operation(summary = "로그아웃", description = "access token을 블랙리스트에 등록하고 refresh token 쿠키를 제거합니다.")
   @PostMapping("/logout")
   public ResponseEntity<ApiResponse<Void>> logout(
-      @RequestHeader("Authorization") String authHeader,
+      @RequestHeader(value = "Authorization", required = false) String authHeader,
       @AuthenticationPrincipal UserDetails userDetails
   ) {
     if (authHeader == null || !authHeader.startsWith("Bearer ")) {

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -19,7 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -77,13 +78,18 @@ public class AuthController {
   @PostMapping("/logout")
   public ResponseEntity<ApiResponse<Void>> logout(
       @RequestHeader("Authorization") String authHeader,
-      Authentication authentication
+      @AuthenticationPrincipal UserDetails userDetails
   ) {
     if (authHeader == null || !authHeader.startsWith("Bearer ")) {
       throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
     }
+
+    if (userDetails == null) {
+      throw new BusinessException(ErrorCode.UNAUTHORIZED);
+    }
+
     String accessToken = authHeader.substring(7);
-    String email = authentication.getName();
+    String email = userDetails.getUsername();
 
     authService.invalidateToken(email, accessToken);
 

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthLocal.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/entity/AuthLocal.java
@@ -47,6 +47,7 @@ public class AuthLocal {
   @Column(name = "password_hash", nullable = false)
   private String passwordHash;
 
+  @Builder.Default
   @Column(name = "failed_attempts_count")
   private int failedAttemptsCount = 0;
 

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
@@ -35,18 +35,6 @@ public class AuthService {
     return EmailCheckResponse.from(!authCommandService.existsByEmail(request.email()));
   }
 
-  public Auth createAuthLocal(String email, String password, Role role) {
-    if (authCommandService.existsByEmail(email)) {
-      throw new BusinessException(ErrorCode.AUTH_DUPLICATE_EMAIL);
-    }
-    String encodedPassword = passwordEncoder.encode(password);
-
-    Auth auth = authCommandService.saveAuth(role);
-    authCommandService.saveAuthLocal(auth, email, encodedPassword);
-
-    return auth;
-  }
-
   public TokenDto login(LoginRequest request, HttpServletRequest httpRequest) {
     // TODO: 로그인 실패 횟수에 따른 계정 잠금이나 추가인증 기능 구현
     AuthLocal authLocal = authCommandService.getAuthLocalByEmail(request.email());

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserService.java
@@ -41,6 +41,10 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
   @Transactional
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
     OAuth2User oAuth2User = super.loadUser(userRequest);
+    return processOAuth2User(userRequest, oAuth2User);
+  }
+
+  OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
     OAuth2UserInfo userInfo = extractUserInfo(userRequest, oAuth2User);
     Auth auth = getOrRegisterUser(userInfo);
 

--- a/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/entity/User.java
@@ -59,6 +59,7 @@ public class User {
   @Column(length = 13, unique = true)
   private String phone;
 
+  @Builder.Default
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private Gender gender = Gender.NONE;

--- a/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
           .birthDate(request.birthDate())
           .gender(request.gender())
           .build();
-      userRepo.save(user);
+      user = userRepo.save(user);
     } else {
       if (auth.getRole() == Role.SELLER) {
         auth.updateRole(Role.USER_SELLER);

--- a/src/test/java/com/example/WonkaoTalk/application/facade/WithdrawTransactionProcessorTest.java
+++ b/src/test/java/com/example/WonkaoTalk/application/facade/WithdrawTransactionProcessorTest.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.application.facade;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -8,6 +9,7 @@ import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.auth.service.AuthCommandService;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
+import com.example.WonkaoTalk.domain.seller.service.SellerService;
 import com.example.WonkaoTalk.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,11 +33,15 @@ class WithdrawTransactionProcessorTest {
   @Mock
   private AuthCommandService authCommandService;
 
+  @Mock
+  private SellerService sellerService;
+
   @Test
   @DisplayName("회원 탈퇴 DB 트랜잭션 - 일반 사용자 회원 탈퇴 성공")
   public void processWithdrawSuccessGeneralUser() {
     // given
     Long authId = 1L;
+    given(sellerService.existsActiveSeller(authId)).willReturn(false);
 
     // when
     withdrawTransactionProcessor.withdrawUser(authId);
@@ -50,6 +56,7 @@ class WithdrawTransactionProcessorTest {
   public void processWithdrawSuccessUserSeller() {
     // given
     Long authId = 1L;
+    given(sellerService.existsActiveSeller(authId)).willReturn(true);
 
     // when
     withdrawTransactionProcessor.withdrawUser(authId);

--- a/src/test/java/com/example/WonkaoTalk/common/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/common/integration/BaseIntegrationTest.java
@@ -1,0 +1,24 @@
+package com.example.WonkaoTalk.common.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public abstract class BaseIntegrationTest {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @Value("${jwt.secret}")
+  protected String secretKey;
+}

--- a/src/test/java/com/example/WonkaoTalk/common/oauth/OAuthRevocationAsyncHandlerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/common/oauth/OAuthRevocationAsyncHandlerTest.java
@@ -1,0 +1,93 @@
+package com.example.WonkaoTalk.common.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+
+import com.example.WonkaoTalk.domain.auth.entity.OAuthRevocationFailure;
+import com.example.WonkaoTalk.domain.auth.enums.AuthProvider;
+import com.example.WonkaoTalk.domain.auth.enums.FallbackStatus;
+import com.example.WonkaoTalk.domain.auth.repo.OAuthRevocationFailureRepo;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthRevocationAsyncHandlerTest {
+
+  private OAuthRevocationAsyncHandler asyncHandler;
+
+  @Mock
+  private OAuthRevocationFailureRepo failureRepo;
+  @Mock
+  private OAuthRevocationProvider providerClient;
+  @Mock
+  private Executor executor;
+
+  @BeforeEach
+  void setUp() {
+    asyncHandler = new OAuthRevocationAsyncHandler(failureRepo, List.of(providerClient), executor);
+  }
+
+  @Test
+  @DisplayName("연동 해제 스케줄러 - 외부 API 통신 실패 시 재시도 횟수가 증가하고 상태는 PENDING으로 유지된다")
+  void processSingleFailure_ApiThrowsException_IncrementsRetryCount() {
+    // given
+    Long failureId = 1L;
+    OAuthRevocationFailure failure = OAuthRevocationFailure.builder()
+        .provider(AuthProvider.GOOGLE)
+        .providerUserId("provider_id")
+        .providerRefreshToken("refresh_token")
+        .build();
+
+    ReflectionTestUtils.setField(failure, "retryCount", 0);
+
+    given(failureRepo.findById(failureId)).willReturn(Optional.of(failure));
+    given(providerClient.supports(AuthProvider.GOOGLE)).willReturn(true);
+
+    // 통신 시 예외 발생 시뮬레이션
+    doThrow(new RuntimeException("API Timeout")).when(providerClient).revoke(any(), any());
+
+    // when
+    asyncHandler.processSingleFailure(failureId);
+
+    // then
+    assertThat(failure.getStatus()).isEqualTo(FallbackStatus.PENDING);
+    assertThat(failure.getRetryCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("연동 해제 스케줄러 - 최대 재시도 횟수 초과 시 상태가 PERMANENT_FAILURE로 변경된다")
+  void processSingleFailure_MaxRetryExceeded_ChangesStatusToPermanentFailure() {
+    // given
+    Long failureId = 1L;
+    OAuthRevocationFailure failure = OAuthRevocationFailure.builder()
+        .provider(AuthProvider.GOOGLE)
+        .providerUserId("provider_id")
+        .providerRefreshToken("refresh_token")
+        .build();
+
+    // 재시도 횟수를 임계치(MAX_RETRY_COUNT - 1)로 설정하여, 다음 실패 시 상태가 변경되도록 유도
+    ReflectionTestUtils.setField(failure, "retryCount",
+        OAuthRevocationAsyncHandler.MAX_RETRY_COUNT - 1);
+
+    given(failureRepo.findById(failureId)).willReturn(Optional.of(failure));
+    given(providerClient.supports(AuthProvider.GOOGLE)).willReturn(true);
+    doThrow(new RuntimeException("API Timeout")).when(providerClient).revoke(any(), any());
+
+    // when
+    asyncHandler.processSingleFailure(failureId);
+
+    // then
+    assertThat(failure.getStatus()).isEqualTo(FallbackStatus.PERMANENT_FAILURE);
+    assertThat(failure.getRetryCount()).isEqualTo(OAuthRevocationAsyncHandler.MAX_RETRY_COUNT);
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
@@ -166,9 +166,9 @@ class AuthControllerTest {
     // when & then
     mockMvc.perform(post("/api/v1/auth/logout")
             .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isInternalServerError())
+        .andExpect(status().isUnauthorized())
         .andExpect(jsonPath("$.status").value("ERROR"))
-        .andExpect(jsonPath("$.error").value("SYS-INTERNAL-ERROR"));
+        .andExpect(jsonPath("$.error").value("AUTH-INVALID-TOKEN"));
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
@@ -1,15 +1,22 @@
 package com.example.WonkaoTalk.domain.auth.controller;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.WonkaoTalk.common.config.JacksonConfig;
+import com.example.WonkaoTalk.common.config.security.OAuth2SuccessHandler;
+import com.example.WonkaoTalk.common.config.security.SecurityConfig;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtExceptionFilter;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtTokenProvider;
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.common.redis.RedisService;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckRequest;
 import com.example.WonkaoTalk.domain.auth.dto.EmailCheckResponse;
@@ -17,6 +24,7 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
+import com.example.WonkaoTalk.domain.auth.service.OAuth2UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
@@ -26,12 +34,13 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(JacksonConfig.class)
+@Import({JacksonConfig.class, SecurityConfig.class})
 class AuthControllerTest {
 
   private final Auth auth = Auth.builder().build();
@@ -49,6 +58,10 @@ class AuthControllerTest {
   private JwtTokenProvider jwtTokenProvider;
   @MockitoBean
   private RedisService redisService;
+  @MockitoBean
+  private OAuth2UserService oAuth2UserService;
+  @MockitoBean
+  private OAuth2SuccessHandler oAuth2SuccessHandler;
 
   @Test
   @DisplayName("이메일 중복 검사 - 미가입 이메일 검사 성공")
@@ -59,8 +72,9 @@ class AuthControllerTest {
     given(authService.validateEmail(request)).willReturn(response);
 
     //when & then
-    mockMvc.perform(get("/api/v1/auth/email-check")
-            .param("email", "test@test.com"))
+    mockMvc.perform(post("/api/v1/auth/check-email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.isValid").value(true));
   }
@@ -74,8 +88,9 @@ class AuthControllerTest {
     given(authService.validateEmail(request)).willReturn(response);
 
     //when & then
-    mockMvc.perform(get("/api/v1/auth/email-check")
-            .param("email", "test@test.com"))
+    mockMvc.perform(post("/api/v1/auth/check-email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.isValid").value(false));
   }
@@ -108,11 +123,12 @@ class AuthControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.accessToken").exists());
+        .andExpect(jsonPath("$.data.tokenInfo.accessToken").exists());
   }
 
   @Test
   @DisplayName("로그아웃 - 명시적 로그아웃 및 블랙리스트 등록")
+  @WithMockUser(username = "test@test.com")
   void logoutSuccess() throws Exception {
     // given
     String validAccessToken = "Bearer valid.access.token";
@@ -123,28 +139,104 @@ class AuthControllerTest {
         .andExpect(status().isOk());
   }
 
-//  @Test
-//  @DisplayName("로그아웃 - 이미 만료된 토큰으로 로그아웃 시도 실패")
-//  public void logoutFailed() throws Exception {
-//    //given
-//    String expiredAccessToken = "Bearer expired.access.token";
-//    //when & then
-//    mockMvc.perform(post("/api/v1/auth/logout")
-//            .header("Authorization", expiredAccessToken))
-//        .andExpect(jsonPath("$.status").value("ERROR"))
-//        .andExpect(jsonPath("$.error").value("AUTH-INVALID-TOKEN"));
-//  }
+  @Test
+  @DisplayName("로그아웃 - 이미 만료된 토큰으로 로그아웃 시도 실패")
+  @WithMockUser(username = "test@test.com")
+  public void logoutFailed() throws Exception {
+    //given
+    String expiredAccessToken = "Bearer expired.access.token";
+    String parsedToken = "expired.access.token";
+
+    willThrow(new BusinessException(ErrorCode.AUTH_INVALID_TOKEN)).given(authService)
+        .invalidateToken(eq("test@test.com"), eq(parsedToken));
+    //when & then
+    mockMvc.perform(post("/api/v1/auth/logout")
+            .header("Authorization", expiredAccessToken))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("AUTH-INVALID-TOKEN"));
+  }
 
   @Test
   @DisplayName("로그아웃 - 인증되지 않은 사용자의 로그아웃 시도 실패")
-  void logout_Fail_UnauthenticatedUser() throws Exception {
+  void logoutFailUnauthenticatedUser() throws Exception {
     // given
     // Authorization 헤더가 없는 상태의 요청 (인증되지 않은 사용자)
 
     // when & then
     mockMvc.perform(post("/api/v1/auth/logout")
             .contentType(MediaType.APPLICATION_JSON))
-        // Spring Security의 AuthenticationEntryPoint에 의해 401 반환 검증
-        .andExpect(status().isUnauthorized());
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("SYS-INTERNAL-ERROR"));
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 - 쿠키에 refresh-token이 누락된 경우 AUTH_MISSING_TOKEN 예외 응답을 반환한다")
+  void reissueTokenMissingCookieThrowsException() throws Exception {
+    // given & when & then
+    mockMvc.perform(post("/api/v1/auth/reissue")
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("AUTH-MISSING-TOKEN"));
+  }
+
+  @Test
+  @DisplayName("토큰 재발급 - 유효한 리프레시 토큰을 쿠키로 전달하면 새로운 토큰 정보와 Set-Cookie 헤더를 반환한다")
+  void reissueTokenSuccess() throws Exception {
+    // given
+    String validRefreshToken = "valid.refresh.token";
+    TokenDto mockTokenDto = TokenDto.of(
+        "new.access.token",
+        "new.refresh.token",
+        3600000L,
+        86400000L,
+        Auth.builder().build(),
+        "침착맨"
+    );
+
+    given(authService.reissueToken(validRefreshToken)).willReturn(mockTokenDto);
+
+    // when & then
+    mockMvc.perform(post("/api/v1/auth/reissue")
+            .cookie(new jakarta.servlet.http.Cookie("refresh-token", validRefreshToken)))
+        .andExpect(status().isOk())
+        .andExpect(header().exists(org.springframework.http.HttpHeaders.SET_COOKIE))
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data.tokenInfo.accessToken").value("new.access.token"))
+        .andExpect(jsonPath("$.data.userInfo.profileName").value("침착맨"));
+  }
+
+  @Test
+  @DisplayName("로그인 유효성 검사 실패 - 올바르지 않은 이메일 형식 요청 시 컨트롤러 진입 전 400 에러로 차단된다")
+  void loginInvalidEmailValidationFailed() throws Exception {
+    // given
+    LoginRequest invalidRequest = new LoginRequest("invalid-email-format", "password123");
+
+    // when & then
+    mockMvc.perform(post("/api/v1/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(invalidRequest)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.message").value(containsString("올바른 이메일 형식이 아닙니다")));
+  }
+
+  @Test
+  @DisplayName("로그인 실패 - 서비스에서 비밀번호 불일치 비즈니스 예외가 발생하면 전역 예외 처리기가 에러 포맷으로 변환한다")
+  void loginPasswordMismatchReturnsErrorResponse() throws Exception {
+    // given
+    LoginRequest request = new LoginRequest("test@test.com", "wrong_password");
+    given(authService.login(any(LoginRequest.class), any()))
+        .willThrow(new BusinessException(ErrorCode.AUTH_MISMATCH_PASSWORD));
+
+    // when & then
+    mockMvc.perform(post("/api/v1/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest()) //
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("AUTH-MISMATCH-PASSWORD"));
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/integration/AuthIntegrationTest.java
@@ -1,0 +1,140 @@
+package com.example.WonkaoTalk.domain.auth.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.WonkaoTalk.common.integration.BaseIntegrationTest;
+import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
+import com.example.WonkaoTalk.domain.auth.enums.Role;
+import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
+import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class AuthIntegrationTest extends BaseIntegrationTest {
+
+  private final String testEmail = "integration@test.com";
+  private final String testPassword = "ValidPassword123!";
+  @Autowired
+  private AuthRepo authRepo;
+  @Autowired
+  private AuthLocalRepo authLocalRepo;
+  @Autowired
+  private UserRepo userRepo;
+  @Autowired
+  private LoginHistoryRepo loginHistoryRepo;
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+
+  @BeforeEach
+  void setUp() {
+    Auth auth = Auth.builder().role(Role.USER).build();
+    authRepo.save(auth);
+    AuthLocal authLocal = AuthLocal.builder()
+        .email(testEmail)
+        .passwordHash(passwordEncoder.encode(testPassword))
+        .auth(auth)
+        .build();
+    authLocalRepo.save(authLocal);
+    User user = User.builder()
+        .auth(auth)
+        .nickname("TestUser")
+        .name("TestUser")
+        .phone("010-0000-0000")
+        .build();
+    userRepo.save(user);
+  }
+
+  @Test
+  @DisplayName("시나리오 1: 정상 로그인 시 토큰 발급 및 접속 이력 저장 확인")
+  void login_Success_ReturnsTokenAndSavesHistory() throws Exception {
+    // given
+    long initialHistoryCount = loginHistoryRepo.count();
+    LoginRequest request = new LoginRequest(testEmail, testPassword);
+
+    // when & then
+    mockMvc.perform(post("/api/v1/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.tokenInfo.accessToken").exists())
+        .andExpect(jsonPath("$.data.tokenInfo.grantType").value("Bearer"));
+
+    long finalHistoryCount = loginHistoryRepo.count();
+    assertThat(finalHistoryCount).isEqualTo(initialHistoryCount + 1);
+
+    LoginHistory savedHistory = loginHistoryRepo.findAll().get((int) finalHistoryCount - 1);
+    assertThat(savedHistory.getAuth().getId()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("시나리오 2-A: 조작된 토큰으로 API 접근 시 Security 필터에서 차단 및 401 반환")
+  void access_WithManipulatedToken_ReturnsUnauthorized() throws Exception {
+    // given
+    String manipulatedToken = "Bearer eyJhbGciOiJIUzI1NiJ9.ManipulatedPayload.InvalidSignature";
+
+    // when & then
+    mockMvc.perform(get("/api/v1/users/me")
+            .header("Authorization", manipulatedToken))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("AUTH-INVALID-TOKEN"));
+  }
+
+  @Test
+  @DisplayName("시나리오 2-B: 만료된 토큰으로 API 접근 시 Security 필터에서 차단 및 401 반환")
+  void access_WithExpiredToken_ReturnsUnauthorized() throws Exception {
+    // given
+    String expiredToken = "Bearer " + createExpiredTokenForTest(testEmail);
+
+    // when & then
+    mockMvc.perform(get("/api/v1/users/me")
+            .header("Authorization", expiredToken))
+        .andDo(print())
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error").value("AUTH-EXPIRED-TOKEN"));
+  }
+
+  private String createExpiredTokenForTest(String email) {
+    Date now = new Date();
+    // 현재 시간으로부터 1시간 전으로 만료 시간을 설정 (과거)
+    Date pastExpiration = new Date(now.getTime() - (1000 * 60 * 60));
+
+    byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+
+    return Jwts.builder()
+        .setSubject(email)
+        .setIssuedAt(now)
+        .setExpiration(pastExpiration)
+        .signWith(Keys.hmacShaKeyFor(keyBytes), SignatureAlgorithm.HS256)
+        .compact();
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandServiceTest.java
@@ -2,24 +2,40 @@ package com.example.WonkaoTalk.domain.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.dto.AuthIntegrationResultDto;
+import com.example.WonkaoTalk.domain.auth.dto.AuthUserInfoDto;
+import com.example.WonkaoTalk.domain.auth.dto.SocialLoginDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import com.example.WonkaoTalk.domain.auth.entity.AuthSocial;
+import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
+import com.example.WonkaoTalk.domain.auth.enums.AuthProvider;
+import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
 import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
 import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
 import com.example.WonkaoTalk.domain.auth.repo.AuthSocialRepo;
+import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
+import com.example.WonkaoTalk.domain.seller.entity.Seller;
+import com.example.WonkaoTalk.domain.seller.repo.SellerRepo;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,6 +45,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 class AuthCommandServiceTest {
 
   private final Long authId = 1L;
+  @Mock
+  LoginHistoryRepo loginHistoryRepo;
   @InjectMocks
   private AuthCommandService authCommandService;
   @Mock
@@ -37,20 +55,24 @@ class AuthCommandServiceTest {
   private AuthLocalRepo authLocalRepo;
   @Mock
   private AuthSocialRepo authSocialRepo;
+  @Mock
+  private UserRepo userRepo;
+  @Mock
+  private SellerRepo sellerRepo;
 
   @Test
   @DisplayName("일반/소셜 통합 계정에서 유저 탈퇴 시, 활성화된 판매자가 있다면 Role만 SELLER로 부분 탈퇴된다.")
-  public void handleUserWithdraw_PartialWithdraw_RoleDowngraded() {
+  public void handleUserWithdrawPartialWithdrawRoleDowngraded() {
     // given
     Auth auth = Auth.builder().role(Role.USER_SELLER).build();
     ReflectionTestUtils.setField(auth, "id", authId);
 
     given(authRepo.findById(authId)).willReturn(Optional.of(auth));
 
-    // when (활성화된 판매자가 존재함 = true)
+    // when
     authCommandService.handleUserWithdraw(authId, true);
 
-    // then (상태 검증)
+    // then
     assertThat(auth.getRole()).isEqualTo(Role.SELLER);
     then(authLocalRepo).should(never()).findByAuth(auth);
     then(authSocialRepo).should(never()).findByAuth(auth);
@@ -70,15 +92,12 @@ class AuthCommandServiceTest {
     given(authLocalRepo.findByAuth(auth)).willReturn(Optional.of(authLocal));
     given(authSocialRepo.findByAuth(auth)).willReturn(List.of(authSocial));
 
-    // when (활성화된 판매자가 없음 = false)
+    // when
     authCommandService.handleUserWithdraw(authId, false);
 
-    // then (상태 검증: 엔티티 내부의 withdraw() 동작 확인)
-    assertThat(authLocal.getEmail()).isNotEqualTo("test@test.com"); // 마스킹 적용 확인
-    assertThat(authSocial.getProviderUserId()).isNotEqualTo("google_12345"); // 마스킹 적용 확인
-
-    // 엔티티 구조에 맞춰 isDeleted 필드나 getDeletedAt() 필드의 상태를 확인해야 합니다.
-    // 예시: assertThat(auth.getDeletedAt()).isNotNull();
+    // then
+    assertThat(authLocal.getEmail()).isNotEqualTo("test@test.com");
+    assertThat(authSocial.getProviderUserId()).isNotEqualTo("google_12345");
 
     then(authLocalRepo).should(times(1)).findByAuth(auth);
     then(authSocialRepo).should(times(1)).findByAuth(auth);
@@ -111,5 +130,328 @@ class AuthCommandServiceTest {
     assertThatThrownBy(() -> authCommandService.handleUserWithdraw(authId, false))
         .extracting("errorCode")
         .isEqualTo(ErrorCode.AUTH_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 데이터 생성 - 일반 사용자(USER)인 경우 SellerId는 null이어야 한다.")
+  public void generateSocialLoginDataUserRoleReturnsDtoWithoutSellerId() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+    AuthSocial authSocial = AuthSocial.builder().auth(auth).build();
+
+    User user = User.builder().build();
+    ReflectionTestUtils.setField(user, "id", 100L);
+
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(AuthProvider.GOOGLE, "google_123"))
+        .willReturn(Optional.of(authSocial));
+    given(userRepo.findByAuth(auth)).willReturn(Optional.of(user));
+
+    // when
+    SocialLoginDto result = authCommandService.generateSocialLoginData("test@test.com",
+        AuthProvider.GOOGLE, "google_123");
+
+    // then
+    assertThat(result.authId()).isEqualTo(1L);
+    assertThat(result.userId()).isEqualTo(100L);
+    assertThat(result.sellerId()).isNull();
+    assertThat(result.role()).isEqualTo(Role.USER);
+    verify(sellerRepo, never()).findByAuth(any());
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 데이터 생성 - 판매자(USER_SELLER)인 경우 UserId와 SellerId를 모두 반환한다.")
+  public void generateSocialLoginDataSellerRoleReturnsDtoWithBothIds() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER_SELLER).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+    AuthSocial authSocial = AuthSocial.builder().auth(auth).build();
+
+    User user = User.builder().build();
+    ReflectionTestUtils.setField(user, "id", 100L);
+    Seller seller = Seller.builder().build();
+    ReflectionTestUtils.setField(seller, "id", 50L);
+
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(AuthProvider.NAVER, "naver_123"))
+        .willReturn(Optional.of(authSocial));
+    given(userRepo.findByAuth(auth)).willReturn(Optional.of(user));
+    given(sellerRepo.findByAuth(auth)).willReturn(Optional.of(seller));
+
+    // when
+    SocialLoginDto result = authCommandService.generateSocialLoginData("test@test.com",
+        AuthProvider.NAVER, "naver_123");
+
+    // then
+    assertThat(result.userId()).isEqualTo(100L);
+    assertThat(result.sellerId()).isEqualTo(50L);
+    assertThat(result.role()).isEqualTo(Role.USER_SELLER);
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 데이터 생성 - 소셜 계정이 존재하지 않으면 AUTH_NOT_FOUND 예외가 발생한다.")
+  public void generateSocialLoginDataNotFoundThrowsException() {
+    // given
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(any(), any()))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+        () -> authCommandService.generateSocialLoginData("test@test.com", AuthProvider.GOOGLE,
+            "invalid_id"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.AUTH_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("로그인 이력 저장 - 파라미터가 LoginHistory 엔티티로 정상 변환되어 저장된다.")
+  public void saveLoginHistoryConvertsAndSavesProperly() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER).build();
+    ArgumentCaptor<LoginHistory> captor = ArgumentCaptor.forClass(LoginHistory.class);
+
+    // when
+    authCommandService.saveLoginHistory(auth, LoginStatus.SUCCESS, "Mozilla/5.0", "192.168.0.1");
+
+    // then
+    verify(loginHistoryRepo, times(1)).save(captor.capture());
+    LoginHistory savedHistory = captor.getValue();
+
+    assertThat(savedHistory.getAuth()).isEqualTo(auth);
+    assertThat(savedHistory.getStatus()).isEqualTo(LoginStatus.SUCCESS);
+    assertThat(savedHistory.getUserAgent()).isEqualTo("Mozilla/5.0");
+    assertThat(savedHistory.getIpAddress()).isEqualTo("192.168.0.1");
+  }
+
+  @Test
+  @DisplayName("소셜 이메일 단건 조회 - 이메일 기반 첫 번째 소셜 계정을 정상적으로 반환한다.")
+  public void getFirstAuthSocialByEmailReturnsFirstMatched() {
+    // given
+    String email = "test@test.com";
+    AuthSocial social = AuthSocial.builder().email(email).build();
+    given(authSocialRepo.findFirstByEmail(email)).willReturn(Optional.of(social));
+
+    // when
+    Optional<AuthSocial> result = authCommandService.getFirstAuthSocialByEmail(email);
+
+    // then
+    assertThat(result).isPresent();
+    assertThat(result.get().getEmail()).isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("일반 계정 조회 - 이메일로 AuthLocal을 정상 조회한다")
+  public void getAuthLocalByEmailSuccess() {
+    // given
+    String email = "test@test.com";
+    AuthLocal authLocal = AuthLocal.builder().email(email).build();
+    given(authLocalRepo.findByEmailWithAuth(email)).willReturn(Optional.of(authLocal));
+
+    // when
+    AuthLocal result = authCommandService.getAuthLocalByEmail(email);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getEmail()).isEqualTo(email);
+  }
+
+  @Test
+  @DisplayName("일반 계정 조회 - 이메일이 존재하지 않으면 예외가 발생한다")
+  public void getAuthLocalByEmailNotFoundThrowsException() {
+    // given
+    given(authLocalRepo.findByEmailWithAuth(anyString())).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> authCommandService.getAuthLocalByEmail("unknown@test.com"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.AUTH_INVALID_EMAIL);
+  }
+
+  @Test
+  @DisplayName("인증 유저 정보 조회 - User 권한일 경우 UserRepo에서 프로필(닉네임)을 정상 반환한다")
+  public void getAuthUserInfoUserRoleReturnsCorrectInfo() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+
+    User user = User.builder().build(); // name 대신 nickname 필드 사용 가정
+    ReflectionTestUtils.setField(user, "id", 100L);
+    ReflectionTestUtils.setField(user, "nickname", "침착맨");
+
+    given(userRepo.findByAuth(auth)).willReturn(Optional.of(user));
+
+    // when
+    AuthUserInfoDto result = authCommandService.getAuthUserInfo(auth);
+
+    // then
+    assertThat(result.userId()).isEqualTo(100L);
+    assertThat(result.profileName()).isEqualTo("침착맨");
+    assertThat(result.sellerId()).isNull();
+  }
+
+  @Test
+  @DisplayName("인증 유저 정보 조회 - 프로필 정보가 데이터베이스에 없으면 예외가 발생한다")
+  public void getAuthUserInfoProfileNotFoundThrowsException() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER).build();
+    given(userRepo.findByAuth(auth)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> authCommandService.getAuthUserInfo(auth))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 DTO 생성 - 관리자(ADMIN) 권한일 경우 sellerRepo 조회를 생략한다 (Branch 통과)")
+  public void generateSocialLoginDataAdminRoleSkipsSellerRepo() {
+    // given
+    Auth auth = Auth.builder().role(Role.ADMIN).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+    AuthSocial authSocial = AuthSocial.builder().auth(auth).build();
+    User user = User.builder().build();
+    ReflectionTestUtils.setField(user, "id", 99L);
+
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(AuthProvider.GOOGLE, "123"))
+        .willReturn(Optional.of(authSocial));
+    given(userRepo.findByAuth(auth)).willReturn(Optional.of(user));
+
+    // when
+    SocialLoginDto dto = authCommandService.generateSocialLoginData("admin@test.com",
+        AuthProvider.GOOGLE, "123");
+
+    // then
+    assertThat(dto.role()).isEqualTo(Role.ADMIN);
+    assertThat(dto.sellerId()).isNull();
+    verify(sellerRepo, never()).findByAuth(any());
+  }
+
+  @Test
+  @DisplayName("완전 탈퇴 처리 - 연결된 AuthLocal과 AuthSocial이 없어도 안전하게 처리된다 (null-safe Branch)")
+  public void processFullWithdrawEmptyRelationsDoesNotThrow() {
+    // given
+    Long authId = 1L;
+    Auth auth = Auth.builder().role(Role.USER).build();
+    ReflectionTestUtils.setField(auth, "id", authId);
+
+    given(authRepo.findById(authId)).willReturn(Optional.of(auth));
+    given(authLocalRepo.findByAuth(auth)).willReturn(Optional.empty()); // Local 없음
+    given(authSocialRepo.findByAuth(auth)).willReturn(List.of()); // Social 없음
+
+    // when
+    authCommandService.handleUserWithdraw(authId, false);
+
+    // then
+    verify(authRepo, times(1)).findById(authId);
+  }
+
+  @Test
+  @DisplayName("일반 계정 저장 - 이메일이 이미 존재하면 AUTH_DUPLICATE_EMAIL 예외가 발생한다")
+  public void saveAuthLocalDuplicateEmailThrowsException() {
+    // given
+    Auth auth = Auth.builder().build();
+    String email = "test@test.com";
+    given(authLocalRepo.existsByEmail(email)).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> authCommandService.saveAuthLocal(auth, email, "password"))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.AUTH_DUPLICATE_EMAIL);
+
+    verify(authLocalRepo, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("일반 계정 저장 - 이메일 중복이 없으면 정상적으로 AuthLocal 엔티티가 저장된다")
+  public void saveAuthLocalSuccess() {
+    // given
+    Auth auth = Auth.builder().build();
+    String email = "test@test.com";
+    given(authLocalRepo.existsByEmail(email)).willReturn(false);
+
+    // when
+    authCommandService.saveAuthLocal(auth, email, "password");
+
+    // then
+    verify(authLocalRepo, times(1)).save(any(AuthLocal.class));
+  }
+
+  @Test
+  @DisplayName("인증 유저 정보 조회 - 순수 SELLER 권한일 때 SellerRepo에서만 정보를 가져온다")
+  public void getAuthUserInfoOnlySellerRoleReturnsSellerInfo() {
+    // given
+    Auth auth = Auth.builder().role(Role.SELLER).build();
+    Seller seller = Seller.builder().name("침착상회").build();
+    ReflectionTestUtils.setField(seller, "id", 50L);
+
+    given(sellerRepo.findByAuth(auth)).willReturn(Optional.of(seller));
+
+    // when
+    AuthUserInfoDto result = authCommandService.getAuthUserInfo(auth);
+
+    // then
+    assertThat(result.sellerId()).isEqualTo(50L);
+    assertThat(result.profileName()).isEqualTo("침착상회");
+    assertThat(result.userId()).isNull();
+    verify(userRepo, never()).findByAuth(any());
+  }
+
+  @Test
+  @DisplayName("인증 유저 정보 조회 - SELLER 권한이 포함되어 있으나 Seller 엔티티가 없으면 예외 발생")
+  public void getAuthUserInfoSellerNotFoundThrowsException() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER_SELLER).build();
+    given(sellerRepo.findByAuth(auth)).willReturn(Optional.empty());
+    User user = User.builder().build();
+    ReflectionTestUtils.setField(user, "id", 100L);
+    ReflectionTestUtils.setField(user, "nickname", "침착맨");
+    given(userRepo.findByAuth(auth)).willReturn(Optional.of(user));
+
+    // when & then
+    assertThatThrownBy(() -> authCommandService.getAuthUserInfo(auth))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("소셜 연동 처리 - 이미 소셜 이메일이 존재할 경우, 신규 Auth를 생성하지 않고 기존 Auth에 Local을 연동한다")
+  public void linkOrCreateLocal_ExistingSocial_LinksToExistingAuth() {
+    // given
+    String email = "test@test.com";
+    String password = "encodedPassword";
+
+    Auth existingAuth = Auth.builder().role(Role.USER).build();
+    AuthSocial existingSocial = AuthSocial.builder().auth(existingAuth).email(email).build();
+    given(authSocialRepo.findFirstByEmail(email)).willReturn(Optional.of(existingSocial));
+
+    // when
+    AuthIntegrationResultDto result = authCommandService.linkOrCreateTransaction(email, password,
+        Role.USER);
+
+    // then
+    assertThat(result.isNewCreated()).isFalse();
+    assertThat(result.auth()).isEqualTo(existingAuth);
+
+    verify(authRepo, never()).save(any());
+    verify(authLocalRepo, times(1)).save(any(AuthLocal.class));
+  }
+
+  @Test
+  @DisplayName("일반 계정 단독 저장 - Auth와 AuthLocal이 정상적으로 저장된다")
+  public void saveAuth_and_saveAuthLocal_Success() {
+    // given
+    Auth auth = Auth.builder().role(Role.USER).build();
+    String email = "test@test.com";
+    String encodedPassword = "encodedPassword";
+
+    given(authRepo.save(any(Auth.class))).willReturn(auth);
+    given(authLocalRepo.existsByEmail(email)).willReturn(false);
+
+    // when
+    Auth savedAuth = authCommandService.saveAuth(Role.USER);
+    authCommandService.saveAuthLocal(savedAuth, email, encodedPassword);
+
+    // then
+    verify(authRepo, times(1)).save(any(Auth.class));
+    verify(authLocalRepo, times(1)).save(any(AuthLocal.class));
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
-import com.example.WonkaoTalk.common.exception.BusinessException;
 import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
@@ -59,7 +58,7 @@ class AuthCommandServiceTest {
 
   @Test
   @DisplayName("유저 단일 계정 탈퇴 시, 활성화된 판매자가 없다면 연관된 인증 정보가 마스킹되고 완전 탈퇴(Soft Delete)된다.")
-  public void handleUserWithdraw_FullWithdraw_AnonymizedAndDeleted() {
+  public void handleUserWithdrawFullWithdrawAnonymizedAndDeleted() {
     // given
     Auth auth = Auth.builder().role(Role.USER).build();
     ReflectionTestUtils.setField(auth, "id", authId);
@@ -87,7 +86,7 @@ class AuthCommandServiceTest {
 
   @Test
   @DisplayName("일반/소셜 통합 계정에서 판매자 탈퇴 시, 활성화된 유저가 있다면 Role만 USER로 부분 탈퇴된다.")
-  public void handleSellerWithdraw_PartialWithdraw_RoleDowngraded() {
+  public void handleSellerWithdrawPartialWithdrawRoleDowngraded() {
     // given
     Auth auth = Auth.builder().role(Role.USER_SELLER).build();
     ReflectionTestUtils.setField(auth, "id", authId);
@@ -104,13 +103,13 @@ class AuthCommandServiceTest {
 
   @Test
   @DisplayName("존재하지 않는 계정 탈퇴 요청 시 BusinessException 예외가 발생한다.")
-  public void handleWithdraw_NotFound_ThrowsException() {
+  public void handleWithdrawNotFoundThrowsException() {
     // given
     given(authRepo.findById(authId)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> authCommandService.handleUserWithdraw(authId, false))
-        .isInstanceOf(BusinessException.class)
-        .hasMessageContaining(ErrorCode.AUTH_NOT_FOUND.name());
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.AUTH_NOT_FOUND);
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -25,17 +25,14 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
-import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
 import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
-import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -58,11 +55,6 @@ class AuthServiceTest {
   private JwtTokenProvider jwtTokenProvider;
   @Mock
   private RedisService redisService;
-  @Mock
-  private LoginHistoryRepo loginHistoryRepo;
-
-  @Captor
-  private ArgumentCaptor<LoginHistory> loginHistoryCaptor;
 
   private MockHttpServletRequest httpRequest;
 
@@ -100,20 +92,6 @@ class AuthServiceTest {
     //then
     assertThat(response.isValid()).isFalse();
 
-  }
-
-  @Test
-  @DisplayName("회원가입 - 클라이언트 검증을 우회한 중복 가입 시도 실패")
-  public void createAuthFailedByDuplicateEmail() {
-    //given
-    given(authCommandService.existsByEmail(email)).willReturn(true);
-
-    //when & then
-    BusinessException e = assertThrows(BusinessException.class, () -> {
-      authService.createAuthLocal(email, "password", Role.USER);
-    });
-
-    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.AUTH_DUPLICATE_EMAIL);
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -25,13 +25,17 @@ import com.example.WonkaoTalk.domain.auth.dto.LoginRequest;
 import com.example.WonkaoTalk.domain.auth.dto.TokenDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.entity.LoginHistory;
 import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
+import com.example.WonkaoTalk.domain.auth.repo.LoginHistoryRepo;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -54,12 +58,18 @@ class AuthServiceTest {
   private JwtTokenProvider jwtTokenProvider;
   @Mock
   private RedisService redisService;
+  @Mock
+  private LoginHistoryRepo loginHistoryRepo;
+
+  @Captor
+  private ArgumentCaptor<LoginHistory> loginHistoryCaptor;
+
   private MockHttpServletRequest httpRequest;
 
   @BeforeEach
   void setUp() {
     httpRequest = new MockHttpServletRequest();
-    httpRequest.addHeader("User-Agent", "Test-Agent");
+    httpRequest.addHeader("User-Agent", "User-Agent");
     httpRequest.setRemoteAddr("127.0.0.1");
   }
 
@@ -155,7 +165,8 @@ class AuthServiceTest {
         .email(email).passwordHash("encoded").auth(auth).build();
 
     given(authCommandService.getAuthLocalByEmail(email)).willReturn(authLocal);
-    given(passwordEncoder.matches(password, authLocal.getPasswordHash())).willReturn(false);
+    given(passwordEncoder.matches(request.password(), authLocal.getPasswordHash())).willReturn(
+        false);
 
     //when & then
     assertThatThrownBy(() -> authService.login(request, httpRequest))
@@ -253,5 +264,68 @@ class AuthServiceTest {
 
     // 탈취 의심 시 해당 유저의 기존 Refresh Token을 즉각 삭제하는지 검증
     verify(redisService, times(1)).deleteValues("RT:" + email);
+  }
+
+  @Test
+  @DisplayName("로그인 - X-Forwarded-For 헤더에 다수의 IP가 존재할 경우 첫 번째 IP를 정확히 추출한다")
+  void loginExtractsFirstIpFromXForwardedFor() {
+    // given
+    ArgumentCaptor<String> ipAddressCaptor = ArgumentCaptor.forClass(String.class);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("X-Forwarded-For", "192.168.0.1, 10.0.0.1, 172.16.0.1");
+    request.setRemoteAddr("127.0.0.1");
+
+    LoginRequest loginRequest = new LoginRequest("test@test.com", "password123");
+    Auth auth = Auth.builder().role(Role.USER).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+
+    AuthLocal authLocal = AuthLocal.builder().email("test@test.com").passwordHash("hashed")
+        .auth(auth).build();
+
+    given(authCommandService.getAuthLocalByEmail(loginRequest.email())).willReturn(authLocal);
+    given(passwordEncoder.matches(loginRequest.password(), authLocal.getPasswordHash())).willReturn(
+        true);
+    given(authCommandService.getAuthUserInfo(auth)).willReturn(
+        new AuthUserInfoDto("침착맨", 1L, null));
+    given(jwtTokenProvider.createAccessToken(any(), any(), any(), any(), any())).willReturn(
+        "access.token");
+    given(jwtTokenProvider.createRefreshToken(any())).willReturn("refresh.token");
+    given(jwtTokenProvider.getRefreshTokenValidTime()).willReturn(86400000L);
+    given(jwtTokenProvider.getAccessTokenValidTime()).willReturn(3600000L);
+
+    // when
+    authService.login(loginRequest, request);
+
+    // then
+    verify(authCommandService).saveLoginHistory(
+        eq(auth),
+        eq(LoginStatus.SUCCESS),
+        any(), // User-Agent (이 테스트에서는 중요하지 않음)
+        ipAddressCaptor.capture() // 추출된 IP가 파라미터로 잘 넘어갔는지 캡처
+    );
+    assertThat(ipAddressCaptor.getValue()).isEqualTo("192.168.0.1");
+  }
+
+  @Test
+  @DisplayName("토큰 무효화 - 이미 만료되었거나 Redis에 없는 토큰이라도 남은 시간만큼 블랙리스트에 정상 등록된다")
+  void invalidateToken_SuccessfullyAddsToBlacklist() {
+    // given
+    String email = "test@test.com";
+    String accessToken = "valid.access.token";
+    long expirationTime = 1800000L; // 30분
+
+    given(redisService.hasKey("RT:" + email)).willReturn(false);
+    given(jwtTokenProvider.getExpiration(accessToken)).willReturn(expirationTime);
+
+    // when
+    authService.invalidateToken(email, accessToken);
+
+    // then
+    verify(redisService, never()).deleteValues(anyString());
+    verify(redisService, times(1)).setValues(
+        eq("BlackList:" + accessToken),
+        eq("logout"),
+        eq(Duration.ofMillis(expirationTime))
+    );
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -248,7 +248,7 @@ class AuthServiceTest {
 
   @Test
   @DisplayName("토큰 재발급 - 토큰 탈취 감지 시 강제 로그아웃")
-  void reissue_Exception_TokenTheftSuspected() {
+  void reissue_ExceptionTokenTheftSuspected() {
     // given
     String refreshToken = "stolen.refresh.token";
 
@@ -262,7 +262,6 @@ class AuthServiceTest {
         () -> authService.reissueToken(refreshToken));
     assertEquals(ErrorCode.AUTH_SUSPECT_THEFT_TOKEN, exception.getErrorCode());
 
-    // 탈취 의심 시 해당 유저의 기존 Refresh Token을 즉각 삭제하는지 검증
     verify(redisService, times(1)).deleteValues("RT:" + email);
   }
 
@@ -300,15 +299,15 @@ class AuthServiceTest {
     verify(authCommandService).saveLoginHistory(
         eq(auth),
         eq(LoginStatus.SUCCESS),
-        any(), // User-Agent (이 테스트에서는 중요하지 않음)
-        ipAddressCaptor.capture() // 추출된 IP가 파라미터로 잘 넘어갔는지 캡처
+        any(),
+        ipAddressCaptor.capture()
     );
     assertThat(ipAddressCaptor.getValue()).isEqualTo("192.168.0.1");
   }
 
   @Test
   @DisplayName("토큰 무효화 - 이미 만료되었거나 Redis에 없는 토큰이라도 남은 시간만큼 블랙리스트에 정상 등록된다")
-  void invalidateToken_SuccessfullyAddsToBlacklist() {
+  void invalidateTokenSuccessfullyAddsToBlacklist() {
     // given
     String email = "test@test.com";
     String accessToken = "valid.access.token";
@@ -327,5 +326,46 @@ class AuthServiceTest {
         eq("logout"),
         eq(Duration.ofMillis(expirationTime))
     );
+  }
+
+  @Test
+  @DisplayName("IP 추출 엣지 케이스 - X-Forwarded-For 헤더가 null, 빈 문자열, 또는 unknown일 경우 RemoteAddr을 반환한다")
+  public void extractIpAddressEdgeCasesReturnsRemoteAddress() {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("10.0.0.99");
+
+    // 1. null인 경우
+    // 헤더를 추가하지 않음
+    String resultNull = ReflectionTestUtils.invokeMethod(authService, "extractIpAddress", request);
+    assertThat(resultNull).isEqualTo("10.0.0.99");
+
+    // 2. 빈 문자열인 경우
+    request.addHeader("X-Forwarded-For", "");
+    String resultEmpty = ReflectionTestUtils.invokeMethod(authService, "extractIpAddress", request);
+    assertThat(resultEmpty).isEqualTo("10.0.0.99");
+
+    // 3. unknown인 경우 (대소문자 무시)
+    request.removeHeader("X-Forwarded-For");
+    request.addHeader("X-Forwarded-For", "UnKnOwN");
+    String resultUnknown = ReflectionTestUtils.invokeMethod(authService, "extractIpAddress",
+        request);
+    assertThat(resultUnknown).isEqualTo("10.0.0.99");
+  }
+
+  @Test
+  @DisplayName("로그아웃 시 Redis에 RT 키가 존재하면 삭제 로직을 정상 수행한다 (Branch 통과)")
+  public void invalidateTokenHasKeyDeletesFromRedis() {
+    // given
+    String email = "test@test.com";
+    String accessToken = "valid.token";
+    given(redisService.hasKey("RT:" + email)).willReturn(true);
+    given(jwtTokenProvider.getExpiration(accessToken)).willReturn(1000L);
+
+    // when
+    authService.invalidateToken(email, accessToken);
+
+    // then
+    verify(redisService, times(1)).deleteValues("RT:" + email);
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserServiceTest.java
@@ -1,0 +1,149 @@
+package com.example.WonkaoTalk.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.dto.OAuth.CustomOAuth2User;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
+import com.example.WonkaoTalk.domain.auth.entity.AuthSocial;
+import com.example.WonkaoTalk.domain.auth.event.OAuth2UserCreatedEvent;
+import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
+import com.example.WonkaoTalk.domain.auth.repo.AuthSocialRepo;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2UserServiceTest {
+
+  @InjectMocks
+  private OAuth2UserService oauth2UserService;
+
+  @Mock
+  private AuthRepo authRepo;
+  @Mock
+  private AuthLocalRepo authLocalRepo;
+  @Mock
+  private AuthSocialRepo authSocialRepo;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  private OAuth2UserRequest createMockUserRequest(String provider) {
+    ClientRegistration registration = ClientRegistration.withRegistrationId(provider)
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .clientId("client")
+        .tokenUri("http://token")
+        .authorizationUri("http://auth")
+        .redirectUri("http://localhost/login/oauth2/code/" + provider)
+        .build();
+    OAuth2UserRequest userRequest = mock(OAuth2UserRequest.class);
+    given(userRequest.getClientRegistration()).willReturn(registration);
+    return userRequest;
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 소셜 제공자로부터 이메일 정보를 받지 못한 경우 즉시 예외가 발생한다")
+  void processOAuth2User_NullEmail_ThrowsException() {
+    // given
+    OAuth2UserRequest userRequest = createMockUserRequest("google");
+    OAuth2User oAuth2User = mock(OAuth2User.class);
+
+    // 이메일이 누락된 구글의 속성 맵을 모킹합니다 (sub만 존재)
+    given(oAuth2User.getAttributes()).willReturn(Map.of("sub", "providerId123"));
+
+    // when & then
+    // 리플렉션 없이 동일 패키지 내의 default 메서드를 직접 호출합니다.
+    assertThatThrownBy(() -> oauth2UserService.processOAuth2User(userRequest, oAuth2User))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.OAUTH_NULL_EMAIL);
+
+    verify(authSocialRepo, never()).findByProviderAndProviderUserIdWithAuth(any(), any());
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 동일한 이메일의 기존 일반 회원이 존재할 경우 기존 Auth에 소셜 계정을 연동한다")
+  void processOAuth2User_ExistingLocalUser_LinksSocialAccount() {
+    // given
+    String email = "test@test.com";
+    OAuth2UserRequest userRequest = createMockUserRequest("google");
+    OAuth2User oAuth2User = mock(OAuth2User.class);
+
+    // 정상적인 이메일이 포함된 속성 맵
+    given(oAuth2User.getAttributes()).willReturn(Map.of(
+        "sub", "providerId123",
+        "email", email,
+        "name", "Test User"
+    ));
+
+    Auth existingAuth = Auth.builder().build();
+    ReflectionTestUtils.setField(existingAuth, "id", 1L);
+    AuthLocal authLocal = AuthLocal.builder().auth(existingAuth).email(email).build();
+
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(any(), any())).willReturn(
+        Optional.empty());
+    given(authLocalRepo.findByEmail(email)).willReturn(Optional.of(authLocal));
+
+    // when
+    OAuth2User resultUser = oauth2UserService.processOAuth2User(userRequest, oAuth2User);
+
+    // then
+    assertThat(resultUser).isInstanceOf(CustomOAuth2User.class);
+    assertThat(((CustomOAuth2User) resultUser).getAuth().getId()).isEqualTo(1L); // 기존 Auth가 반환됨
+
+    verify(authRepo, never()).save(any()); // 신규 Auth 생성은 일어나지 않음
+    verify(authSocialRepo, times(1)).save(any(AuthSocial.class)); // 소셜 연동 데이터만 저장됨
+  }
+
+  @Test
+  @DisplayName("소셜 로그인 - 완전한 신규 사용자일 경우 새로운 Auth를 생성하고 이벤트를 발행한다")
+  void processOAuth2User_CompletelyNewUser_CreatesAuthAndPublishesEvent() {
+    // given
+    String email = "new@test.com";
+    OAuth2UserRequest userRequest = createMockUserRequest("google");
+    OAuth2User oAuth2User = mock(OAuth2User.class);
+
+    given(oAuth2User.getAttributes()).willReturn(Map.of(
+        "sub", "providerId123",
+        "email", email,
+        "name", "New User"
+    ));
+
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(any(), any())).willReturn(
+        Optional.empty());
+    given(authLocalRepo.findByEmail(email)).willReturn(Optional.empty());
+    given(authSocialRepo.findFirstByEmail(email)).willReturn(Optional.empty());
+
+    // when
+    OAuth2User resultUser = oauth2UserService.processOAuth2User(userRequest, oAuth2User);
+
+    // then
+    assertThat(resultUser).isInstanceOf(CustomOAuth2User.class);
+
+    // 신규 Auth 및 Social 정보가 저장되었는지 검증
+    verify(authRepo, times(1)).save(any(Auth.class));
+    verify(authSocialRepo, times(1)).save(any(AuthSocial.class));
+    // 외부 프로필 생성을 위한 이벤트가 발행되었는지 검증
+    verify(eventPublisher, times(1)).publishEvent(any(OAuth2UserCreatedEvent.class));
+  }
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserServiceTest.java
@@ -64,16 +64,13 @@ class OAuth2UserServiceTest {
 
   @Test
   @DisplayName("소셜 로그인 - 소셜 제공자로부터 이메일 정보를 받지 못한 경우 즉시 예외가 발생한다")
-  void processOAuth2User_NullEmail_ThrowsException() {
+  void processOAuth2UserNullEmailThrowsException() {
     // given
     OAuth2UserRequest userRequest = createMockUserRequest("google");
     OAuth2User oAuth2User = mock(OAuth2User.class);
-
-    // 이메일이 누락된 구글의 속성 맵을 모킹합니다 (sub만 존재)
     given(oAuth2User.getAttributes()).willReturn(Map.of("sub", "providerId123"));
 
     // when & then
-    // 리플렉션 없이 동일 패키지 내의 default 메서드를 직접 호출합니다.
     assertThatThrownBy(() -> oauth2UserService.processOAuth2User(userRequest, oAuth2User))
         .isInstanceOf(BusinessException.class)
         .extracting("errorCode").isEqualTo(ErrorCode.OAUTH_NULL_EMAIL);
@@ -83,13 +80,12 @@ class OAuth2UserServiceTest {
 
   @Test
   @DisplayName("소셜 로그인 - 동일한 이메일의 기존 일반 회원이 존재할 경우 기존 Auth에 소셜 계정을 연동한다")
-  void processOAuth2User_ExistingLocalUser_LinksSocialAccount() {
+  void processOAuth2UserExistingLocalUserLinksSocialAccount() {
     // given
     String email = "test@test.com";
     OAuth2UserRequest userRequest = createMockUserRequest("google");
     OAuth2User oAuth2User = mock(OAuth2User.class);
 
-    // 정상적인 이메일이 포함된 속성 맵
     given(oAuth2User.getAttributes()).willReturn(Map.of(
         "sub", "providerId123",
         "email", email,
@@ -109,17 +105,17 @@ class OAuth2UserServiceTest {
 
     // then
     assertThat(resultUser).isInstanceOf(CustomOAuth2User.class);
-    assertThat(((CustomOAuth2User) resultUser).getAuth().getId()).isEqualTo(1L); // 기존 Auth가 반환됨
+    assertThat(((CustomOAuth2User) resultUser).getAuth().getId()).isEqualTo(1L);
 
-    verify(authRepo, never()).save(any()); // 신규 Auth 생성은 일어나지 않음
-    verify(authSocialRepo, times(1)).save(any(AuthSocial.class)); // 소셜 연동 데이터만 저장됨
+    verify(authRepo, never()).save(any());
+    verify(authSocialRepo, times(1)).save(any(AuthSocial.class));
   }
 
   @Test
   @DisplayName("소셜 로그인 - 완전한 신규 사용자일 경우 새로운 Auth를 생성하고 이벤트를 발행한다")
-  void processOAuth2User_CompletelyNewUser_CreatesAuthAndPublishesEvent() {
+  void processOAuth2UserCompletelyNewUserCreatesAuthAndPublishesEvent() {
     // given
-    String email = "new@test.com";
+    String email = "test@test.com";
     OAuth2UserRequest userRequest = createMockUserRequest("google");
     OAuth2User oAuth2User = mock(OAuth2User.class);
 
@@ -140,10 +136,67 @@ class OAuth2UserServiceTest {
     // then
     assertThat(resultUser).isInstanceOf(CustomOAuth2User.class);
 
-    // 신규 Auth 및 Social 정보가 저장되었는지 검증
     verify(authRepo, times(1)).save(any(Auth.class));
     verify(authSocialRepo, times(1)).save(any(AuthSocial.class));
-    // 외부 프로필 생성을 위한 이벤트가 발행되었는지 검증
     verify(eventPublisher, times(1)).publishEvent(any(OAuth2UserCreatedEvent.class));
+  }
+
+  @Test
+  @DisplayName("제공자 식별 분기 - 네이버(naver) 로그인이 들어오면 NaverUserInfo 객체로 래핑된다")
+  public void extractUserInfoNaverProviderReturnsNaverUserInfo() {
+    // given
+    OAuth2UserRequest userRequest = createMockUserRequest("naver");
+    OAuth2User oAuth2User = mock(OAuth2User.class);
+    given(oAuth2User.getAttributes()).willReturn(
+        Map.of("response", Map.of("id", "naver_123", "email", "n@n.com")));
+
+    // when
+    Object userInfo = ReflectionTestUtils.invokeMethod(oauth2UserService, "extractUserInfo",
+        userRequest, oAuth2User);
+
+    // then
+    assertThat(userInfo.getClass().getSimpleName()).isEqualTo("NaverUserInfo");
+  }
+
+  @Test
+  @DisplayName("제공자 식별 분기 - 지원하지 않는 제공자(kakao 등)일 경우 예외가 발생한다")
+  public void extractUserInfoInvalidProviderThrowsException() {
+    // given
+    OAuth2UserRequest userRequest = createMockUserRequest("kakao");
+    OAuth2User oAuth2User = mock(OAuth2User.class);
+
+    // when & then
+    assertThatThrownBy(
+        () -> ReflectionTestUtils.invokeMethod(oauth2UserService, "extractUserInfo", userRequest,
+            oAuth2User))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorCode").isEqualTo(ErrorCode.OAUTH_INVALID_PROVIDER);
+  }
+
+  @Test
+  @DisplayName("소셜 연동 병합 분기 - AuthLocal이 없고 다른 AuthSocial만 존재할 경우 해당 Auth에 병합된다")
+  public void processOAuth2UserNoLocalButExistingSocialLinksAccount() {
+    // given
+    String email = "test@test.com";
+    OAuth2UserRequest userRequest = createMockUserRequest("naver");
+    OAuth2User oAuth2User = mock(OAuth2User.class);
+    given(oAuth2User.getAttributes()).willReturn(
+        Map.of("response", Map.of("id", "naver_123", "email", email)));
+
+    Auth existingAuth = Auth.builder().build();
+    ReflectionTestUtils.setField(existingAuth, "id", 77L);
+    AuthSocial existingSocial = AuthSocial.builder().auth(existingAuth).email(email).build();
+
+    given(authSocialRepo.findByProviderAndProviderUserIdWithAuth(any(), any())).willReturn(
+        Optional.empty());
+    given(authLocalRepo.findByEmail(email)).willReturn(Optional.empty());
+    given(authSocialRepo.findFirstByEmail(email)).willReturn(Optional.of(existingSocial));
+
+    // when
+    OAuth2User result = oauth2UserService.processOAuth2User(userRequest, oAuth2User);
+
+    // then
+    assertThat(((CustomOAuth2User) result).getAuth().getId()).isEqualTo(77L);
+    verify(authSocialRepo, times(1)).save(any(AuthSocial.class));
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/friend/service/FriendServiceTest.java
@@ -1,12 +1,16 @@
 package com.example.WonkaoTalk.domain.friend.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.friend.dto.FriendAddRequest;
 import com.example.WonkaoTalk.domain.friend.dto.FriendAddResponse;
+import com.example.WonkaoTalk.domain.friend.dto.FriendStatusRequest;
 import com.example.WonkaoTalk.domain.friend.dto.FriendUpdateRequest;
 import com.example.WonkaoTalk.domain.friend.dto.FriendUpdateResponse;
 import com.example.WonkaoTalk.domain.friend.entity.Friend;
@@ -43,14 +47,10 @@ class FriendServiceTest {
 
   @BeforeEach
   void setUp() {
-    me = User.builder()
-        .nickname("본인").name("나").phone("010-1111-1111")
-        .build();
+    me = User.builder().nickname("본인").name("나").phone("010-1111-1111").build();
     ReflectionTestUtils.setField(me, "id", 1L);
 
-    target = User.builder()
-        .nickname("목표").name("너").phone("010-2222-2222")
-        .build();
+    target = User.builder().nickname("목표").name("너").phone("010-2222-2222").build();
     ReflectionTestUtils.setField(target, "id", 2L);
 
     friend = Friend.builder()
@@ -83,6 +83,44 @@ class FriendServiceTest {
   }
 
   @Test
+  @DisplayName("친구 추가 실패 - 자기 자신을 추가")
+  void addFriendFailSelfRef() {
+    FriendAddRequest request = new FriendAddRequest(1L);
+
+    BusinessException exception = assertThrows(BusinessException.class, () ->
+        friendService.addFriend(1L, request)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FRND_SELF_REF);
+  }
+
+  @Test
+  @DisplayName("친구 추가 실패 - 이미 등록된 친구")
+  void addFriendFailAlreadyExists() {
+    FriendAddRequest request = new FriendAddRequest(2L);
+
+    given(friendRepo.existsByUserIdAndTargetId(1L, 2L)).willReturn(true);
+
+    BusinessException exception = assertThrows(BusinessException.class, () ->
+        friendService.addFriend(1L, request)
+    );
+    assertThat(exception.getErrorCode().name()).contains("FRND_REGISTERED_ALREADY");
+  }
+
+  @Test
+  @DisplayName("친구 추가 실패 - 요청자 ID(userId)가 null인 경우")
+  void addFriendFailUserIdIsNull() {
+    // given
+    FriendAddRequest request = new FriendAddRequest(2L);
+
+    // when & then
+    BusinessException exception = assertThrows(BusinessException.class, () ->
+        friendService.addFriend(null, request)
+    );
+
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FRND_SELF_REF);
+  }
+
+  @Test
   @DisplayName("친구 목록 조회 성공")
   public void getFriendsSuccess() {
     //given
@@ -97,7 +135,7 @@ class FriendServiceTest {
   }
 
   @Test
-  @DisplayName("친구 정보 변경 성공")
+  @DisplayName("친구 정보 변경 성공 - 별명 및 메모 변경")
   public void updateFriendSuccess() {
     //given
     FriendUpdateRequest request = new FriendUpdateRequest("새별명", "새메모");
@@ -110,6 +148,63 @@ class FriendServiceTest {
     assertThat(friend.getAlias()).isEqualTo("새별명");
     assertThat(friend.getMemo()).isEqualTo("새메모");
     assertThat(response).isNotNull();
+  }
+
+  @Test
+  @DisplayName("친구 정보 변경 성공 - 별명만 변경하고 메모는 null로 요청 (부분 업데이트)")
+  void updateFriendPartialOnlyAlias() {
+    // given
+    // memo를 null로 전달
+    FriendUpdateRequest request = new FriendUpdateRequest("바뀐별명", null);
+    friend.updateMemo("기존메모"); // 사전에 기존 메모 세팅
+    given(friendRepo.findByIdAndUserId(100L, 1L)).willReturn(Optional.of(friend));
+
+    // when
+    FriendUpdateResponse response = friendService.updateFriendsInfo(1L, 100L, request);
+
+    // then
+    assertThat(friend.getAlias()).isEqualTo("바뀐별명"); // 별명은 변경됨
+    assertThat(friend.getMemo()).isEqualTo("기존메모"); // 메모는 기존 값 유지됨
+  }
+
+  @Test
+  @DisplayName("친구 정보 변경 성공 - 메모만 변경하고 별명은 null로 요청 (부분 업데이트)")
+  void updateFriendPartialOnlyMemo() {
+    // given
+    // alias를 null로 전달
+    FriendUpdateRequest request = new FriendUpdateRequest(null, "바뀐메모");
+    String originalAlias = friend.getAlias();
+    given(friendRepo.findByIdAndUserId(100L, 1L)).willReturn(Optional.of(friend));
+
+    // when
+    FriendUpdateResponse response = friendService.updateFriendsInfo(1L, 100L, request);
+
+    // then
+    assertThat(friend.getAlias()).isEqualTo(originalAlias); // 별명은 기존 값 유지됨
+    assertThat(friend.getMemo()).isEqualTo("바뀐메모"); // 메모는 변경됨
+  }
+
+  @Test
+  @DisplayName("친구 정보 변경 실패 - 존재하지 않는 친구 관계")
+  void updateFriendFailNotFound() {
+    FriendUpdateRequest request = new FriendUpdateRequest("새별명", "새메모");
+    given(friendRepo.findByIdAndUserId(100L, 1L)).willReturn(Optional.empty());
+
+    BusinessException exception = assertThrows(BusinessException.class, () ->
+        friendService.updateFriendsInfo(1L, 100L, request)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FRND_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("친구 상태 변경 성공")
+  void changeFriendStatusSuccess() {
+    FriendStatusRequest request = new FriendStatusRequest(FriendStatus.HIDDEN);
+    given(friendRepo.findByIdAndUserId(100L, 1L)).willReturn(Optional.of(friend));
+
+    friendService.changeFriendStatus(1L, 100L, request);
+
+    assertThat(friend.getStatus()).isEqualTo(FriendStatus.HIDDEN);
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/seller/service/SellerServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/seller/service/SellerServiceTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
+import com.example.WonkaoTalk.domain.auth.dto.AuthIntegrationResultDto;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
 import com.example.WonkaoTalk.domain.auth.repo.AuthRepo;
@@ -80,6 +84,26 @@ class SellerServiceTest {
   }
 
   @Test
+  @DisplayName("판매자 권한 승격 실패 - 사업자번호 이미 존재")
+  public void registerSellerFailWhenDuplicateBuzNo() {
+    // given
+    SellerRegisterRequest request = new SellerRegisterRequest("1234567890", "중복스토어",
+        "010-3333-3333");
+    Auth auth = Auth.builder().role(Role.USER).build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+
+    given(sellerRepo.existsByBuzNo(request.buzNo())).willReturn(true);
+
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.registerSeller(auth.getId(), request)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SELLER_DUPLICATE_BUZNO);
+    verify(sellerRepo, never()).save(any());
+  }
+
+  @Test
   @DisplayName("신규 판매자 회원가입 성공")
   public void signUpAsSellerSuccess() {
     //given
@@ -93,21 +117,65 @@ class SellerServiceTest {
         .build();
 
     Auth auth = Auth.builder()
-        .id(1L)
         .role(Role.SELLER)
         .build();
+    ReflectionTestUtils.setField(auth, "id", 1L);
+    AuthIntegrationResultDto resultDto = new AuthIntegrationResultDto(auth, true);
 
     given(sellerRepo.existsByBuzNo(request.buzNo())).willReturn(false);
-    given(authService.createAuthLocal(request.email(), request.password(), Role.SELLER))
-        .willReturn(auth);
+    given(authService.linkOrCreateLocal(request.email(), request.password(), Role.SELLER))
+        .willReturn(resultDto);
 
     //when
     sellerService.signUpAsSeller(request);
 
     //then
-    verify(authService).createAuthLocal(request.email(), request.password(), Role.SELLER);
+    verify(authService).linkOrCreateLocal(request.email(), request.password(), Role.SELLER);
     verify(sellerRepo).save(any(Seller.class));
+  }
 
+  @Test
+  @DisplayName("판매자 회원가입 실패 - 비밀번호 불일치")
+  public void signUpAsSellerFailWhenPasswordMismatch() {
+    // given
+    SellerSignUpRequest request = SellerSignUpRequest.builder()
+        .email("test@gmail.com")
+        .password("Qwer1234")
+        .passwordCheck("DifferentPassword123!") // 불일치하는 비밀번호
+        .buzNo("1234567890")
+        .name("판매자1")
+        .phone("010-1234-5678")
+        .build();
+
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.signUpAsSeller(request)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_MISMATCH_PASSWORD);
+  }
+
+  @Test
+  @DisplayName("판매자 회원가입 실패 - 사업자번호 중복")
+  public void signUpAsSellerFailWhenDuplicateBuzNo() {
+    // given
+    SellerSignUpRequest request = SellerSignUpRequest.builder()
+        .email("test@gmail.com")
+        .password("Qwer1234")
+        .passwordCheck("Qwer1234")
+        .buzNo("1234567890")
+        .name("판매자1")
+        .phone("010-1234-5678")
+        .build();
+
+    given(sellerRepo.existsByBuzNo(request.buzNo())).willReturn(true);
+
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.signUpAsSeller(request)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SELLER_DUPLICATE_BUZNO);
   }
 
   @Test
@@ -126,6 +194,31 @@ class SellerServiceTest {
   }
 
   @Test
+  @DisplayName("판매자 정보 조회 실패 - sellerId가 null인 경우")
+  public void getSellerInfoFailWhenIdIsNull() {
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.getSellerInfo(null)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("판매자 정보 조회 실패 - 존재하지 않는 판매자")
+  public void getSellerInfoFailWhenNotFound() {
+    // given
+    given(sellerRepo.findById(999L)).willReturn(Optional.empty());
+
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.getSellerInfo(999L)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
   @DisplayName("판매자 정보 수정 성공")
   public void updateSellerInfoSuccess() {
     //given
@@ -139,6 +232,67 @@ class SellerServiceTest {
     assertThat(response.sellerId()).isEqualTo(1L);
     assertThat(response.name()).isEqualTo("이병건스토어");
     assertThat(response.phone()).isEqualTo("010-1111-1111");
+  }
+
+  @Test
+  @DisplayName("판매자 정보 수정 성공 - 이름만 전달된 경우 (전화번호 기존 값 유지)")
+  public void updateSellerInfoSuccessPartialNameOnly() {
+    // given
+    SellerUpdateRequest request = new SellerUpdateRequest("새로운스토어이름", null); // 전화번호 누락
+    given(sellerRepo.findById(1L)).willReturn(Optional.of(seller));
+
+    // when
+    SellerResponse response = sellerService.updateSellerInfo(1L, request);
+
+    // then
+    assertThat(response.name()).isEqualTo("새로운스토어이름");
+    assertThat(response.phone()).isEqualTo(seller.getPhone()); // 기존 번호가 유지되었는지 검증
+  }
+
+  @Test
+  @DisplayName("판매자 정보 수정 성공 - 전화번호만 전달된 경우 (이름 기존 값 유지)")
+  public void updateSellerInfoSuccessPartialPhoneOnly() {
+    // given
+    SellerUpdateRequest request = new SellerUpdateRequest("", "010-9999-9999"); // 이름 누락(빈 문자열)
+    given(sellerRepo.findById(1L)).willReturn(Optional.of(seller));
+
+    // when
+    SellerResponse response = sellerService.updateSellerInfo(1L, request);
+
+    // then
+    assertThat(response.name()).isEqualTo(seller.getName()); // 기존 이름이 유지되었는지 검증
+    assertThat(response.phone()).isEqualTo("010-9999-9999");
+  }
+
+  @Test
+  @DisplayName("판매자 정보 수정 성공 - 빈 문자열 전달 시 기존 정보 유지")
+  public void updateSellerInfoSuccessWhenEmptyString() {
+    // given
+    // 클라이언트가 고의 또는 실수로 공백이나 빈 문자열을 보낸 경우
+    SellerUpdateRequest request = new SellerUpdateRequest("   ", "");
+    given(sellerRepo.findById(1L)).willReturn(Optional.of(seller));
+
+    // when
+    SellerResponse response = sellerService.updateSellerInfo(1L, request);
+
+    // then
+    // 빈 문자열이 무시되고 기존 엔티티의 이름과 전화번호가 유지되었는지 객체 상태 검증
+    assertThat(response.name()).isEqualTo(seller.getName());
+    assertThat(response.phone()).isEqualTo(seller.getPhone());
+  }
+
+  @Test
+  @DisplayName("판매자 정보 수정 실패 - sellerId가 null인 경우 방어 로직 작동")
+  public void updateSellerInfoFailWhenIdIsNull() {
+    // given
+    SellerUpdateRequest request = new SellerUpdateRequest("수정스토어", "010-1234-5678");
+
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.updateSellerInfo(null, request)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
   }
 
   @Test
@@ -159,9 +313,35 @@ class SellerServiceTest {
     // then
     then(sellerRepo).should(times(1)).findByAuthId(1L);
 
-    // 비즈니스 로직 검증: anonymize()가 호출되어 원본 데이터가 소실(마스킹)되었는지 확인
     assertThat(seller.getBuzNo()).isNotEqualTo("1234567890");
     assertThat(seller.getName()).isNotEqualTo("판매자1");
     assertThat(seller.getPhone()).isNotEqualTo("010-1234-5678");
+  }
+
+  @Test
+  @DisplayName("판매자 탈퇴 실패 - Auth ID에 해당하는 판매자가 없는 경우")
+  public void withdrawSellerFailWhenNotFound() {
+    // given
+    given(sellerRepo.findByAuthId(999L)).willReturn(Optional.empty());
+
+    // when & then
+    BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+        BusinessException.class,
+        () -> sellerService.withdrawSeller(999L)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SELLER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("활성 판매자 존재 여부 확인 - 존재하는 경우 true 반환")
+  public void existsActiveSellerReturnsTrue() {
+    // given
+    given(sellerRepo.existsByAuthId(1L)).willReturn(true);
+
+    // when
+    boolean result = sellerService.existsActiveSeller(1L);
+
+    // then
+    assertThat(result).isTrue();
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/store/service/StoreServiceTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.example.WonkaoTalk.common.exception.BusinessException;
+import com.example.WonkaoTalk.common.exception.ErrorCode;
 import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.seller.entity.Seller;
 import com.example.WonkaoTalk.domain.store.dto.StoreCreateRequest;
@@ -85,6 +87,61 @@ class StoreServiceTest {
   }
 
   @Test
+  @DisplayName("스토어 생성 성공 - 썸네일이 null인 경우 기본 썸네일 적용")
+  public void createStoreSuccessDefaultThumbnail() {
+    // given
+    StoreCreateRequest request = new StoreCreateRequest("스토어", "설명", "02-3456-7890", null);
+
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.empty());
+    given(storeRepo.existsByName(request.name())).willReturn(false);
+
+    Store savedStore = Store.builder()
+        .name(request.name())
+        .description(request.description())
+        .phone(request.phone())
+        .thumbnail("http://defaultThumbnail.png")
+        .seller(seller)
+        .build();
+    ReflectionTestUtils.setField(savedStore, "id", 2L);
+    given(storeRepo.save(any(Store.class))).willReturn(savedStore);
+
+    // when
+    StoreResponse response = storeService.createStore(seller, request);
+
+    // then
+    assertThat(response.thumbnail()).isEqualTo("http://defaultThumbnail.png");
+  }
+
+  @Test
+  @DisplayName("스토어 생성 실패 - 이미 해당 판매자의 스토어가 존재하는 경우")
+  public void createStoreFailAlreadyExists() {
+    // given
+    StoreCreateRequest request = new StoreCreateRequest("새 스토어", "설명", "02-3456-7890", "썸네일");
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.of(store));
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> storeService.createStore(seller, request))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_EXISTS_ALREADY);
+  }
+
+  @Test
+  @DisplayName("스토어 생성 실패 - 이미 존재하는 스토어 이름인 경우")
+  public void createStoreFailDuplicatedName() {
+    // given
+    StoreCreateRequest request = new StoreCreateRequest("스토어1", "설명", "02-3456-7890", "썸네일");
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.empty());
+    given(storeRepo.existsByName(request.name())).willReturn(true);
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> storeService.createStore(seller, request))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_EXISTS_NAME);
+  }
+
+  @Test
   @DisplayName("스토어 조회 성공")
   public void getStoreSuccess() {
     // given
@@ -97,6 +154,18 @@ class StoreServiceTest {
     assertThat(response).isNotNull();
     assertThat(response.name()).isEqualTo("스토어1");
     assertThat(response.id()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("스토어 조회 실패 - 스토어가 존재하지 않는 경우")
+  public void getStoreFailNotFound() {
+    // given
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.empty());
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> storeService.getStore(seller))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_NOT_FOUND);
   }
 
   @Test
@@ -117,6 +186,54 @@ class StoreServiceTest {
   }
 
   @Test
+  @DisplayName("스토어 수정 성공 - 일부 필드만 업데이트 시 기존 필드 유지")
+  public void updateStoreSuccessPartialUpdate() {
+    // given
+    StoreUpdateRequest request = new StoreUpdateRequest(null, "", "02-2222-2222", "새 썸네일");
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.of(store));
+
+    given(storeRepo.existsByName(request.name())).willReturn(false);
+
+    // when
+    StoreResponse response = storeService.updateStore(seller, request);
+
+    // then
+    assertThat(response.name()).isEqualTo("스토어1");
+    assertThat(response.description()).isEqualTo("설명");
+    assertThat(response.phone()).isEqualTo("02-2222-2222");
+    assertThat(response.thumbnail()).isEqualTo("새 썸네일");
+  }
+
+  @Test
+  @DisplayName("스토어 수정 실패 - 스토어가 존재하지 않는 경우")
+  public void updateStoreFailNotFound() {
+    // given
+    StoreUpdateRequest request = new StoreUpdateRequest("새 스토어", "새 설명", null, null);
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.empty());
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> storeService.updateStore(seller, request))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("스토어 수정 실패 - 변경하려는 이름이 이미 존재하는 경우")
+  public void updateStore_Fail_DuplicatedName() {
+    // given
+    StoreUpdateRequest request = new StoreUpdateRequest("이미 존재하는 이름", "새 설명", null, null);
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.of(store));
+    given(storeRepo.existsByName(request.name())).willReturn(true);
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> storeService.updateStore(seller, request))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_EXISTS_NAME);
+  }
+
+  @Test
   @DisplayName("스토어 삭제(Soft Delete) 성공")
   public void deleteStoreSuccess() {
     // given
@@ -129,5 +246,17 @@ class StoreServiceTest {
     assertThat(store.getName()).contains("삭제된 스토어");
     assertThat(store.getDescription()).isEqualTo("DELETED");
     assertThat(store.getPhone()).isEqualTo("000-0000-0000");
+  }
+
+  @Test
+  @DisplayName("스토어 삭제 실패 - 스토어가 존재하지 않는 경우")
+  public void deleteStore_Fail_NotFound() {
+    // given
+    given(storeRepo.findBySeller(seller)).willReturn(Optional.empty());
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> storeService.deleteStore(seller))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STORE_NOT_FOUND);
   }
 }

--- a/src/test/java/com/example/WonkaoTalk/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,130 @@
+package com.example.WonkaoTalk.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.WonkaoTalk.application.facade.AccountWithdraw;
+import com.example.WonkaoTalk.common.config.security.SecurityConfig;
+import com.example.WonkaoTalk.common.config.security.jwt.JwtAuthenticationFilter;
+import com.example.WonkaoTalk.common.config.security.jwt.JwtExceptionFilter;
+import com.example.WonkaoTalk.domain.auth.dto.CustomUserDetails;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchRequest;
+import com.example.WonkaoTalk.domain.user.dto.UserSearchResponse;
+import com.example.WonkaoTalk.domain.user.service.UserService;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+@WebMvcTest(
+    controllers = UserController.class,
+    excludeFilters = {
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = {
+                SecurityConfig.class,
+                JwtAuthenticationFilter.class,
+                JwtExceptionFilter.class
+            }
+        )
+    }
+)
+class UserControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockitoBean
+  private UserService userService;
+
+  @MockitoBean
+  private AccountWithdraw accountWithdraw;
+
+  private CustomUserDetails userDetails;
+
+  @BeforeEach
+  void setUp() {
+    List<GrantedAuthority> authorities = Collections.singletonList(
+        new SimpleGrantedAuthority("ROLE_" + "USER")
+    );
+
+    userDetails = CustomUserDetails.customBuilder()
+        .email("test@test.com")
+        .authId(1L)
+        .userId(100L)
+        .sellerId(null)
+        .authorities(authorities)
+        .build();
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 API 성공")
+  public void withdrawSuccess() throws Exception {
+    // given
+    String token = "valid.jwt.token";
+
+    // when & then
+    mockMvc.perform(delete("/api/v1/users/withdraw")
+            .header("Authorization", "Bearer " + token)
+            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
+
+    verify(accountWithdraw).withdrawUser(1L, "test@test.com", token);
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 API 실패 - Authorization 헤더 누락/형식 오류")
+  public void withdrawFailInvalidHeader() throws Exception {
+    // Bearer 접두사가 없는 잘못된 토큰 형식
+    mockMvc.perform(delete("/api/v1/users/withdraw")
+            .header("Authorization", "InvalidTokenFormat")
+            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+            .with(csrf()))
+        .andExpect(status().isUnauthorized()) // 401 상태 코드로 검증 변경
+        .andExpect(jsonPath("$.error").value("AUTH-INVALID-TOKEN"));
+  }
+
+  @Test
+  @DisplayName("전화번호로 사용자 검색 API 성공")
+  public void searchUserByPhoneSuccess() throws Exception {
+    // given
+    UserSearchRequest request = new UserSearchRequest("010-1234-5678");
+    UserSearchResponse response = new UserSearchResponse(2L, "010-1234-5678", "침착맨", "image.png");
+
+    given(userService.findUserByPhone(eq(100L), eq("010-1234-5678"))).willReturn(response);
+
+    // when & then
+    mockMvc.perform(post("/api/v1/users/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+            .with(SecurityMockMvcRequestPostProcessors.user(userDetails))
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.userId").value(2L))
+        .andExpect(jsonPath("$.data.nickname").value("침착맨"));
+  }
+
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/user/service/UserEventListenerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/user/service/UserEventListenerTest.java
@@ -1,0 +1,51 @@
+package com.example.WonkaoTalk.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.event.OAuth2UserCreatedEvent;
+import com.example.WonkaoTalk.domain.user.entity.User;
+import com.example.WonkaoTalk.domain.user.enums.Gender;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserEventListenerTest {
+
+  @Mock
+  private UserRepo userRepo;
+
+  @InjectMocks
+  private UserEventListener userEventListener;
+
+  @Test
+  @DisplayName("소셜 사용자 생성 이벤트 수신 시 User 엔티티를 저장한다")
+  public void handleOAuth2UserCreatedEventSuccess() {
+    // given
+    Auth mockAuth = Auth.builder().build();
+    OAuth2UserCreatedEvent event = new OAuth2UserCreatedEvent(mockAuth, "test@test.com", "침착",
+        "010-9999-9999");
+
+    // when
+    userEventListener.handleOAuth2UserCreatedEvent(event);
+
+    // then
+    ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepo).save(userCaptor.capture());
+
+    User savedUser = userCaptor.getValue();
+    assertThat(savedUser.getName()).isEqualTo("침착");
+    assertThat(savedUser.getNickname()).isEqualTo("침착");
+    assertThat(savedUser.getPhone()).isEqualTo("010-9999-9999");
+    assertThat(savedUser.getGender()).isEqualTo(Gender.NONE);
+    assertThat(savedUser.isMarketingAgree()).isFalse();
+  }
+
+}

--- a/src/test/java/com/example/WonkaoTalk/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/user/service/UserServiceTest.java
@@ -3,7 +3,6 @@ package com.example.WonkaoTalk.domain.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -73,10 +72,8 @@ class UserServiceTest {
         LocalDate.of(1983, 12, 6), Gender.MALE
     );
     Auth auth = Auth.builder().id(1L).role(Role.USER).build();
-    given(authService.createAuthLocal(eq(request.email()), eq(request.password()),
-        eq(Role.USER))).willReturn(auth);
-
     AuthIntegrationResultDto result = new AuthIntegrationResultDto(auth, true);
+
     given(authService.linkOrCreateLocal(request.email(), request.password(), Role.USER))
         .willReturn(result);
     User newUser = User.builder().id(100L).auth(auth).build();
@@ -168,11 +165,33 @@ class UserServiceTest {
     given(userRepo.findById(userId)).willReturn(Optional.of(user));
 
     // when
-    userService.updateUserInfo(userId, request);
+    UserResponse response = userService.updateUserInfo(userId, request);
 
     // then
     assertThat(user.getNickname()).isEqualTo("침착맨");
     assertThat(user.getBirthDate()).isEqualTo(LocalDate.of(1995, 1, 1));
+  }
+
+  @Test
+  @DisplayName("사용자 정보 수정 - 성공 (부분 업데이트 시 기존 값 보존)")
+  public void updateUserInfoSuccess() {
+    // given
+    Long userId = 1L;
+
+    UserUpdateRequest request = new UserUpdateRequest(
+        "침병건", "new_image.png", null, null, null
+    );
+
+    given(userRepo.findById(userId)).willReturn(Optional.of(user));
+
+    // when
+    UserResponse response = userService.updateUserInfo(userId, request);
+
+    // then
+    assertThat(response.nickname()).isEqualTo("침병건");
+    assertThat(response.image()).isEqualTo("new_image.png");
+    assertThat(response.gender()).isEqualTo(Gender.MALE);
+    assertThat(response.birthDate()).isEqualTo(LocalDate.of(2001, 4, 13));
   }
 
   @Test
@@ -264,5 +283,35 @@ class UserServiceTest {
     assertThat(user.getName()).isNotEqualTo("이병건");
     assertThat(user.getPhone()).isNotEqualTo("010-2222-2222");
     assertThat(user.getDeletedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("사용자 활성 상태 확인 - 존재하는 경우")
+  public void existsActiveUserTrue() {
+    // given
+    Long authId = 100L;
+    given(userRepo.existsByAuthId(authId)).willReturn(true);
+
+    // when
+    boolean result = userService.existsActiveUser(authId);
+
+    // then
+    assertThat(result).isTrue();
+    verify(userRepo).existsByAuthId(authId);
+  }
+
+  @Test
+  @DisplayName("사용자 활성 상태 확인 - 존재하지 않는 경우")
+  public void existsActiveUserFalse() {
+    // given
+    Long authId = 999L;
+    given(userRepo.existsByAuthId(authId)).willReturn(false);
+
+    // when
+    boolean result = userService.existsActiveUser(authId);
+
+    // then
+    assertThat(result).isFalse();
+    verify(userRepo).existsByAuthId(authId);
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #134 

## 📝 작업 내용
- 인증, 사용자, 판매자, 친구, 스토어 도메인의 단위테스트 커버리지를 80% 이상으로 확장했습니다.
- 인증 도메인의 통합 테스트를 작성했습니다.

## ✅ 작업 결과 
<img width="1021" height="338" alt="image" src="https://github.com/user-attachments/assets/c4b5aa16-208a-4d23-9f25-d39ebd088700" />


## 🎸 기타
seller 도메인 전체 커버리지가 80%가 안되는데 controller 테스트를 작성 안해서 그런거 같습니다.. 일단 발표자료용으로 이대로 올리고 나중에 추가해서 올리겠습니다..!
