### PR TITLE
Feat: 로그인 요청 비동기 처리 및 벌크헤드 패턴 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ src/test/java/com/example/WonkaoTalk/domain/product/datagen/
 ### AI CLI ###
 .claude
 .antigravitycli
+k6-seed-data.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     volumes:
       - ./minio/data:/data
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -89,14 +89,14 @@ services:
       mc anonymous set download local/wonkao-talk;
       "
 
-  elasticsearch:
-    build:
-      context: .
-      dockerfile: elasticsearch.Dockerfile
-    container_name: wonkao-talk-es
-    ports:
-      - "9200:9200"
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-
+#  elasticsearch:
+#    build:
+#      context: .
+#      dockerfile: elasticsearch.Dockerfile
+#    container_name: wonkao-talk-es
+#    ports:
+#      - "9200:9200"
+#    environment:
+#      - discovery.type=single-node
+#      - xpack.security.enabled=false
+#

--- a/src/main/java/com/example/WonkaoTalk/common/config/AsyncConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/AsyncConfig.java
@@ -22,4 +22,27 @@ public class AsyncConfig {
     executor.initialize();
     return executor;
   }
+
+  /**
+   * BCrypt 연산(로그인 검증, 회원가입 해싱)을 위한 벌크헤드 스레드풀. 톰캣 워커 스레드가 BCrypt 연산으로 선점되지 않도록 별도 풀로 분리하고, CPU 코어의 약
+   * 65%만 점유하도록 고정 크기로 제한해 다른 API 처리용 CPU 자원을 남겨둔다. >> 80%까지 상향 수정 core == max 로 고정해 풀이 늘어나며 CPU를 추가
+   * 점유하지 않게 한다. 로그인/회원가입 모두 같은 CPU 예산을 공유하므로 풀을 분리하지 않고 함께 사용한다. 대기 큐의 공간 대폭 감축 계산식: (스레드 풀 크기 /
+   * BCrypt 1회 소요 시간) * 허용 대기 시간 = (8 / 300ms) * 1000ms = 27 -> 30으로 설정 errorRate 폭등으로 인한 여유 공간 필요로
+   * 3배인 90으로 설정
+   */
+  @Bean(name = "bcryptExecutor")
+  public Executor bcryptExecutor() {
+    int cores = Runtime.getRuntime().availableProcessors();
+    int poolSize = Math.max(2, (int) Math.round(cores * 0.8));
+
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(poolSize);
+    executor.setMaxPoolSize(poolSize);
+    executor.setQueueCapacity(90); // 큐 초과 시 TaskRejectedException -> 503 처리
+    executor.setThreadNamePrefix("BCryptAsync-");
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setAwaitTerminationSeconds(30);
+    executor.initialize();
+    return executor;
+  }
 }

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/OAuth2SuccessHandler.java
@@ -58,7 +58,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     response.addCookie(createCookie("refresh-token", refreshToken, true,
         (int) (jwtTokenProvider.getRefreshTokenValidTime() / 1000)));
-    // response.addCookie(createCookie("access-token", accessToken, false, 60));
+    response.addCookie(createCookie("access-token", accessToken, false, 60));
 
     OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
     OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
@@ -73,12 +73,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
       });
     }
 
