### PR TITLE
Refactor: 소셜인증 리다이렉트 URI 변경으로 인한 프로퍼티 파일 추가

### DIFF
--- a/src/main/java/com/example/WonkaoTalk/WonkaoTalkApplication.java
+++ b/src/main/java/com/example/WonkaoTalk/WonkaoTalkApplication.java
@@ -2,14 +2,12 @@ package com.example.WonkaoTalk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 
-@EnableAsync
 @SpringBootApplication
 public class WonkaoTalkApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(WonkaoTalkApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(WonkaoTalkApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/example/WonkaoTalk/common/config/properties/FrontendProperties.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/properties/FrontendProperties.java
@@ -1,0 +1,10 @@
+package com.example.WonkaoTalk.common.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.frontend")
+public record FrontendProperties(
+    String oauthRedirectUri
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/common/config/properties/FrontendProperties.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/properties/FrontendProperties.java
@@ -1,9 +1,13 @@
 package com.example.WonkaoTalk.common.config.properties;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "app.frontend")
 public record FrontendProperties(
+    @NotBlank
     String oauthRedirectUri
 ) {
 

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
@@ -58,6 +58,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     response.addCookie(createCookie("refresh-token", refreshToken, true,
         (int) (jwtTokenProvider.getRefreshTokenValidTime() / 1000)));
+    // response.addCookie(createCookie("access-token", accessToken, false, 60));
 
     OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
     OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
@@ -72,8 +73,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       });
     }
 
-    getRedirectStrategy().sendRedirect(request, response,
-        frontEndProperties.oauthRedirectUri() + "?accessToken=" + accessToken);
+    String targetUrl = org.springframework.web.util.UriComponentsBuilder
+        .fromUriString(frontEndProperties.oauthRedirectUri())
+        .queryParam("accessToken", accessToken)
+        .build().toUriString();
+
+    getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
 
   private Cookie createCookie(String name, String value, boolean httpOnly, int maxAge) {

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.common.config.security;
 
+import com.example.WonkaoTalk.common.config.properties.FrontendProperties;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtTokenProvider;
 import com.example.WonkaoTalk.common.redis.RedisService;
 import com.example.WonkaoTalk.domain.auth.dto.OAuth.CustomOAuth2User;
@@ -31,6 +32,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final RedisService redisService;
   private final OAuth2AuthorizedClientService authorizedClientService;
   private final AuthSocialRepo authSocialRepo;
+  private final FrontendProperties frontEndProperties;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -56,7 +58,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     response.addCookie(createCookie("refresh-token", refreshToken, true,
         (int) (jwtTokenProvider.getRefreshTokenValidTime() / 1000)));
-    response.addCookie(createCookie("access-token", accessToken, false, 60));
+    //response.addCookie(createCookie("access-token", accessToken, false, 60));
 
     OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
     OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
@@ -71,7 +73,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       });
     }
 
-    getRedirectStrategy().sendRedirect(request, response, "http://localhost:3000");
+    getRedirectStrategy().sendRedirect(request, response,
+        frontEndProperties.oauthRedirectUri() + "?accessToken=" + accessToken);
   }
 
   private Cookie createCookie(String name, String value, boolean httpOnly, int maxAge) {

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
@@ -58,7 +58,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     response.addCookie(createCookie("refresh-token", refreshToken, true,
         (int) (jwtTokenProvider.getRefreshTokenValidTime() / 1000)));
-    //response.addCookie(createCookie("access-token", accessToken, false, 60));
 
     OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
     OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -179,7 +179,7 @@ public class SecurityConfig {
     // 구글에 오프라인 접근(RT 발급) 요청
     if ("google".equals(req.getAttribute(OAuth2ParameterNames.REGISTRATION_ID))) {
       extraParams.put("access_type", "offline");
-      // extraParams.put("prompt", "consent");
+      extraParams.put("prompt", "consent");
     }
     return OAuth2AuthorizationRequest.from(req).additionalParameters(extraParams).build();
   }

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.WonkaoTalk.common.config.security;
 
+import com.example.WonkaoTalk.common.config.properties.FrontendProperties;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtAuthenticationFilter;
 import com.example.WonkaoTalk.common.config.security.jwt.JwtExceptionFilter;
 import com.example.WonkaoTalk.domain.auth.service.OAuth2UserService;
@@ -9,6 +10,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -31,6 +33,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+@EnableConfigurationProperties(FrontendProperties.class)
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor

--- a/src/main/java/com/example/WonkaoTalk/common/converter/EncryptAttributeConverter.java
+++ b/src/main/java/com/example/WonkaoTalk/common/converter/EncryptAttributeConverter.java
@@ -23,8 +23,7 @@ public class EncryptAttributeConverter implements AttributeConverter<String, Str
   private static final int GCM_TAG_LENGTH = 128;
   private static String ALGORITHM = "AES/GCM/NoPadding";
   private byte[] KEY;
-
-  // 이부분을 수정!
+  
   @Value("${oauth.encryption.key}")
   public void setKey(String key) {
     KEY = java.util.Base64.getDecoder().decode(key);

--- a/src/main/java/com/example/WonkaoTalk/common/converter/EncryptAttributeConverter.java
+++ b/src/main/java/com/example/WonkaoTalk/common/converter/EncryptAttributeConverter.java
@@ -10,11 +10,13 @@ import java.util.Base64;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @Converter
+@Slf4j
 public class EncryptAttributeConverter implements AttributeConverter<String, String> {
 
   private static final int GCM_IV_LENGTH = 12;
@@ -22,9 +24,10 @@ public class EncryptAttributeConverter implements AttributeConverter<String, Str
   private static String ALGORITHM = "AES/GCM/NoPadding";
   private byte[] KEY;
 
+  // 이부분을 수정!
   @Value("${oauth.encryption.key}")
   public void setKey(String key) {
-    KEY = key.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    KEY = java.util.Base64.getDecoder().decode(key);
   }
 
   @Override
@@ -44,6 +47,7 @@ public class EncryptAttributeConverter implements AttributeConverter<String, Str
       System.arraycopy(cipherText, 0, encryptedBuffer, iv.length, cipherText.length);
       return Base64.getEncoder().encodeToString(encryptedBuffer);
     } catch (Exception e) {
+      log.error("Attribute encryption failed", e);
       throw new BusinessException(ErrorCode.OAUTH_FAILURE_ENCRYPT);
     }
   }
@@ -64,6 +68,7 @@ public class EncryptAttributeConverter implements AttributeConverter<String, Str
           encryptedBuffer.length - iv.length);
       return new String(plaintext, StandardCharsets.UTF_8);
     } catch (Exception e) {
+      log.error("Attribute decryption failed", e);
       throw new BusinessException(ErrorCode.OAUTH_FAILURE_DECRYPT);
     }
   }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/OAuth/CustomOAuth2User.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/OAuth/CustomOAuth2User.java