-    String targetUrl = org.springframework.web.util.UriComponentsBuilder
-        .fromUriString(frontEndProperties.oauthRedirectUri())
-        .queryParam("accessToken", accessToken)
-        .build().toUriString();
-
-    getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    getRedirectStrategy().sendRedirect(request, response, frontEndProperties.oauthRedirectUri());
   }
 
   private Cookie createCookie(String name, String value, boolean httpOnly, int maxAge) {

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig {
                 "/api/v1/auth/check-email",
                 "/api/v1/auth/login",
                 "/api/v1/auth/reissue",
+                "/api/v1/auth/social-login", // local 프로필 전용 Mock 엔드포인트(MockAuthController)
+
                 "/api/v1/users/signup",
                 "/api/v1/sellers/signup",
                 "/api/v1/search",

--- a/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/WonkaoTalk/common/config/security/SecurityConfig.java
@@ -181,7 +181,7 @@ public class SecurityConfig {
     // 구글에 오프라인 접근(RT 발급) 요청
     if ("google".equals(req.getAttribute(OAuth2ParameterNames.REGISTRATION_ID))) {
       extraParams.put("access_type", "offline");
-      extraParams.put("prompt", "consent");
+      // extraParams.put("prompt", "consent");
     }
     return OAuth2AuthorizationRequest.from(req).additionalParameters(extraParams).build();
   }

--- a/src/main/java/com/example/WonkaoTalk/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/WonkaoTalk/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.WonkaoTalk.common.exception;
 
 import com.example.WonkaoTalk.common.response.ApiResponse;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -41,6 +42,16 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
         .body(ApiResponse.error(ErrorCode.BAD_REQUEST.getCode(), "요청 형식이 올바르지 않습니다"));
+  }
+
+  // 벌크헤드 스레드풀(bcryptExecutor 등)의 큐가 가득 차 작업을 거부했을 때
+  @ExceptionHandler(TaskRejectedException.class)
+  protected ResponseEntity<ApiResponse<Void>> handleTaskRejectedException(
+      TaskRejectedException e) {
+    ErrorCode errorCode = ErrorCode.SERVICE_UNAVAILABLE;
+    return ResponseEntity
+        .status(errorCode.getHttpStatus())
+        .body(ApiResponse.error(errorCode.getCode(), "요청이 많아 처리할 수 없습니다. 잠시 후 다시 시도해 주세요."));
   }
 
   // 그 외 예상치 못한 에러가 발생했을 때 (500 에러 포장)

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -51,26 +52,40 @@ public class AuthController {
 
   @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 access token과 refresh token을 발급합니다.")
   @PostMapping("/login")
-  public ResponseEntity<ApiResponse<LoginResponse>> login(
+  public CompletableFuture<ResponseEntity<ApiResponse<LoginResponse>>> login(
       @Valid @RequestBody LoginRequest request,
       HttpServletRequest httpRequest
   ) {
-    TokenDto dto = authService.login(request, httpRequest);
+    // BCrypt 검증은 별도 풀(bcryptExecutor)에서 비동기로 처리되므로,
+    // 톰캣 워커 스레드에 묶여 있는 요청 정보는 핸드오프 전에 미리 추출해 둔다.
+    String userAgent = httpRequest.getHeader("User-Agent");
+    String ipAddress = extractIpAddress(httpRequest);
 
-    ResponseCookie refreshCookie = ResponseCookie.from("refresh-token", dto.refreshToken())
-        .httpOnly(true)
-        .secure(true)
-        .path("/")
-        .maxAge(dto.refreshExpirationTime())
-        .sameSite("Strict")
-        .build();
+    return authService.login(request, userAgent, ipAddress)
+        .thenApply(dto -> {
+          ResponseCookie refreshCookie = ResponseCookie.from("refresh-token", dto.refreshToken())
+              .httpOnly(true)
+              .secure(true)
+              .path("/")
+              .maxAge(dto.refreshExpirationTime())
+              .sameSite("Strict")
+              .build();
 
-    LoginResponse responseBody = LoginResponse.of(dto.accessToken(), dto.accessExpirationTime(),
-        dto.auth(), dto.profileName());
+          LoginResponse responseBody = LoginResponse.of(dto.accessToken(),
+              dto.accessExpirationTime(), dto.auth(), dto.profileName());
 
-    return ResponseEntity.ok()
-        .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
-        .body(ApiResponse.success("로그인에 성공하였습니다.", responseBody));
+          return ResponseEntity.ok()
+              .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+              .body(ApiResponse.success("로그인에 성공하였습니다.", responseBody));
+        });
+  }
+
+  private String extractIpAddress(HttpServletRequest request) {
+    String ipAddress = request.getHeader("X-Forwarded-For");
+    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+      return request.getRemoteAddr();
+    }
+    return ipAddress.split(",")[0].trim();
   }
 
   @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/controller/MockAuthController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/controller/MockAuthController.java
@@ -1,0 +1,75 @@
+package com.example.WonkaoTalk.domain.auth.controller;
+
+import com.example.WonkaoTalk.common.config.security.jwt.JwtTokenProvider;
+import com.example.WonkaoTalk.common.redis.RedisService;
+import com.example.WonkaoTalk.common.response.ApiResponse;
+import com.example.WonkaoTalk.domain.auth.dto.AuthUserInfoDto;
+import com.example.WonkaoTalk.domain.auth.dto.LoginResponse;
+import com.example.WonkaoTalk.domain.auth.dto.MockSocialLoginRequest;
+import com.example.WonkaoTalk.domain.auth.dto.SocialLoginDto;
+import com.example.WonkaoTalk.domain.auth.entity.Auth;
+import com.example.WonkaoTalk.domain.auth.service.AuthCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * local 프로필 전용 Mock 소셜 로그인 엔드포인트. 부하테스트(k6) 등에서 실제 OAuth2 핸드셰이크 없이
+ * 소셜 로그인 트래픽 비율을 검증하기 위한 용도이며, dev/prod 프로필에서는 빈 자체가 등록되지 않는다.
+ */
+@RestController
+@RequestMapping("api/v1/auth")
+@RequiredArgsConstructor
+@Profile("local")
+@Tag(name = "인증(local 전용)", description = "부하테스트용 Mock 소셜 로그인 API")
+public class MockAuthController {
+
+  private final AuthCommandService authCommandService;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RedisService redisService;
+
+  @Operation(summary = "[local 전용] Mock 소셜 로그인",
+      description = "실제 OAuth2 핸드셰이크 없이 provider/providerId/email만으로 소셜 로그인을 흉내냅니다.")
+  @PostMapping("/social-login")
+  public ResponseEntity<ApiResponse<LoginResponse>> mockSocialLogin(
+      @Valid @RequestBody MockSocialLoginRequest request
+  ) {
+    SocialLoginDto loginData = authCommandService.getOrCreateMockSocialLogin(
+        request.provider(), request.providerId(), request.email());
+    Auth auth = authCommandService.getAuthById(loginData.authId());
+    AuthUserInfoDto userInfo = authCommandService.getAuthUserInfo(auth);
+
+    String accessToken = jwtTokenProvider.createAccessToken(
+        request.email(), loginData.authId(), loginData.userId(), loginData.sellerId(),
+        loginData.role().name());
+    String refreshToken = jwtTokenProvider.createRefreshToken(request.email());
+
+    redisService.setValues("RT:" + request.email(), refreshToken,
+        Duration.ofMillis(jwtTokenProvider.getRefreshTokenValidTime()));
+
+    ResponseCookie refreshCookie = ResponseCookie.from("refresh-token", refreshToken)
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .maxAge(jwtTokenProvider.getRefreshTokenValidTime() / 1000)
+        .sameSite("Strict")
+        .build();
+
+    LoginResponse responseBody = LoginResponse.of(accessToken,
+        jwtTokenProvider.getAccessTokenValidTime(), auth, userInfo.profileName());
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+        .body(ApiResponse.success("Mock 소셜 로그인에 성공하였습니다.", responseBody));
+  }
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/dto/MockSocialLoginRequest.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/dto/MockSocialLoginRequest.java
@@ -1,0 +1,14 @@
+package com.example.WonkaoTalk.domain.auth.dto;
+
+import com.example.WonkaoTalk.domain.auth.enums.AuthProvider;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MockSocialLoginRequest(
+    @NotNull(message = "provider는 필수입니다.") AuthProvider provider,
+    @NotBlank(message = "providerId는 필수입니다.") String providerId,
+    @NotBlank(message = "email은 필수입니다.") @Email(message = "올바른 이메일 형식이 아닙니다.") String email
+) {
+
+}

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthCommandService.java
@@ -165,6 +165,55 @@ public class AuthCommandService {
     return authSocialRepo.findFirstByEmail(email);
   }
 
+  /**
+   * local 프로필 전용 Mock 소셜 로그인. 실제 OAuth2 핸드셰이크 없이 provider/providerId/email만으로
+   * {@link com.example.WonkaoTalk.domain.auth.service.OAuth2UserService#processOAuth2User}와 동일한
+   * find-or-create 흐름을 흉내낸다. 처음 보는 소셜 계정이면 Auth/AuthSocial/User를 새로 생성한다.
+   */
+  @Transactional
+  public SocialLoginDto getOrCreateMockSocialLogin(AuthProvider provider, String providerId,
+      String email) {
+    Optional<AuthSocial> optionalSocial = authSocialRepo.findByProviderAndProviderUserIdWithAuth(
+        provider, providerId);
+
+    Auth auth;
+    if (optionalSocial.isPresent()) {
+      auth = optionalSocial.get().getAuth();
+    } else {
+      Auth linkedAuth = authLocalRepo.findByEmail(email).map(AuthLocal::getAuth)
+          .or(() -> authSocialRepo.findFirstByEmail(email).map(AuthSocial::getAuth))
+          .orElse(null);
+
+      if (linkedAuth != null) {
+        auth = linkedAuth;
+      } else {
+        auth = saveAuth(Role.USER);
+        User user = User.builder()
+            .auth(auth)
+            .name(providerId)
+            .nickname(providerId)
+            .build();
+        userRepo.save(user);
+      }
+
+      AuthSocial authSocial = AuthSocial.builder()
+          .auth(auth)
+          .providerUserId(providerId)
+          .provider(provider)
+          .email(email)
+          .build();
+      authSocialRepo.save(authSocial);
+    }
+
+    Long userId = userRepo.findByAuth(auth).map(User::getId).orElse(null);
+    Long sellerId = null;
+    if (auth.getRole().name().contains("SELLER")) {
+      sellerId = sellerRepo.findByAuth(auth).map(Seller::getId).orElse(null);
+    }
+
+    return new SocialLoginDto(auth.getId(), userId, sellerId, auth.getRole());
+  }
+
   @Transactional(readOnly = true)
   public List<AuthSocial> getLinkedSocials(Long authId) {
     return authSocialRepo.findByAuthId(authId);

--- a/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/auth/service/AuthService.java
@@ -14,10 +14,11 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -35,13 +36,13 @@ public class AuthService {
     return EmailCheckResponse.from(!authCommandService.existsByEmail(request.email()));
   }
 
-  public TokenDto login(LoginRequest request, HttpServletRequest httpRequest) {
+  // BCrypt 검증은 CPU 비용이 커서 톰캣 워커 스레드를 점유하지 않도록 별도 풀(bcryptExecutor)에서 처리한다.
+  @Async("bcryptExecutor")
+  public CompletableFuture<TokenDto> login(LoginRequest request, String userAgent,
+      String ipAddress) {
     // TODO: 로그인 실패 횟수에 따른 계정 잠금이나 추가인증 기능 구현
     AuthLocal authLocal = authCommandService.getAuthLocalByEmail(request.email());
     Auth auth = authLocal.getAuth();
-
-    String userAgent = httpRequest.getHeader("User-Agent");
-    String ipAddress = extractIpAddress(httpRequest);
 
     if (!passwordEncoder.matches(request.password(), authLocal.getPasswordHash())) {
       authCommandService.saveLoginHistory(auth, LoginStatus.FAILURE, userAgent, ipAddress);
@@ -52,7 +53,7 @@ public class AuthService {
 
     authCommandService.saveLoginHistory(auth, LoginStatus.SUCCESS, userAgent, ipAddress);
 
-    return dto;
+    return CompletableFuture.completedFuture(dto);
   }
 
   public TokenDto reissueToken(String refreshToken) {
@@ -111,13 +112,5 @@ public class AuthService {
     log.info("블랙리스트 등록 토큰: {}", accessToken);
     log.info("남은 만료 시간: {}", expiration);
     redisService.setValues("BlackList:" + accessToken, "logout", Duration.ofMillis(expiration));
-  }
-
-  private String extractIpAddress(HttpServletRequest request) {
-    String ipAddress = request.getHeader("X-Forwarded-For");
-    if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
-      return request.getRemoteAddr();
-    }
-    return ipAddress.split(",")[0].trim();
   }
 }

--- a/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/seller/controller/SellerController.java
@@ -16,7 +16,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,16 +40,20 @@ public class SellerController {
 
   private final SellerService sellerService;
   private final AccountWithdraw accountWithdraw;
+  @Qualifier("bcryptExecutor")
+  private final Executor bcryptExecutor;
 
   @Operation(summary = "판매자 회원가입", description = "이메일, 비밀번호, 사업자 정보를 입력해 판매자 계정을 생성합니다.")
   @PostMapping("/signup")
-  public ResponseEntity<ApiResponse<SellerSignUpResponse>> signUp(
+  public CompletableFuture<ResponseEntity<ApiResponse<SellerSignUpResponse>>> signUp(
       @Valid @RequestBody SellerSignUpRequest request
   ) {
-    SellerSignUpResponse response = sellerService.signUpAsSeller(request);
-
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .body(ApiResponse.success("판매자 회원가입이 완료되었습니다.", response));
+    // signUpAsSeller는 @Transactional 메서드이므로 @Async로 감싸지 않고,
+    // 벌크헤드 풀에서 트랜잭션 전체(BCrypt 해싱 포함)를 한 스레드에서 실행한 뒤 결과만 받는다.
+    return CompletableFuture.supplyAsync(() -> sellerService.signUpAsSeller(request),
+            bcryptExecutor)
+        .thenApply(response -> ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success("판매자 회원가입이 완료되었습니다.", response)));
   }
 
   @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)

--- a/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/WonkaoTalk/domain/user/controller/UserController.java
@@ -17,7 +17,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,19 +41,22 @@ public class UserController {
 
   private final UserService userService;
   private final AccountWithdraw accountWithdraw;
+  @Qualifier("bcryptExecutor")
+  private final Executor bcryptExecutor;
 
   @Operation(
       summary = "일반 사용자 회원가입",
       description = "이메일, 비밀번호, 이름, 닉네임, 전화번호, 생년월일, 성별 정보를 입력해 일반 사용자 계정을 생성합니다."
   )
   @PostMapping("/signup")
-  public ResponseEntity<ApiResponse<UserSignUpResponse>> signUp(
+  public CompletableFuture<ResponseEntity<ApiResponse<UserSignUpResponse>>> signUp(
       @Valid @RequestBody UserSignUpRequest request
   ) {
-    UserSignUpResponse response = userService.signUpAsUser(request);
-
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .body(ApiResponse.success("일반 회원가입이 완료되었습니다.", response));
+    // signUpAsUser는 @Transactional 메서드이므로 @Async로 감싸지 않고,
+    // 벌크헤드 풀에서 트랜잭션 전체(BCrypt 해싱 포함)를 한 스레드에서 실행한 뒤 결과만 받는다.
+    return CompletableFuture.supplyAsync(() -> userService.signUpAsUser(request), bcryptExecutor)
+        .thenApply(response -> ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success("일반 회원가입이 완료되었습니다.", response)));
   }
 
   @SecurityRequirement(name = OpenApiConfig.BEARER_AUTH)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,9 @@ management:
       exposure:
         include: prometheus
   metrics:
+    export:
+      prometheus:
+        enabled: true
     tags:
       application: ${spring.application.name}
     distribution:

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/controller/AuthControllerTest.java
@@ -1,13 +1,17 @@
 package com.example.WonkaoTalk.domain.auth.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.WonkaoTalk.common.config.JacksonConfig;
@@ -26,17 +30,21 @@ import com.example.WonkaoTalk.domain.auth.entity.Auth;
 import com.example.WonkaoTalk.domain.auth.service.AuthService;
 import com.example.WonkaoTalk.domain.auth.service.OAuth2UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletRequest;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(controllers = AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -115,15 +123,67 @@ class AuthControllerTest {
   void loginSuccess() throws Exception {
     //given
     LoginRequest request = new LoginRequest("test@example.com", "Qwer1234");
-    given(authService.login(any(LoginRequest.class), any(HttpServletRequest.class))).willReturn(
-        mockToken);
+    given(authService.login(any(LoginRequest.class), any(), any())).willReturn(
+        CompletableFuture.completedFuture(mockToken));
 
     //when & then
-    mockMvc.perform(post("/api/v1/auth/login")
+    MvcResult mvcResult = mockMvc.perform(post("/api/v1/auth/login")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
+        .andExpect(request().asyncStarted())
+        .andReturn();
+
+    mockMvc.perform(asyncDispatch(mvcResult))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.tokenInfo.accessToken").exists());
+  }
+
+  @Test
+  @DisplayName("로그인 - X-Forwarded-For 헤더에 다수의 IP가 존재할 경우 첫 번째 IP를 서비스에 전달한다")
+  void loginExtractsFirstIpFromXForwardedFor() throws Exception {
+    //given
+    LoginRequest request = new LoginRequest("test@example.com", "Qwer1234");
+    given(authService.login(any(LoginRequest.class), any(), any())).willReturn(
+        CompletableFuture.completedFuture(mockToken));
+
+    //when
+    MvcResult mvcResult = mockMvc.perform(post("/api/v1/auth/login")
+            .header("X-Forwarded-For", "192.168.0.1, 10.0.0.1, 172.16.0.1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(request().asyncStarted())
+        .andReturn();
+    mockMvc.perform(asyncDispatch(mvcResult)).andExpect(status().isOk());
+
+    //then
+    ArgumentCaptor<String> ipAddressCaptor = ArgumentCaptor.forClass(String.class);
+    verify(authService).login(any(LoginRequest.class), any(), ipAddressCaptor.capture());
+    assertThat(ipAddressCaptor.getValue()).isEqualTo("192.168.0.1");
+  }
+
+  @Test
+  @DisplayName("IP 추출 엣지 케이스 - X-Forwarded-For 헤더가 null, 빈 문자열, 또는 unknown일 경우 RemoteAddr을 반환한다")
+  void extractIpAddressEdgeCasesReturnsRemoteAddress() {
+    // given
+    AuthController controller = new AuthController(authService);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRemoteAddr("10.0.0.99");
+
+    // 1. null인 경우 (헤더를 추가하지 않음)
+    String resultNull = ReflectionTestUtils.invokeMethod(controller, "extractIpAddress", request);
+    assertThat(resultNull).isEqualTo("10.0.0.99");
+
+    // 2. 빈 문자열인 경우
+    request.addHeader("X-Forwarded-For", "");
+    String resultEmpty = ReflectionTestUtils.invokeMethod(controller, "extractIpAddress", request);
+    assertThat(resultEmpty).isEqualTo("10.0.0.99");
+
+    // 3. unknown인 경우 (대소문자 무시)
+    request.removeHeader("X-Forwarded-For");
+    request.addHeader("X-Forwarded-For", "UnKnOwN");
+    String resultUnknown = ReflectionTestUtils.invokeMethod(controller, "extractIpAddress",
+        request);
+    assertThat(resultUnknown).isEqualTo("10.0.0.99");
   }
 
   @Test
@@ -228,7 +288,7 @@ class AuthControllerTest {
   void loginPasswordMismatchReturnsErrorResponse() throws Exception {
     // given
     LoginRequest request = new LoginRequest("test@test.com", "wrong_password");
-    given(authService.login(any(LoginRequest.class), any()))
+    given(authService.login(any(LoginRequest.class), any(), any()))
         .willThrow(new BusinessException(ErrorCode.AUTH_MISMATCH_PASSWORD));
 
     // when & then

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/integration/AuthIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.example.WonkaoTalk.domain.auth.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.WonkaoTalk.common.integration.BaseIntegrationTest;
@@ -31,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -78,9 +81,14 @@ public class AuthIntegrationTest extends BaseIntegrationTest {
     LoginRequest request = new LoginRequest(testEmail, testPassword);
 
     // when & then
-    mockMvc.perform(post("/api/v1/auth/login")
+    // 로그인은 별도 스레드풀(bcryptExecutor)에서 비동기로 처리되므로 비동기 디스패치를 거쳐 결과를 확인한다.
+    MvcResult mvcResult = mockMvc.perform(post("/api/v1/auth/login")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(request)))
+        .andExpect(request().asyncStarted())
+        .andReturn();
+
+    mockMvc.perform(asyncDispatch(mvcResult))
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.tokenInfo.accessToken").exists())

--- a/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/auth/service/AuthServiceTest.java
@@ -28,15 +28,12 @@ import com.example.WonkaoTalk.domain.auth.entity.AuthLocal;
 import com.example.WonkaoTalk.domain.auth.enums.LoginStatus;
 import com.example.WonkaoTalk.domain.auth.enums.Role;
 import java.time.Duration;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -55,15 +52,6 @@ class AuthServiceTest {
   private JwtTokenProvider jwtTokenProvider;
   @Mock
   private RedisService redisService;
-
-  private MockHttpServletRequest httpRequest;
-
-  @BeforeEach
-  void setUp() {
-    httpRequest = new MockHttpServletRequest();
-    httpRequest.addHeader("User-Agent", "User-Agent");
-    httpRequest.setRemoteAddr("127.0.0.1");
-  }
 
   @Test
   @DisplayName("이메일 중복 검사 - 미가입 이메일 검사 성공")
@@ -116,7 +104,7 @@ class AuthServiceTest {
     given(jwtTokenProvider.getAccessTokenValidTime()).willReturn(1800000L);
 
     //when
-    TokenDto response = authService.login(request, httpRequest);
+    TokenDto response = authService.login(request, "User-Agent", "127.0.0.1").join();
 
     //then
     assertThat(response).isNotNull();
@@ -147,7 +135,7 @@ class AuthServiceTest {
         false);
 
     //when & then
-    assertThatThrownBy(() -> authService.login(request, httpRequest))
+    assertThatThrownBy(() -> authService.login(request, "User-Agent", "127.0.0.1"))
         .isInstanceOf(BusinessException.class)
         .hasMessageContaining(ErrorCode.AUTH_MISMATCH_PASSWORD.getMessage());
     then(authCommandService).should(times(1))
@@ -244,46 +232,6 @@ class AuthServiceTest {
   }
 
   @Test
-  @DisplayName("로그인 - X-Forwarded-For 헤더에 다수의 IP가 존재할 경우 첫 번째 IP를 정확히 추출한다")
-  void loginExtractsFirstIpFromXForwardedFor() {
-    // given
-    ArgumentCaptor<String> ipAddressCaptor = ArgumentCaptor.forClass(String.class);
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.addHeader("X-Forwarded-For", "192.168.0.1, 10.0.0.1, 172.16.0.1");
-    request.setRemoteAddr("127.0.0.1");
-
-    LoginRequest loginRequest = new LoginRequest("test@test.com", "password123");
-    Auth auth = Auth.builder().role(Role.USER).build();
-    ReflectionTestUtils.setField(auth, "id", 1L);
-
-    AuthLocal authLocal = AuthLocal.builder().email("test@test.com").passwordHash("hashed")
-        .auth(auth).build();
-
-    given(authCommandService.getAuthLocalByEmail(loginRequest.email())).willReturn(authLocal);
-    given(passwordEncoder.matches(loginRequest.password(), authLocal.getPasswordHash())).willReturn(
-        true);
-    given(authCommandService.getAuthUserInfo(auth)).willReturn(
-        new AuthUserInfoDto("침착맨", 1L, null));
-    given(jwtTokenProvider.createAccessToken(any(), any(), any(), any(), any())).willReturn(
-        "access.token");
-    given(jwtTokenProvider.createRefreshToken(any())).willReturn("refresh.token");
-    given(jwtTokenProvider.getRefreshTokenValidTime()).willReturn(86400000L);
-    given(jwtTokenProvider.getAccessTokenValidTime()).willReturn(3600000L);
-
-    // when
-    authService.login(loginRequest, request);
-
-    // then
-    verify(authCommandService).saveLoginHistory(
-        eq(auth),
-        eq(LoginStatus.SUCCESS),
-        any(),
-        ipAddressCaptor.capture()
-    );
-    assertThat(ipAddressCaptor.getValue()).isEqualTo("192.168.0.1");
-  }
-
-  @Test
   @DisplayName("토큰 무효화 - 이미 만료되었거나 Redis에 없는 토큰이라도 남은 시간만큼 블랙리스트에 정상 등록된다")
   void invalidateTokenSuccessfullyAddsToBlacklist() {
     // given
@@ -304,31 +252,6 @@ class AuthServiceTest {
         eq("logout"),
         eq(Duration.ofMillis(expirationTime))
     );
-  }
-
-  @Test
-  @DisplayName("IP 추출 엣지 케이스 - X-Forwarded-For 헤더가 null, 빈 문자열, 또는 unknown일 경우 RemoteAddr을 반환한다")
-  public void extractIpAddressEdgeCasesReturnsRemoteAddress() {
-    // given
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRemoteAddr("10.0.0.99");
-
-    // 1. null인 경우
-    // 헤더를 추가하지 않음
-    String resultNull = ReflectionTestUtils.invokeMethod(authService, "extractIpAddress", request);
-    assertThat(resultNull).isEqualTo("10.0.0.99");
-
-    // 2. 빈 문자열인 경우
-    request.addHeader("X-Forwarded-For", "");
-    String resultEmpty = ReflectionTestUtils.invokeMethod(authService, "extractIpAddress", request);
-    assertThat(resultEmpty).isEqualTo("10.0.0.99");
-
-    // 3. unknown인 경우 (대소문자 무시)
-    request.removeHeader("X-Forwarded-For");
-    request.addHeader("X-Forwarded-For", "UnKnOwN");
-    String resultUnknown = ReflectionTestUtils.invokeMethod(authService, "extractIpAddress",
-        request);
-    assertThat(resultUnknown).isEqualTo("10.0.0.99");
   }
 
   @Test

--- a/src/test/java/com/example/WonkaoTalk/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/user/controller/UserControllerTest.java
@@ -19,6 +19,7 @@ import com.example.WonkaoTalk.domain.user.dto.UserSearchResponse;
 import com.example.WonkaoTalk.domain.user.service.UserService;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,9 @@ class UserControllerTest {
 
   @MockitoBean
   private AccountWithdraw accountWithdraw;
+
+  @MockitoBean(name = "bcryptExecutor")
+  private Executor bcryptExecutor;
 
   private CustomUserDetails userDetails;
 

--- a/src/test/java/com/example/WonkaoTalk/domain/user/integration/UserSignUpIntegrationTest.java
+++ b/src/test/java/com/example/WonkaoTalk/domain/user/integration/UserSignUpIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.example.WonkaoTalk.domain.user.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.WonkaoTalk.common.integration.BaseIntegrationTest;
+import com.example.WonkaoTalk.domain.auth.repo.AuthLocalRepo;
+import com.example.WonkaoTalk.domain.user.dto.UserSignUpRequest;
+import com.example.WonkaoTalk.domain.user.enums.Gender;
+import com.example.WonkaoTalk.domain.user.repo.UserRepo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class UserSignUpIntegrationTest extends BaseIntegrationTest {
+
+  @Autowired
+  private AuthLocalRepo authLocalRepo;
+  @Autowired
+  private UserRepo userRepo;
+
+  @Test
+  @DisplayName("회원가입은 벌크헤드 풀에서 비동기로 처리되며, BCrypt 해싱과 User/AuthLocal 저장이 한 트랜잭션으로 커밋된다")
+  void signUp_Success_PersistsAuthLocalAndUserInOneTransaction() throws Exception {
+    // given
+    UserSignUpRequest request = new UserSignUpRequest(
+        "signup-async@test.com", "Qwer1234", "Qwer1234",
+        "테스터", "테스터닉네임", "010-1234-5678", null, Gender.NONE);
+
+    // when
+    MvcResult mvcResult = mockMvc.perform(post("/api/v1/users/signup")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(request().asyncStarted())
+        .andReturn();
+
+    // then
+    mockMvc.perform(asyncDispatch(mvcResult))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value("SUCCESS"));
+
+    assertThat(authLocalRepo.findByEmail("signup-async@test.com")).isPresent();
+    assertThat(userRepo.findAll())
+        .anyMatch(user -> "테스터닉네임".equals(user.getNickname()));
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #169 

## 📝 작업 내용
- 테스트 과정에서 로그인 요청의 과도한 CPU 사용으로 인한 병목 해소를 위해 비동기로 요청을 처리하도록 로직을 수정했습니다.
- CPU 자원 점유율을 낮추기 위해 벌크헤드 패턴을 도입했습니다.

## ✅ 작업 결과 
- 테스트 결과/기능 정상 동작 확인 완료 (스크린샷/로그 첨부)

## 🎸 기타
- 이런걸 중점적으로 봐주세요 등 있으면 기재