@@ -1,6 +1,5 @@
 package com.example.WonkaoTalk.domain.auth.dto.OAuth;
 
-import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.enums.AuthProvider;
 import java.util.Collection;
 import java.util.Collections;
@@ -14,8 +13,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @Getter
 @RequiredArgsConstructor
 public class CustomOAuth2User implements OAuth2User {
-
-  private final Auth auth;
+  
+  private final String role;
   private final Map<String, Object> attributes;
   private final AuthProvider provider;
   private final String providerId;
@@ -23,11 +22,11 @@ public class CustomOAuth2User implements OAuth2User {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + auth.getRole().name()));
+    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
   }
 
   @Override
   public String getName() {
-    return auth.getId().toString();
+    return email;
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserService.java
@@ -52,7 +52,8 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
     String providerId = userInfo.getProviderId();
     String email = userInfo.getEmail();
 
-    return new CustomOAuth2User(auth, oAuth2User.getAttributes(), provider, providerId, email);
+    return new CustomOAuth2User(auth.getRole().name(), oAuth2User.getAttributes(), provider,
+        providerId, email);
   }
 
   private OAuth2UserInfo extractUserInfo(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ jwt:
   access-expiration-time: 1800000 # 30분
   refresh-expiration-time: 1209600000 # 14일
 
-  app:
-    frontend:
-      base-uri: "http://localhost:3000"
-      oauth-redirect-uri: "http://localhost:3000/oauth2/redirect"
+app:
+  frontend:
+    base-uri: "http://localhost:3000"
+    oauth-redirect-uri: "http://localhost:3000/oauth2/redirect"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,3 +21,8 @@ jwt:
   # secret: ${JWT_SECRET_KEY} # 시스템 환경변수에서 값을 주입받음
   access-expiration-time: 1800000 # 30분
   refresh-expiration-time: 1209600000 # 14일
+
+  app:
+    frontend:
+      base-uri: "http://localhost:3000"
+      oauth-redirect-uri: "http://localhost:3000/oauth2/redirect"

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/OAuth2UserServiceTest.java
@@ -105,7 +105,6 @@ class OAuth2UserServiceTest {
 
     // then
     assertThat(resultUser).isInstanceOf(CustomOAuth2User.class);
-    assertThat(((CustomOAuth2User) resultUser).getAuth().getId()).isEqualTo(1L);
 
     verify(authRepo, never()).save(any());
     verify(authSocialRepo, times(1)).save(any(AuthSocial.class));
@@ -196,7 +195,6 @@ class OAuth2UserServiceTest {
     OAuth2User result = oauth2UserService.processOAuth2User(userRequest, oAuth2User);
 
     // then
-    assertThat(((CustomOAuth2User) result).getAuth().getId()).isEqualTo(77L);
     verify(authSocialRepo, times(1)).save(any(AuthSocial.class));
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #161 

## 📝 작업 내용
- FrontendProperties를 통해 yml파일의 값을 읽어오도록 했습니다
- 소셜 인증의 AT 저장방식을 변경했습니다.

## ✅ 작업 결과 


## 🎸 기타
E2E 테스트중인데 앞선 PR에서 수정한 부분이 이번 브랜치에 적용이 안되어있어서 둘 다 머지한 뒤 다시 가져가서 테스트 진행하겠습니다.
